### PR TITLE
Fix position when slider is updatd while hidden

### DIFF
--- a/src/structure/pure/slide.js
+++ b/src/structure/pure/slide.js
@@ -25,12 +25,10 @@ define( ['_common'], function( design ) {
   {
     if (!$main.data('disableSliderTransform')) {
       if (!isNaN(value)) {
-        var handleWidth = $(handle).outerWidth();
         var sliderMax = $(handle).parent().slider("option","max")+($(handle).parent().slider("option","min")*-1);
         var percent = Math.round((100/sliderMax)*(value+($(handle).parent().slider("option","min")*-1)));
-        var translate = Math.round(handleWidth * percent/100);
-        //console.log("Width: "+handleWidth+", Value: "+value+", Max/Min: "+sliderMax+", %: "+percent+" => "+percent);
-        $(handle).css('transform', 'translateX(-'+translate+'px)');
+        //console.log("Value: "+value+", Max/Min: "+sliderMax+", %: "+percent+" => "+percent);
+        $(handle).css('transform', 'translateX(-'+percent+'%)');
       }
     }
   }


### PR DESCRIPTION
If a slider gets updated (e.g. by a KNX message) while it is hidden (another page selected) the position is incorrectly calculated. According to the jQuery documentation outerWidth() doesn't work reliably for hidden objects.

Instead of calculating the absolute pixel offset the fixed code now relies on the browser to do the math. 

Problem is reproducible on Safari, both on iOS9.0.0 and OS X 10.10.5. Fix only tested on these platforms.