### PR TITLE
make sure that navbar initialization is done first in postDOM functions

### DIFF
--- a/src/structure/pure/navbar.js
+++ b/src/structure/pure/navbar.js
@@ -73,7 +73,7 @@ design.basicdesign.addCreator('navbar', {
     if( isNotSubscribed )
     {
       isNotSubscribed = false;
-      templateEngine.postDOMSetupFns.push( function(){
+      templateEngine.postDOMSetupFns.unshift( function(){
         if( navbarTop    ) $( '#navbarTop'    ).append( navbarTop    );
         if( navbarLeft   ) $( '#navbarLeft'   ).append( navbarLeft   );
         if( navbarRight  ) $( '#navbarRight'  ).append( navbarRight  );


### PR DESCRIPTION
as it also modifies the DOM tree

see: http://knx-user-forum.de/forum/supportforen/cometvisu/828147-svn-git-version-icon-in-der-navbar-funktioniert-nicht-mehr