### PR TITLE
- added default mapping to metal-config

### DIFF
--- a/src/config/demo/visu_config_metal.xml
+++ b/src/config/demo/visu_config_metal.xml
@@ -19,7 +19,7 @@
         </entry>
       </mapping>
       <mapping name="OnOff">
-        <entry value="0">O</entry>
+        <entry default="true" value="0">O</entry>
         <entry value="1">I</entry>
       </mapping>
       <mapping name="OnOff_Licht">
@@ -101,7 +101,7 @@ Config</a> ]]></status>
         <label><icon name="weather_sun"/>Flavour</label>
       </pagejump>
     </navbar>
-    <group name="Allgemein">
+    <group name="Allgemein" target="KNX">
       <layout colspan="12"/>
       <info>
         <label>Modus</label>

--- a/src/structure/pure/_common.js
+++ b/src/structure/pure/_common.js
@@ -396,7 +396,12 @@ function VisuDesign() {
       'path'    : path
     });
     var ret_val = '<div class="'+classes+'" ' + style + '>' + label;
-    
+    if (address) {
+      templateEngine.bindActionForLoadingFinished(function() {
+        // initially setting a value
+        basicdesign.defaultUpdate( undefined, undefined, $("#"+path), true, path );
+      });
+    }
     return ret_val;
   };
   

--- a/src/structure/pure/_common.js
+++ b/src/structure/pure/_common.js
@@ -396,8 +396,8 @@ function VisuDesign() {
       'path'    : path
     });
     var ret_val = '<div class="'+classes+'" ' + style + '>' + label;
-    if (address) {
-      templateEngine.bindActionForLoadingFinished(function() {
+    if (address && updateFn!=undefined) {
+      templateEngine.postDOMSetupFns.push( function() {
         // initially setting a value
         basicdesign.defaultUpdate( undefined, undefined, $("#"+path), true, path );
       });

--- a/src/structure/pure/multitrigger.js
+++ b/src/structure/pure/multitrigger.js
@@ -37,7 +37,7 @@ design.basicdesign.addCreator('multitrigger', {
       button4label: $e.attr('button4label'),
       button4value: $e.attr('button4value')
     } );
-    console.log(data);
+    
     // create the actor
     ret_val += '<div class="actor_container" style="float:left">';
     var buttonCount = 0;

--- a/src/structure/pure/multitrigger.js
+++ b/src/structure/pure/multitrigger.js
@@ -37,7 +37,7 @@ design.basicdesign.addCreator('multitrigger', {
       button4label: $e.attr('button4label'),
       button4value: $e.attr('button4value')
     } );
-    
+    console.log(data);
     // create the actor
     ret_val += '<div class="actor_container" style="float:left">';
     var buttonCount = 0;


### PR DESCRIPTION
- fix for default value handling (fixes #153)

I´m not sure if this completely fixes #153. Are there any widgets that need to call the defaultUpdate method and do not use the createDefaultWidget-method?