### PR TITLE
Sprintf undef fix

### DIFF
--- a/src/lib/compatibility.js
+++ b/src/lib/compatibility.js
@@ -45,7 +45,7 @@ var sprintfOrg = window.sprintf;
 window.sprintf = function() {
   for (var arg in arguments) {
     if (typeof arguments[arg] == "undefined")
-      return "<UNDEF>";
+      arguments[arg] = "<UNDEF>";
   }
 
   try {


### PR DESCRIPTION
The new version sets the undefined parameter to the string "<UNDEF>" and doesn't return it on purpose.

This fixes a  valid call like `sprintf( "%.1f", 12, undefined )`