### PR TITLE
Make GA update more robust

### DIFF
--- a/src/lib/templateengine.js
+++ b/src/lib/templateengine.js
@@ -328,6 +328,9 @@ function TemplateEngine( undefined ) {
     function update(json) {
       for( var key in json ) {
         //$.event.trigger('_' + key, json[key]);
+        if( !(key in ga_list) )
+          continue;
+        
         var data = json[ key ];
         ga_list[ key ].forEach( function( id ){
           if( typeof id === 'string' )


### PR DESCRIPTION
Handle cases where a GA is sent back from the backend that is not in the
ga_list.
(This can e.g. happen when non valid GAs were used in the config that
translate to a valid different GA)