### PR TITLE
Fix demo with metal

### DIFF
--- a/src/lib/templateengine.js
+++ b/src/lib/templateengine.js
@@ -768,7 +768,7 @@ function TemplateEngine( undefined ) {
     // the calculation has to be done again, even if the page hasn´t changed (e.g. switching between portrait and landscape mode on a mobile can cause that)
     var bodyWidth = $('body').width();
     var mobileUseChanged = (lastBodyWidth<thisTemplateEngine.maxMobileScreenWidth)!=(bodyWidth<thisTemplateEngine.maxMobileScreenWidth);
-    if (thisTemplateEngine.currentPageUnavailableWidth<0 || mobileUseChanged) {
+    if (thisTemplateEngine.currentPageUnavailableWidth<0 || mobileUseChanged || true) {
 //      console.log("Mobile.css use changed "+mobileUseChanged);
       thisTemplateEngine.currentPageUnavailableWidth=0;
       var navbarVisibility = thisTemplateEngine.getCurrentPageNavbarVisibility(thisTemplateEngine.currentPage);


### PR DESCRIPTION
Opening the (normal) demo config with the metal design in Chrome didn't
show the main screen as it was too wide and the browser placed it to the
bottom.

This patch fixes the issue by forcing a recalculation.

A real fix would be to follow though the page creation, especially when
the navbars are active, and handle the sized. This is kept for future
development...