### PR TITLE
Bugfix for bad mapping

### DIFF
--- a/src/lib/templateengine.js
+++ b/src/lib/templateengine.js
@@ -687,7 +687,7 @@ function TemplateEngine( undefined ) {
       if (!ret && m['defaultValue']) {
         ret = mapValue(m['defaultValue']);
       }
-      if (ret) {
+      if( ret !== undefined ) {
         return ret;
       }
     }


### PR DESCRIPTION
When the result of a mpping was false (or 0 which is translated to false)
then the original value was returned.