### PR TITLE
Add retry link to error message

### DIFF
--- a/src/lib/templateengine.js
+++ b/src/lib/templateengine.js
@@ -151,6 +151,7 @@ require([
         else
           message += '.';
     }
+    message += '<br/><br/><a href="">Retry</a>';
     $('#loading').html(message);
   };
   // get the data once the page was loaded


### PR DESCRIPTION
Usecase: when the visu is shown in kiosk mode and the server can't deliver
the config (e.g. after power failure when visu and server are restarting)
there is currently only the error message shown. There is no option
to reload the page when the config gets available again.
As there's no other interaction possibility the visu currently must be
restarted.

This fix helps by adding a possibility to reload the page from the
error message itself.