### PR TITLE
added missing session to write-command

### DIFF
--- a/src/lib/cometvisu-client.js
+++ b/src/lib/cometvisu-client.js
@@ -306,7 +306,7 @@ function CometVisu( urlPrefix )
       url:      this.urlPrefix + 'w',
       dataType: 'json',
       context:  this,
-      data:     'a=' + address + '&v=' + value + '&ts=' + ts
+      data:     's=' + this.session + '&a=' + address + '&v=' + value + '&ts=' + ts
     });
   }
   


### PR DESCRIPTION
write command was missing the session variable.

Even if session is not well supported by current backends, it should be possible for any backend to renew it's internal session timer/timeout when processing a write-command based in provided session.