### PR TITLE
Update license header

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -129,7 +129,7 @@ module.exports = function(grunt) {
           }
         },
         files: {
-          src: [ 'src/lib/*.js', 'src/structure/pure/*.js' ]
+          src: [ 'src/lib/**.js', 'src/structure/**.js', 'src/transforms/**.js', 'src/designs/*/*.js' ]
         }
       }
     },

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -97,7 +97,7 @@ module.exports = function(grunt) {
 
             return grunt.template.process('/* <%= filename %> \n'+
               ' * \n'+
-              ' * copyright (c) 2010-<%= grunt.template.today("yyyy") %> by <%= author %>\n'+
+              ' * copyright (c) 2010-<%= grunt.template.today("yyyy") %>, Christian Mayer and the CometVisu contributers.\n'+
               ' * \n'+
               ' * This program is free software; you can redistribute it and/or modify it\n'+
               ' * under the terms of the GNU General Public License as published by the Free\n'+

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -115,7 +115,6 @@ module.exports = function(grunt) {
               ' *\n'+
               ' * @module <%= modulename %> \n'+
               ' * @title  <%= title %> \n'+
-              ' * @version <%= version %>\n'+
               ' */\n', {
                   data: {
                     filename: filename,
@@ -129,7 +128,7 @@ module.exports = function(grunt) {
           }
         },
         files: {
-          src: [ 'src/lib/**.js', 'src/structure/**.js', 'src/transforms/**.js', 'src/designs/*/*.js' ]
+          src: [ 'src/lib/**/*.js', 'src/structure/**/*.js', 'src/transforms/**.js', 'src/designs/*/*.js' ]
         }
       }
     },

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -128,7 +128,7 @@ module.exports = function(grunt) {
           }
         },
         files: {
-          src: [ 'src/lib/**/*.js', 'src/structure/**/*.js', 'src/transforms/**.js', 'src/designs/*/*.js' ]
+          src: [ 'src/lib/**/*.js', 'src/structure/**/*.js', 'src/transforms/**/*.js', 'src/designs/*/design_setup.js' ]
         }
       }
     },

--- a/src/designs/alaska/design_setup.js
+++ b/src/designs/alaska/design_setup.js
@@ -1,6 +1,6 @@
 /* design_setup.js 
  * 
- * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * copyright (c) 2010-2016, Christian Mayer and the CometVisu contributers.
  * 
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free

--- a/src/designs/alaska/design_setup.js
+++ b/src/designs/alaska/design_setup.js
@@ -1,26 +1,33 @@
-//
-//  Design setup for the pure design
-//
-//   Copyright (C) 2012 by Christian Mayer
-//   cometvisu (at) ChristianMayer.de
-//
-//   This program is free software; you can redistribute it and/or modify
-//   it under the terms of the GNU General Public License as published by
-//   the Free Software Foundation; either version 2 of the License, or
-//   (at your option) any later version.
-//
-//   This program is distributed in the hope that it will be useful,
-//   but WITHOUT ANY WARRANTY; without even the implied warranty of
-//   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//   GNU General Public License for more details.
-//
-//   You should have received a copy of the GNU General Public License
-//   along with this program; if not, write to the
-//   Free Software Foundation, Inc.,
-//   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
-//
-//////////////////////////////////////////////////////////////////////////////
+/* design_setup.js 
+ * 
+ * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * 
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+ *
+ * @module Design_setup 
+ * @title  CometVisu Design_setup 
+ * @version 0.9.1-RC2
+ */
 
+
+/**
+ * Design setup for the alaska design
+ *
+ * @author Christian Mayer
+ * @since 2012
+ */
 $('#navbarLeft').data('columns', 6 );
 $('#main').data('columns', 12 );
 $('#navbarRight').data('columns', 6 );

--- a/src/designs/alaska/design_setup.js
+++ b/src/designs/alaska/design_setup.js
@@ -18,7 +18,6 @@
  *
  * @module Design_setup 
  * @title  CometVisu Design_setup 
- * @version 0.9.1-RC2
  */
 
 

--- a/src/designs/alaska_slim/design_setup.js
+++ b/src/designs/alaska_slim/design_setup.js
@@ -1,6 +1,6 @@
 /* design_setup.js 
  * 
- * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * copyright (c) 2010-2016, Christian Mayer and the CometVisu contributers.
  * 
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free

--- a/src/designs/alaska_slim/design_setup.js
+++ b/src/designs/alaska_slim/design_setup.js
@@ -18,7 +18,6 @@
  *
  * @module Design_setup 
  * @title  CometVisu Design_setup 
- * @version 0.9.1-RC2
  */
 
 

--- a/src/designs/alaska_slim/design_setup.js
+++ b/src/designs/alaska_slim/design_setup.js
@@ -1,26 +1,33 @@
-//
-//  Design setup for the pure design
-//
-//   Copyright (C) 2012 by Christian Mayer
-//   cometvisu (at) ChristianMayer.de
-//
-//   This program is free software; you can redistribute it and/or modify
-//   it under the terms of the GNU General Public License as published by
-//   the Free Software Foundation; either version 2 of the License, or
-//   (at your option) any later version.
-//
-//   This program is distributed in the hope that it will be useful,
-//   but WITHOUT ANY WARRANTY; without even the implied warranty of
-//   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//   GNU General Public License for more details.
-//
-//   You should have received a copy of the GNU General Public License
-//   along with this program; if not, write to the
-//   Free Software Foundation, Inc.,
-//   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
-//
-//////////////////////////////////////////////////////////////////////////////
+/* design_setup.js 
+ * 
+ * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * 
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+ *
+ * @module Design_setup 
+ * @title  CometVisu Design_setup 
+ * @version 0.9.1-RC2
+ */
 
+
+/**
+ * Design setup for the alaska slim design
+ *
+ * @author Christian Mayer
+ * @since 2012
+ */
 $('#navbarLeft').data('columns', 6 );
 $('#main').data('columns', 12 );
 $('#navbarRight').data('columns', 6 );

--- a/src/designs/discreet/design_setup.js
+++ b/src/designs/discreet/design_setup.js
@@ -1,6 +1,6 @@
 /* design_setup.js 
  * 
- * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * copyright (c) 2010-2016, Christian Mayer and the CometVisu contributers.
  * 
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free

--- a/src/designs/discreet/design_setup.js
+++ b/src/designs/discreet/design_setup.js
@@ -18,7 +18,6 @@
  *
  * @module Design_setup 
  * @title  CometVisu Design_setup 
- * @version 0.9.1-RC2
  */
 
 

--- a/src/designs/discreet/design_setup.js
+++ b/src/designs/discreet/design_setup.js
@@ -1,26 +1,33 @@
-//
-//  Design setup for the pure design
-//
-//   Copyright (C) 2012 by Christian Mayer
-//   cometvisu (at) ChristianMayer.de
-//
-//   This program is free software; you can redistribute it and/or modify
-//   it under the terms of the GNU General Public License as published by
-//   the Free Software Foundation; either version 2 of the License, or
-//   (at your option) any later version.
-//
-//   This program is distributed in the hope that it will be useful,
-//   but WITHOUT ANY WARRANTY; without even the implied warranty of
-//   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//   GNU General Public License for more details.
-//
-//   You should have received a copy of the GNU General Public License
-//   along with this program; if not, write to the
-//   Free Software Foundation, Inc.,
-//   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
-//
-//////////////////////////////////////////////////////////////////////////////
+/* design_setup.js 
+ * 
+ * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * 
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+ *
+ * @module Design_setup 
+ * @title  CometVisu Design_setup 
+ * @version 0.9.1-RC2
+ */
 
+
+/**
+ * Design setup for the discreet design
+ *
+ * @author Christian Mayer
+ * @since 2012
+ */
 $('#navbarLeft').data('columns', 6 );
 $('#main').data('columns', 12 );
 $('#navbarRight').data('columns', 6 );

--- a/src/designs/discreet_sand/design_setup.js
+++ b/src/designs/discreet_sand/design_setup.js
@@ -1,6 +1,6 @@
 /* design_setup.js 
  * 
- * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * copyright (c) 2010-2016, Christian Mayer and the CometVisu contributers.
  * 
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free

--- a/src/designs/discreet_sand/design_setup.js
+++ b/src/designs/discreet_sand/design_setup.js
@@ -1,26 +1,33 @@
-//
-//  Design setup for the pure design
-//
-//   Copyright (C) 2012 by Christian Mayer
-//   cometvisu (at) ChristianMayer.de
-//
-//   This program is free software; you can redistribute it and/or modify
-//   it under the terms of the GNU General Public License as published by
-//   the Free Software Foundation; either version 2 of the License, or
-//   (at your option) any later version.
-//
-//   This program is distributed in the hope that it will be useful,
-//   but WITHOUT ANY WARRANTY; without even the implied warranty of
-//   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//   GNU General Public License for more details.
-//
-//   You should have received a copy of the GNU General Public License
-//   along with this program; if not, write to the
-//   Free Software Foundation, Inc.,
-//   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
-//
-//////////////////////////////////////////////////////////////////////////////
+/* design_setup.js 
+ * 
+ * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * 
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+ *
+ * @module Design_setup 
+ * @title  CometVisu Design_setup 
+ * @version 0.9.1-RC2
+ */
 
+
+/**
+ * Design setup for the discreet sand design
+ *
+ * @author Christian Mayer
+ * @since 2012
+ */
 $('#navbarLeft').data('columns', 6 );
 $('#main').data('columns', 12 );
 $('#navbarRight').data('columns', 6 );

--- a/src/designs/discreet_sand/design_setup.js
+++ b/src/designs/discreet_sand/design_setup.js
@@ -18,7 +18,6 @@
  *
  * @module Design_setup 
  * @title  CometVisu Design_setup 
- * @version 0.9.1-RC2
  */
 
 

--- a/src/designs/discreet_slim/design_setup.js
+++ b/src/designs/discreet_slim/design_setup.js
@@ -1,6 +1,6 @@
 /* design_setup.js 
  * 
- * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * copyright (c) 2010-2016, Christian Mayer and the CometVisu contributers.
  * 
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free

--- a/src/designs/discreet_slim/design_setup.js
+++ b/src/designs/discreet_slim/design_setup.js
@@ -1,26 +1,33 @@
-//
-//  Design setup for the pure design
-//
-//   Copyright (C) 2012 by Christian Mayer
-//   cometvisu (at) ChristianMayer.de
-//
-//   This program is free software; you can redistribute it and/or modify
-//   it under the terms of the GNU General Public License as published by
-//   the Free Software Foundation; either version 2 of the License, or
-//   (at your option) any later version.
-//
-//   This program is distributed in the hope that it will be useful,
-//   but WITHOUT ANY WARRANTY; without even the implied warranty of
-//   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//   GNU General Public License for more details.
-//
-//   You should have received a copy of the GNU General Public License
-//   along with this program; if not, write to the
-//   Free Software Foundation, Inc.,
-//   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
-//
-//////////////////////////////////////////////////////////////////////////////
+/* design_setup.js 
+ * 
+ * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * 
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+ *
+ * @module Design_setup 
+ * @title  CometVisu Design_setup 
+ * @version 0.9.1-RC2
+ */
 
+
+/**
+ * Design setup for the discreet slim design
+ *
+ * @author Christian Mayer
+ * @since 2012
+ */
 $('#navbarLeft').data('columns', 6 );
 $('#main').data('columns', 12 );
 $('#navbarRight').data('columns', 6 );

--- a/src/designs/discreet_slim/design_setup.js
+++ b/src/designs/discreet_slim/design_setup.js
@@ -18,7 +18,6 @@
  *
  * @module Design_setup 
  * @title  CometVisu Design_setup 
- * @version 0.9.1-RC2
  */
 
 

--- a/src/designs/metal/design_setup.js
+++ b/src/designs/metal/design_setup.js
@@ -1,6 +1,6 @@
 /* design_setup.js 
  * 
- * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * copyright (c) 2010-2016, Christian Mayer and the CometVisu contributers.
  * 
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free

--- a/src/designs/metal/design_setup.js
+++ b/src/designs/metal/design_setup.js
@@ -18,8 +18,8 @@
  *
  * @module Design_setup 
  * @title  CometVisu Design_setup 
- * @version 0.9.1-RC2
  */
+
 
 /**
  * Design setup  for the metal design

--- a/src/designs/metal/design_setup.js
+++ b/src/designs/metal/design_setup.js
@@ -1,26 +1,32 @@
-//
-//  Design setup for the metal design
-//
-//   Copyright (C) 2012 by Christian Mayer
-//   cometvisu (at) ChristianMayer.de
-//
-//   This program is free software; you can redistribute it and/or modify
-//   it under the terms of the GNU General Public License as published by
-//   the Free Software Foundation; either version 2 of the License, or
-//   (at your option) any later version.
-//
-//   This program is distributed in the hope that it will be useful,
-//   but WITHOUT ANY WARRANTY; without even the implied warranty of
-//   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//   GNU General Public License for more details.
-//
-//   You should have received a copy of the GNU General Public License
-//   along with this program; if not, write to the
-//   Free Software Foundation, Inc.,
-//   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
-//
-//////////////////////////////////////////////////////////////////////////////
-//$(".value < img").css("padding", "0");
+/* design_setup.js 
+ * 
+ * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * 
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+ *
+ * @module Design_setup 
+ * @title  CometVisu Design_setup 
+ * @version 0.9.1-RC2
+ */
+
+/**
+ * Design setup  for the metal design
+ * 
+ * @author Tobias Bräutigam
+ * @since 2012
+ */
 $('#navbarLeft').data('columns', 6 );
 $('#main').data('columns', 12 );
 $('#navbarRight').data('columns', 6 );

--- a/src/designs/pitchblack/design_setup.js
+++ b/src/designs/pitchblack/design_setup.js
@@ -1,6 +1,6 @@
 /* design_setup.js 
  * 
- * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * copyright (c) 2010-2016, Christian Mayer and the CometVisu contributers.
  * 
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free

--- a/src/designs/pitchblack/design_setup.js
+++ b/src/designs/pitchblack/design_setup.js
@@ -1,25 +1,32 @@
-//
-//  Design setup for the pure design
-//
-//   Copyright (C) 2012 by Christian Mayer
-//   cometvisu (at) ChristianMayer.de
-//
-//   This program is free software; you can redistribute it and/or modify
-//   it under the terms of the GNU General Public License as published by
-//   the Free Software Foundation; either version 2 of the License, or
-//   (at your option) any later version.
-//
-//   This program is distributed in the hope that it will be useful,
-//   but WITHOUT ANY WARRANTY; without even the implied warranty of
-//   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//   GNU General Public License for more details.
-//
-//   You should have received a copy of the GNU General Public License
-//   along with this program; if not, write to the
-//   Free Software Foundation, Inc.,
-//   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
-//
-//////////////////////////////////////////////////////////////////////////////
+/* design_setup.js 
+ * 
+ * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * 
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+ *
+ * @module Design_setup 
+ * @title  CometVisu Design_setup 
+ * @version 0.9.1-RC2
+ */
 
+
+/**
+ * Design setup for the pitchblack design
+ *
+ * @author Christian Mayer
+ * @since 2012
+ */
 $('head').data('colspanDefault', 1 );
 

--- a/src/designs/pitchblack/design_setup.js
+++ b/src/designs/pitchblack/design_setup.js
@@ -18,7 +18,6 @@
  *
  * @module Design_setup 
  * @title  CometVisu Design_setup 
- * @version 0.9.1-RC2
  */
 
 

--- a/src/designs/planet/design_setup.js
+++ b/src/designs/planet/design_setup.js
@@ -1,6 +1,6 @@
 /* design_setup.js 
  * 
- * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * copyright (c) 2010-2016, Christian Mayer and the CometVisu contributers.
  * 
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free

--- a/src/designs/planet/design_setup.js
+++ b/src/designs/planet/design_setup.js
@@ -1,26 +1,33 @@
-//
-//  Design setup for the pure design
-//
-//   Copyright (C) 2012 by Christian Mayer
-//   cometvisu (at) ChristianMayer.de
-//
-//   This program is free software; you can redistribute it and/or modify
-//   it under the terms of the GNU General Public License as published by
-//   the Free Software Foundation; either version 2 of the License, or
-//   (at your option) any later version.
-//
-//   This program is distributed in the hope that it will be useful,
-//   but WITHOUT ANY WARRANTY; without even the implied warranty of
-//   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//   GNU General Public License for more details.
-//
-//   You should have received a copy of the GNU General Public License
-//   along with this program; if not, write to the
-//   Free Software Foundation, Inc.,
-//   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
-//
-//////////////////////////////////////////////////////////////////////////////
+/* design_setup.js 
+ * 
+ * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * 
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+ *
+ * @module Design_setup 
+ * @title  CometVisu Design_setup 
+ * @version 0.9.1-RC2
+ */
 
+
+/**
+ * Design setup for the planet design
+ *
+ * @author Christian Mayer
+ * @since 2012
+ */
 /*$('#navbarLeft').data('columns', 6 );
 */
 $('#main').data('columns', 12 );

--- a/src/designs/planet/design_setup.js
+++ b/src/designs/planet/design_setup.js
@@ -18,7 +18,6 @@
  *
  * @module Design_setup 
  * @title  CometVisu Design_setup 
- * @version 0.9.1-RC2
  */
 
 

--- a/src/designs/pure/design_setup.js
+++ b/src/designs/pure/design_setup.js
@@ -1,6 +1,6 @@
 /* design_setup.js 
  * 
- * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * copyright (c) 2010-2016, Christian Mayer and the CometVisu contributers.
  * 
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free

--- a/src/designs/pure/design_setup.js
+++ b/src/designs/pure/design_setup.js
@@ -1,26 +1,33 @@
-//
-//  Design setup for the pure design
-//
-//   Copyright (C) 2012 by Christian Mayer
-//   cometvisu (at) ChristianMayer.de
-//
-//   This program is free software; you can redistribute it and/or modify
-//   it under the terms of the GNU General Public License as published by
-//   the Free Software Foundation; either version 2 of the License, or
-//   (at your option) any later version.
-//
-//   This program is distributed in the hope that it will be useful,
-//   but WITHOUT ANY WARRANTY; without even the implied warranty of
-//   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//   GNU General Public License for more details.
-//
-//   You should have received a copy of the GNU General Public License
-//   along with this program; if not, write to the
-//   Free Software Foundation, Inc.,
-//   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
-//
-//////////////////////////////////////////////////////////////////////////////
+/* design_setup.js 
+ * 
+ * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * 
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+ *
+ * @module Design_setup 
+ * @title  CometVisu Design_setup 
+ * @version 0.9.1-RC2
+ */
 
+
+/**
+ * Design setup for the pure design
+ * 
+ * @author Christian Mayer
+ * @since 2012
+ */
 $('#navbarLeft').data('columns', 6 );
 $('#main').data('columns', 12 );
 $('#navbarRight').data('columns', 6 );

--- a/src/designs/pure/design_setup.js
+++ b/src/designs/pure/design_setup.js
@@ -18,7 +18,6 @@
  *
  * @module Design_setup 
  * @title  CometVisu Design_setup 
- * @version 0.9.1-RC2
  */
 
 

--- a/src/lib/cometvisu-client.js
+++ b/src/lib/cometvisu-client.js
@@ -18,7 +18,6 @@
  *
  * @module Cometvisu-client 
  * @title  CometVisu Cometvisu-client 
- * @version 0.9.1-RC2
  */
 
 

--- a/src/lib/cometvisu-client.js
+++ b/src/lib/cometvisu-client.js
@@ -1,5 +1,7 @@
-/* cometvisu.js (c) 2010 by Christian Mayer [CometVisu at ChristianMayer dot de]
- *
+/* cometvisu-client.js 
+ * 
+ * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * 
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free
  * Software Foundation; either version 3 of the License, or (at your option)
@@ -7,12 +9,16 @@
  *
  * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
  * more details.
  *
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+ *
+ * @module Cometvisu-client 
+ * @title  CometVisu Cometvisu-client 
+ * @version 0.9.1-RC2
  */
 
 /**
@@ -20,7 +26,10 @@
  *
  * @title CometVisu Client
  * @exports comentvisu-client
- * @reqires jQuery
+ * @requires jQuery
+ * @author Christan Mayer
+ * @author Tobias Bräutigam
+ * @since 2010
  */
 define( 'cometvisu-client', ['jquery'], function( $ ) {
   "use strict";

--- a/src/lib/cometvisu-client.js
+++ b/src/lib/cometvisu-client.js
@@ -21,6 +21,7 @@
  * @version 0.9.1-RC2
  */
 
+
 /**
  * The JavaScript library that implements the CometVisu protocol.
  *

--- a/src/lib/cometvisu-client.js
+++ b/src/lib/cometvisu-client.js
@@ -1,6 +1,6 @@
 /* cometvisu-client.js 
  * 
- * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * copyright (c) 2010-2016, Christian Mayer and the CometVisu contributers.
  * 
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free

--- a/src/lib/compatibility.js
+++ b/src/lib/compatibility.js
@@ -1,6 +1,6 @@
 /* compatibility.js 
  * 
- * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * copyright (c) 2010-2016, Christian Mayer and the CometVisu contributers.
  * 
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free

--- a/src/lib/compatibility.js
+++ b/src/lib/compatibility.js
@@ -1,5 +1,7 @@
-/* compatability.js (c) 2013 by Christian Mayer [CometVisu at ChristianMayer dot de]
- *
+/* compatibility.js 
+ * 
+ * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * 
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free
  * Software Foundation; either version 3 of the License, or (at your option)
@@ -7,15 +9,23 @@
  *
  * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
  * more details.
  *
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+ *
+ * @module Compatibility 
+ * @title  CometVisu Compatibility 
+ * @version 0.9.1-RC2
+ */
+
+/**
+ * CometVisu helper functions for compatability issues
  * 
- * @module Compatability
- * @title  CometVisu helper functions for compatability issues
+ * @author Christian Mayer
+ * @since 2013
  */
 define( ['jquery', 'dependencies/sprintf'], function( $ ) {
   "use strict";

--- a/src/lib/compatibility.js
+++ b/src/lib/compatibility.js
@@ -21,6 +21,7 @@
  * @version 0.9.1-RC2
  */
 
+
 /**
  * CometVisu helper functions for compatability issues
  * 

--- a/src/lib/compatibility.js
+++ b/src/lib/compatibility.js
@@ -18,7 +18,6 @@
  *
  * @module Compatibility 
  * @title  CometVisu Compatibility 
- * @version 0.9.1-RC2
  */
 
 

--- a/src/lib/iconhandler.js
+++ b/src/lib/iconhandler.js
@@ -18,7 +18,6 @@
  *
  * @module Iconhandler 
  * @title  CometVisu Iconhandler 
- * @version 0.9.1-RC2
  */
 
 

--- a/src/lib/iconhandler.js
+++ b/src/lib/iconhandler.js
@@ -1,26 +1,31 @@
-//
-//  Icon handler for the CometVisu.
-//
-//   Copyright (C) 2012 by Christian Mayer
-//   cometvisu (at) ChristianMayer.de
-//
-//   This program is free software; you can redistribute it and/or modify
-//   it under the terms of the GNU General Public License as published by
-//   the Free Software Foundation; either version 2 of the License, or
-//   (at your option) any later version.
-//
-//   This program is distributed in the hope that it will be useful,
-//   but WITHOUT ANY WARRANTY; without even the implied warranty of
-//   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//   GNU General Public License for more details.
-//
-//   You should have received a copy of the GNU General Public License
-//   along with this program; if not, write to the
-//   Free Software Foundation, Inc.,
-//   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
-//
-//////////////////////////////////////////////////////////////////////////////
+/* iconhandler.js 
+ * 
+ * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * 
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+ *
+ * @module Iconhandler 
+ * @title  CometVisu Iconhandler 
+ * @version 0.9.1-RC2
+ */
 
+
+/**
+ * @author Christian Mayer
+ * @since 2012
+ */
 define( ['icon/iconconfig'], function( iconconfig ) {
   "use strict";
 

--- a/src/lib/iconhandler.js
+++ b/src/lib/iconhandler.js
@@ -1,6 +1,6 @@
 /* iconhandler.js 
  * 
- * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * copyright (c) 2010-2016, Christian Mayer and the CometVisu contributers.
  * 
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free

--- a/src/lib/icontools.js
+++ b/src/lib/icontools.js
@@ -18,7 +18,6 @@
  *
  * @module Icontools 
  * @title  CometVisu Icontools 
- * @version 0.9.1-RC2
  */
 
 

--- a/src/lib/icontools.js
+++ b/src/lib/icontools.js
@@ -1,6 +1,6 @@
 /* icontools.js 
  * 
- * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * copyright (c) 2010-2016, Christian Mayer and the CometVisu contributers.
  * 
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free

--- a/src/lib/icontools.js
+++ b/src/lib/icontools.js
@@ -1,5 +1,7 @@
-/* icontools.js (c) 2015 by Christian Mayer [CometVisu at ChristianMayer dot de]
- *
+/* icontools.js 
+ * 
+ * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * 
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free
  * Software Foundation; either version 3 of the License, or (at your option)
@@ -7,14 +9,22 @@
  *
  * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
  * more details.
  *
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+ *
+ * @module Icontools 
+ * @title  CometVisu Icontools 
+ * @version 0.9.1-RC2
  */
 
+/**
+ * @author Christian Mayer
+ * @since 2015
+ */
 define([ 'jquery' ], function( $ ) {
   "use strict";
 

--- a/src/lib/icontools.js
+++ b/src/lib/icontools.js
@@ -21,6 +21,7 @@
  * @version 0.9.1-RC2
  */
 
+
 /**
  * @author Christian Mayer
  * @since 2015

--- a/src/lib/mockup/Client.js
+++ b/src/lib/mockup/Client.js
@@ -1,6 +1,6 @@
 /* Client.js 
  * 
- * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * copyright (c) 2010-2016, Christian Mayer and the CometVisu contributers.
  * 
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free

--- a/src/lib/mockup/Client.js
+++ b/src/lib/mockup/Client.js
@@ -1,3 +1,25 @@
+/* Client.js 
+ * 
+ * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * 
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+ *
+ * @module Client 
+ * @title  CometVisu Client 
+ */
+
 
 /**
  * Mockup simulating a backend + client for the Cometvisu protocol

--- a/src/lib/mockup/transform_knx.js
+++ b/src/lib/mockup/transform_knx.js
@@ -1,3 +1,25 @@
+/* transform_knx.js 
+ * 
+ * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * 
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+ *
+ * @module Transform_knx 
+ * @title  CometVisu Transform_knx 
+ */
+
 
 /**
  * Transform replacement mockup

--- a/src/lib/mockup/transform_knx.js
+++ b/src/lib/mockup/transform_knx.js
@@ -1,6 +1,6 @@
 /* transform_knx.js 
  * 
- * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * copyright (c) 2010-2016, Christian Mayer and the CometVisu contributers.
  * 
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free

--- a/src/lib/pagehandler.js
+++ b/src/lib/pagehandler.js
@@ -18,7 +18,6 @@
  *
  * @module Pagehandler 
  * @title  CometVisu Pagehandler 
- * @version 0.9.1-RC2
  */
 
 

--- a/src/lib/pagehandler.js
+++ b/src/lib/pagehandler.js
@@ -1,5 +1,7 @@
-/* pagehandler.js (c) 2016 by Christian Mayer [CometVisu at ChristianMayer dot de]
- *
+/* pagehandler.js 
+ * 
+ * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * 
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free
  * Software Foundation; either version 3 of the License, or (at your option)
@@ -7,17 +9,22 @@
  *
  * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
  * more details.
  *
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
- * 
- * @module Pagehandler
- * @title  CometVisu handler to show and hide the different pages
+ *
+ * @module Pagehandler 
+ * @title  CometVisu Pagehandler 
+ * @version 0.9.1-RC2
  */
 
+/**
+ * @author Christian Mayer
+ * @since 2016
+ */
 // FIXME and TODO: This class is currently just a quick hack to get rid
 // of the jQuery-Tools Scrollable. It should be enhanced to allow different
 // page transition animations like blending, etc. pp.

--- a/src/lib/pagehandler.js
+++ b/src/lib/pagehandler.js
@@ -1,6 +1,6 @@
 /* pagehandler.js 
  * 
- * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * copyright (c) 2010-2016, Christian Mayer and the CometVisu contributers.
  * 
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free

--- a/src/lib/pagehandler.js
+++ b/src/lib/pagehandler.js
@@ -21,6 +21,7 @@
  * @version 0.9.1-RC2
  */
 
+
 /**
  * @author Christian Mayer
  * @since 2016

--- a/src/lib/pagepartshandler.js
+++ b/src/lib/pagepartshandler.js
@@ -1,6 +1,6 @@
 /* pagepartshandler.js 
  * 
- * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * copyright (c) 2010-2016, Christian Mayer and the CometVisu contributers.
  * 
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free

--- a/src/lib/pagepartshandler.js
+++ b/src/lib/pagepartshandler.js
@@ -18,7 +18,6 @@
  *
  * @module Pagepartshandler 
  * @title  CometVisu Pagepartshandler 
- * @version 0.9.1-RC2
  */
 
 

--- a/src/lib/pagepartshandler.js
+++ b/src/lib/pagepartshandler.js
@@ -21,6 +21,7 @@
  * @version 0.9.1-RC2
  */
 
+
 /**
  * @author Christian Mayer
  * @since 2010

--- a/src/lib/pagepartshandler.js
+++ b/src/lib/pagepartshandler.js
@@ -1,5 +1,7 @@
-/* pagepartshandler.js (c) 2010-2015 by Christian Mayer [CometVisu at ChristianMayer dot de]
- *
+/* pagepartshandler.js 
+ * 
+ * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * 
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free
  * Software Foundation; either version 3 of the License, or (at your option)
@@ -7,17 +9,22 @@
  *
  * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
  * more details.
  *
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
- * 
- * @module PagePartsHandler
- * @title  CometVisu templateengine
+ *
+ * @module Pagepartshandler 
+ * @title  CometVisu Pagepartshandler 
+ * @version 0.9.1-RC2
  */
 
+/**
+ * @author Christian Mayer
+ * @since 2010
+ */
 define([ 'jquery' ], function( $ ) {
   "use strict";
   return function PagePartsHandler() {

--- a/src/lib/templateengine.js
+++ b/src/lib/templateengine.js
@@ -1,6 +1,6 @@
 /* templateengine.js 
  * 
- * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * copyright (c) 2010-2016, Christian Mayer and the CometVisu contributers.
  * 
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free

--- a/src/lib/templateengine.js
+++ b/src/lib/templateengine.js
@@ -18,7 +18,6 @@
  *
  * @module Templateengine 
  * @title  CometVisu Templateengine 
- * @version 0.9.1-RC2
  */
 
 

--- a/src/lib/templateengine.js
+++ b/src/lib/templateengine.js
@@ -21,6 +21,7 @@
  * @version 0.9.1-RC2
  */
 
+
 /**
  * Main Template engine
  *

--- a/src/lib/templateengine.js
+++ b/src/lib/templateengine.js
@@ -1,5 +1,7 @@
-/* templateengine.js (c) 2010-2016 by Christian Mayer [CometVisu at ChristianMayer dot de]
- *
+/* templateengine.js 
+ * 
+ * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * 
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free
  * Software Foundation; either version 3 of the License, or (at your option)
@@ -7,13 +9,16 @@
  *
  * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
  * more details.
  *
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
  *
+ * @module Templateengine 
+ * @title  CometVisu Templateengine 
+ * @version 0.9.1-RC2
  */
 
 /**

--- a/src/lib/trick-o-matic.js
+++ b/src/lib/trick-o-matic.js
@@ -1,6 +1,6 @@
 /* trick-o-matic.js 
  * 
- * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * copyright (c) 2010-2016, Christian Mayer and the CometVisu contributers.
  * 
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free

--- a/src/lib/trick-o-matic.js
+++ b/src/lib/trick-o-matic.js
@@ -18,7 +18,6 @@
  *
  * @module Trick-o-matic 
  * @title  CometVisu Trick-o-matic 
- * @version 0.9.1-RC2
  */
 
 

--- a/src/lib/trick-o-matic.js
+++ b/src/lib/trick-o-matic.js
@@ -1,5 +1,7 @@
-/* trick-o-matic.js (c) 2010-2015 by Christian Mayer [CometVisu at ChristianMayer dot de]
- *
+/* trick-o-matic.js 
+ * 
+ * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * 
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free
  * Software Foundation; either version 3 of the License, or (at your option)
@@ -7,17 +9,22 @@
  *
  * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
  * more details.
  *
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
- * 
- * @module Tick-o-Matic
- * @title  CometVisu templateengine
+ *
+ * @module Trick-o-matic 
+ * @title  CometVisu Trick-o-matic 
+ * @version 0.9.1-RC2
  */
 
+/**
+ * @author Christian Mayer
+ * @since 2010
+ */
 define([ 'jquery' ], function( $ ) {
   "use strict";
 

--- a/src/lib/trick-o-matic.js
+++ b/src/lib/trick-o-matic.js
@@ -21,6 +21,7 @@
  * @version 0.9.1-RC2
  */
 
+
 /**
  * @author Christian Mayer
  * @since 2010

--- a/src/structure/pure/_common.js
+++ b/src/structure/pure/_common.js
@@ -18,8 +18,8 @@
  *
  * @module _common 
  * @title  CometVisu _common 
- * @version 0.9.1-RC2
  */
+
 
 /**
  * This module defines the widgets for the CometVisu visualisation.

--- a/src/structure/pure/_common.js
+++ b/src/structure/pure/_common.js
@@ -1,6 +1,6 @@
 /* _common.js 
  * 
- * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * copyright (c) 2010-2016, Christian Mayer and the CometVisu contributers.
  * 
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free

--- a/src/structure/pure/_common.js
+++ b/src/structure/pure/_common.js
@@ -1,5 +1,7 @@
-/* _common.js (c) 2010 by Christian Mayer [CometVisu at ChristianMayer dot de]
- *
+/* _common.js 
+ * 
+ * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * 
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free
  * Software Foundation; either version 3 of the License, or (at your option)
@@ -7,18 +9,24 @@
  *
  * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
  * more details.
  *
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+ *
+ * @module _common 
+ * @title  CometVisu _common 
+ * @version 0.9.1-RC2
  */
 
 /**
  * This module defines the widgets for the CometVisu visualisation.
  * @module Structure Pure
  * @title  CometVisu Structure "pure"
+ * @author Christian Mayer [CometVisu at ChristianMayer dot de]
+ * @since 2010
 */
 define( ['jquery'], function($) {
   "use strict";

--- a/src/structure/pure/audio.js
+++ b/src/structure/pure/audio.js
@@ -1,6 +1,6 @@
 /* audio.js 
  * 
- * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * copyright (c) 2010-2016, Christian Mayer and the CometVisu contributers.
  * 
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free

--- a/src/structure/pure/audio.js
+++ b/src/structure/pure/audio.js
@@ -1,5 +1,7 @@
-/* audio.js (c) 2014 by Markus Damman 
- *
+/* audio.js 
+ * 
+ * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * 
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free
  * Software Foundation; either version 3 of the License, or (at your option)
@@ -7,14 +9,22 @@
  *
  * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
  * more details.
  *
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+ *
+ * @module Audio 
+ * @title  CometVisu Audio 
+ * @version 0.9.1-RC2
  */
 
+/**
+ * @author Markus Damman
+ * @since 2014
+ */
 define( ['_common'], function( design ) {
   "use strict";
   var basicdesign = design.basicdesign;

--- a/src/structure/pure/audio.js
+++ b/src/structure/pure/audio.js
@@ -18,8 +18,8 @@
  *
  * @module Audio 
  * @title  CometVisu Audio 
- * @version 0.9.1-RC2
  */
+
 
 /**
  * @author Markus Damman

--- a/src/structure/pure/break.js
+++ b/src/structure/pure/break.js
@@ -18,8 +18,8 @@
  *
  * @module Break 
  * @title  CometVisu Break 
- * @version 0.9.1-RC2
  */
+
 
 /**
  * @author Christian Mayer

--- a/src/structure/pure/break.js
+++ b/src/structure/pure/break.js
@@ -1,6 +1,6 @@
 /* break.js 
  * 
- * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * copyright (c) 2010-2016, Christian Mayer and the CometVisu contributers.
  * 
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free

--- a/src/structure/pure/break.js
+++ b/src/structure/pure/break.js
@@ -1,5 +1,7 @@
-/* break.js (c) 2012 by Christian Mayer [CometVisu at ChristianMayer dot de]
- *
+/* break.js 
+ * 
+ * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * 
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free
  * Software Foundation; either version 3 of the License, or (at your option)
@@ -7,14 +9,22 @@
  *
  * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
  * more details.
  *
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+ *
+ * @module Break 
+ * @title  CometVisu Break 
+ * @version 0.9.1-RC2
  */
 
+/**
+ * @author Christian Mayer
+ * @since 2012
+ */
 define( ['_common'], function( design ) {
   "use strict";
   var basicdesign = design.basicdesign;

--- a/src/structure/pure/designtoggle.js
+++ b/src/structure/pure/designtoggle.js
@@ -1,6 +1,6 @@
 /* designtoggle.js 
  * 
- * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * copyright (c) 2010-2016, Christian Mayer and the CometVisu contributers.
  * 
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free

--- a/src/structure/pure/designtoggle.js
+++ b/src/structure/pure/designtoggle.js
@@ -1,5 +1,7 @@
-/* designtoggle.js (c) 2010 by Christian Mayer [CometVisu at ChristianMayer dot de]
- *
+/* designtoggle.js 
+ * 
+ * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * 
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free
  * Software Foundation; either version 3 of the License, or (at your option)
@@ -7,14 +9,22 @@
  *
  * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
  * more details.
  *
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+ *
+ * @module Designtoggle 
+ * @title  CometVisu Designtoggle 
+ * @version 0.9.1-RC2
  */
 
+/**
+ * @author Christian Mayer
+ * @since 2010
+ */
 define( ['_common'], function( design ) {
   "use strict";
   var basicdesign = design.basicdesign;

--- a/src/structure/pure/designtoggle.js
+++ b/src/structure/pure/designtoggle.js
@@ -18,8 +18,8 @@
  *
  * @module Designtoggle 
  * @title  CometVisu Designtoggle 
- * @version 0.9.1-RC2
  */
+
 
 /**
  * @author Christian Mayer

--- a/src/structure/pure/group.js
+++ b/src/structure/pure/group.js
@@ -18,8 +18,8 @@
  *
  * @module Group 
  * @title  CometVisu Group 
- * @version 0.9.1-RC2
  */
+
 
 /**
  * @author Christian Mayer

--- a/src/structure/pure/group.js
+++ b/src/structure/pure/group.js
@@ -1,6 +1,6 @@
 /* group.js 
  * 
- * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * copyright (c) 2010-2016, Christian Mayer and the CometVisu contributers.
  * 
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free

--- a/src/structure/pure/group.js
+++ b/src/structure/pure/group.js
@@ -1,5 +1,7 @@
-/* group.js (c) 2012 by Christian Mayer [CometVisu at ChristianMayer dot de]
- *
+/* group.js 
+ * 
+ * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * 
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free
  * Software Foundation; either version 3 of the License, or (at your option)
@@ -7,14 +9,22 @@
  *
  * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
  * more details.
  *
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+ *
+ * @module Group 
+ * @title  CometVisu Group 
+ * @version 0.9.1-RC2
  */
 
+/**
+ * @author Christian Mayer
+ * @since 2012
+ */
 define( ['_common'], function( design ) {
   "use strict";
   var basicdesign = design.basicdesign;

--- a/src/structure/pure/image.js
+++ b/src/structure/pure/image.js
@@ -18,8 +18,8 @@
  *
  * @module Image 
  * @title  CometVisu Image 
- * @version 0.9.1-RC2
  */
+
 
 /**
  * @author Christian Mayer

--- a/src/structure/pure/image.js
+++ b/src/structure/pure/image.js
@@ -1,5 +1,7 @@
-/* image.js (c) 2012 by Christian Mayer [CometVisu at ChristianMayer dot de]
- *
+/* image.js 
+ * 
+ * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * 
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free
  * Software Foundation; either version 3 of the License, or (at your option)
@@ -7,14 +9,22 @@
  *
  * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
  * more details.
  *
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+ *
+ * @module Image 
+ * @title  CometVisu Image 
+ * @version 0.9.1-RC2
  */
 
+/**
+ * @author Christian Mayer
+ * @since 2012
+ */
 define( ['_common'], function( design ) {
   "use strict";
   var basicdesign = design.basicdesign;

--- a/src/structure/pure/image.js
+++ b/src/structure/pure/image.js
@@ -1,6 +1,6 @@
 /* image.js 
  * 
- * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * copyright (c) 2010-2016, Christian Mayer and the CometVisu contributers.
  * 
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free

--- a/src/structure/pure/imagetrigger.js
+++ b/src/structure/pure/imagetrigger.js
@@ -1,5 +1,7 @@
-/* imagetrigger.js (c) 2012 by Christian Mayer [CometVisu at ChristianMayer dot de]
- *
+/* imagetrigger.js 
+ * 
+ * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * 
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free
  * Software Foundation; either version 3 of the License, or (at your option)
@@ -7,14 +9,22 @@
  *
  * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
  * more details.
  *
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+ *
+ * @module Imagetrigger 
+ * @title  CometVisu Imagetrigger 
+ * @version 0.9.1-RC2
  */
 
+/**
+ * @author Christian Mayer
+ * @since 2012
+ */
 define( ['_common'], function( design ) {
   "use strict";
   var basicdesign = design.basicdesign;

--- a/src/structure/pure/imagetrigger.js
+++ b/src/structure/pure/imagetrigger.js
@@ -18,8 +18,8 @@
  *
  * @module Imagetrigger 
  * @title  CometVisu Imagetrigger 
- * @version 0.9.1-RC2
  */
+
 
 /**
  * @author Christian Mayer

--- a/src/structure/pure/imagetrigger.js
+++ b/src/structure/pure/imagetrigger.js
@@ -1,6 +1,6 @@
 /* imagetrigger.js 
  * 
- * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * copyright (c) 2010-2016, Christian Mayer and the CometVisu contributers.
  * 
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free

--- a/src/structure/pure/include.js
+++ b/src/structure/pure/include.js
@@ -1,6 +1,6 @@
 /* include.js 
  * 
- * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * copyright (c) 2010-2016, Christian Mayer and the CometVisu contributers.
  * 
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free

--- a/src/structure/pure/include.js
+++ b/src/structure/pure/include.js
@@ -1,5 +1,7 @@
-/* include.js (c) 2012 by Christian Mayer [CometVisu at ChristianMayer dot de]
- *
+/* include.js 
+ * 
+ * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * 
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free
  * Software Foundation; either version 3 of the License, or (at your option)
@@ -7,14 +9,22 @@
  *
  * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
  * more details.
  *
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+ *
+ * @module Include 
+ * @title  CometVisu Include 
+ * @version 0.9.1-RC2
  */
 
+/**
+ * @author Christian Mayer
+ * @since 2012
+ */
 define( ['_common'], function( design ) {
   "use strict";
   var basicdesign = design.basicdesign;

--- a/src/structure/pure/include.js
+++ b/src/structure/pure/include.js
@@ -18,8 +18,8 @@
  *
  * @module Include 
  * @title  CometVisu Include 
- * @version 0.9.1-RC2
  */
+
 
 /**
  * @author Christian Mayer

--- a/src/structure/pure/info.js
+++ b/src/structure/pure/info.js
@@ -1,6 +1,6 @@
 /* info.js 
  * 
- * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * copyright (c) 2010-2016, Christian Mayer and the CometVisu contributers.
  * 
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free

--- a/src/structure/pure/info.js
+++ b/src/structure/pure/info.js
@@ -1,5 +1,7 @@
-/* info.js (c) 2012 by Christian Mayer [CometVisu at ChristianMayer dot de]
- *
+/* info.js 
+ * 
+ * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * 
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free
  * Software Foundation; either version 3 of the License, or (at your option)
@@ -7,14 +9,22 @@
  *
  * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
  * more details.
  *
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+ *
+ * @module Info 
+ * @title  CometVisu Info 
+ * @version 0.9.1-RC2
  */
 
+/**
+ * @author Christian Mayer
+ * @since 2012
+ */
 define( ['_common'], function( design ) {
   "use strict";
   var basicdesign = design.basicdesign;

--- a/src/structure/pure/info.js
+++ b/src/structure/pure/info.js
@@ -18,8 +18,8 @@
  *
  * @module Info 
  * @title  CometVisu Info 
- * @version 0.9.1-RC2
  */
+
 
 /**
  * @author Christian Mayer

--- a/src/structure/pure/infoaction.js
+++ b/src/structure/pure/infoaction.js
@@ -1,6 +1,6 @@
 /* infoaction.js 
  * 
- * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * copyright (c) 2010-2016, Christian Mayer and the CometVisu contributers.
  * 
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free

--- a/src/structure/pure/infoaction.js
+++ b/src/structure/pure/infoaction.js
@@ -1,5 +1,7 @@
-/* infoaction.js (c) 2015 by Tobias Bräutigam [tbraeutigam at gmail dot com]
- *
+/* infoaction.js 
+ * 
+ * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * 
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free
  * Software Foundation; either version 3 of the License, or (at your option)
@@ -7,16 +9,20 @@
  *
  * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
  * more details.
  *
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+ *
+ * @module Infoaction 
+ * @title  CometVisu Infoaction 
+ * @version 0.9.1-RC2
  */
 
 /**
- * Thieinfoaction widget is a combination of an info/text widget
+ * The infoaction widget is a combination of an info/text widget
  * and an "action"-widget
  * 
  * use case: if you have a group of lights, you can show the number of turned on lights

--- a/src/structure/pure/infoaction.js
+++ b/src/structure/pure/infoaction.js
@@ -18,8 +18,8 @@
  *
  * @module Infoaction 
  * @title  CometVisu Infoaction 
- * @version 0.9.1-RC2
  */
+
 
 /**
  * The infoaction widget is a combination of an info/text widget

--- a/src/structure/pure/infotrigger.js
+++ b/src/structure/pure/infotrigger.js
@@ -18,8 +18,8 @@
  *
  * @module Infotrigger 
  * @title  CometVisu Infotrigger 
- * @version 0.9.1-RC2
  */
+
 
 /**
  * @author Christian Mayer

--- a/src/structure/pure/infotrigger.js
+++ b/src/structure/pure/infotrigger.js
@@ -1,6 +1,6 @@
 /* infotrigger.js 
  * 
- * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * copyright (c) 2010-2016, Christian Mayer and the CometVisu contributers.
  * 
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free

--- a/src/structure/pure/infotrigger.js
+++ b/src/structure/pure/infotrigger.js
@@ -1,5 +1,7 @@
-/* infotrigger.js (c) 2012 by Christian Mayer [CometVisu at ChristianMayer dot de]
- *
+/* infotrigger.js 
+ * 
+ * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * 
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free
  * Software Foundation; either version 3 of the License, or (at your option)
@@ -7,14 +9,22 @@
  *
  * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
  * more details.
  *
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+ *
+ * @module Infotrigger 
+ * @title  CometVisu Infotrigger 
+ * @version 0.9.1-RC2
  */
 
+/**
+ * @author Christian Mayer
+ * @since 2012
+ */
 define( ['_common'], function( design ) {
   "use strict";
   var basicdesign = design.basicdesign;

--- a/src/structure/pure/line.js
+++ b/src/structure/pure/line.js
@@ -1,6 +1,6 @@
 /* line.js 
  * 
- * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * copyright (c) 2010-2016, Christian Mayer and the CometVisu contributers.
  * 
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free

--- a/src/structure/pure/line.js
+++ b/src/structure/pure/line.js
@@ -18,8 +18,8 @@
  *
  * @module Line 
  * @title  CometVisu Line 
- * @version 0.9.1-RC2
  */
+
 
 /**
  * @author Christian Mayer

--- a/src/structure/pure/line.js
+++ b/src/structure/pure/line.js
@@ -1,5 +1,7 @@
-/* line.js (c) 2012 by Christian Mayer [CometVisu at ChristianMayer dot de]
- *
+/* line.js 
+ * 
+ * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * 
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free
  * Software Foundation; either version 3 of the License, or (at your option)
@@ -7,14 +9,22 @@
  *
  * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
  * more details.
  *
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+ *
+ * @module Line 
+ * @title  CometVisu Line 
+ * @version 0.9.1-RC2
  */
 
+/**
+ * @author Christian Mayer
+ * @since 2012
+ */
 define( ['_common'], function( design ) {
   "use strict";
   var basicdesign = design.basicdesign;

--- a/src/structure/pure/multitrigger.js
+++ b/src/structure/pure/multitrigger.js
@@ -1,5 +1,7 @@
-/* multitrigger.js (c) 2012 by Christian Mayer [CometVisu at ChristianMayer dot de]
- *
+/* multitrigger.js 
+ * 
+ * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * 
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free
  * Software Foundation; either version 3 of the License, or (at your option)
@@ -7,14 +9,22 @@
  *
  * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
  * more details.
  *
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+ *
+ * @module Multitrigger 
+ * @title  CometVisu Multitrigger 
+ * @version 0.9.1-RC2
  */
 
+/**
+ * @author Christian Mayer
+ * @since 2012
+ */
 define( ['_common'], function( design ) {
   "use strict";
   var basicdesign = design.basicdesign;

--- a/src/structure/pure/multitrigger.js
+++ b/src/structure/pure/multitrigger.js
@@ -1,6 +1,6 @@
 /* multitrigger.js 
  * 
- * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * copyright (c) 2010-2016, Christian Mayer and the CometVisu contributers.
  * 
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free

--- a/src/structure/pure/multitrigger.js
+++ b/src/structure/pure/multitrigger.js
@@ -18,8 +18,8 @@
  *
  * @module Multitrigger 
  * @title  CometVisu Multitrigger 
- * @version 0.9.1-RC2
  */
+
 
 /**
  * @author Christian Mayer

--- a/src/structure/pure/navbar.js
+++ b/src/structure/pure/navbar.js
@@ -1,6 +1,6 @@
 /* navbar.js 
  * 
- * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * copyright (c) 2010-2016, Christian Mayer and the CometVisu contributers.
  * 
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free

--- a/src/structure/pure/navbar.js
+++ b/src/structure/pure/navbar.js
@@ -18,8 +18,8 @@
  *
  * @module Navbar 
  * @title  CometVisu Navbar 
- * @version 0.9.1-RC2
  */
+
 
 /**
  * @author Christian Mayer

--- a/src/structure/pure/navbar.js
+++ b/src/structure/pure/navbar.js
@@ -1,5 +1,7 @@
-/* navbar.js (c) 2012 by Christian Mayer [CometVisu at ChristianMayer dot de]
- *
+/* navbar.js 
+ * 
+ * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * 
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free
  * Software Foundation; either version 3 of the License, or (at your option)
@@ -7,14 +9,22 @@
  *
  * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
  * more details.
  *
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+ *
+ * @module Navbar 
+ * @title  CometVisu Navbar 
+ * @version 0.9.1-RC2
  */
 
+/**
+ * @author Christian Mayer
+ * @since 2012
+ */
 define( ['_common'], function( design ) {
   "use strict";
   var 

--- a/src/structure/pure/page.js
+++ b/src/structure/pure/page.js
@@ -18,8 +18,8 @@
  *
  * @module Page 
  * @title  CometVisu Page 
- * @version 0.9.1-RC2
  */
+
 
 /**
  * @author Christian Mayer

--- a/src/structure/pure/page.js
+++ b/src/structure/pure/page.js
@@ -1,6 +1,6 @@
 /* page.js 
  * 
- * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * copyright (c) 2010-2016, Christian Mayer and the CometVisu contributers.
  * 
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free

--- a/src/structure/pure/page.js
+++ b/src/structure/pure/page.js
@@ -1,5 +1,7 @@
-/* page.js (c) 2012 by Christian Mayer [CometVisu at ChristianMayer dot de]
- *
+/* page.js 
+ * 
+ * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * 
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free
  * Software Foundation; either version 3 of the License, or (at your option)
@@ -7,14 +9,22 @@
  *
  * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
  * more details.
  *
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+ *
+ * @module Page 
+ * @title  CometVisu Page 
+ * @version 0.9.1-RC2
  */
 
+/**
+ * @author Christian Mayer
+ * @since 2012
+ */
 define( ['_common'], function( design ) {
   "use strict";
   var 

--- a/src/structure/pure/pagejump.js
+++ b/src/structure/pure/pagejump.js
@@ -18,8 +18,8 @@
  *
  * @module Pagejump 
  * @title  CometVisu Pagejump 
- * @version 0.9.1-RC2
  */
+
 
 /**
  * @author Christian Mayer

--- a/src/structure/pure/pagejump.js
+++ b/src/structure/pure/pagejump.js
@@ -1,5 +1,7 @@
-/* pagejump.js (c) 2012 by Christian Mayer [CometVisu at ChristianMayer dot de]
- *
+/* pagejump.js 
+ * 
+ * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * 
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free
  * Software Foundation; either version 3 of the License, or (at your option)
@@ -7,14 +9,22 @@
  *
  * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
  * more details.
  *
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+ *
+ * @module Pagejump 
+ * @title  CometVisu Pagejump 
+ * @version 0.9.1-RC2
  */
 
+/**
+ * @author Christian Mayer
+ * @since 2012
+ */
 define( ['_common'], function( design ) {
   "use strict";
   var basicdesign = design.basicdesign;

--- a/src/structure/pure/pagejump.js
+++ b/src/structure/pure/pagejump.js
@@ -1,6 +1,6 @@
 /* pagejump.js 
  * 
- * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * copyright (c) 2010-2016, Christian Mayer and the CometVisu contributers.
  * 
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free

--- a/src/structure/pure/pushbutton.js
+++ b/src/structure/pure/pushbutton.js
@@ -18,8 +18,8 @@
  *
  * @module Pushbutton 
  * @title  CometVisu Pushbutton 
- * @version 0.9.1-RC2
  */
+
 
 /**
  * @since 2013

--- a/src/structure/pure/pushbutton.js
+++ b/src/structure/pure/pushbutton.js
@@ -1,6 +1,6 @@
 /* pushbutton.js 
  * 
- * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * copyright (c) 2010-2016, Christian Mayer and the CometVisu contributers.
  * 
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free

--- a/src/structure/pure/pushbutton.js
+++ b/src/structure/pure/pushbutton.js
@@ -1,5 +1,7 @@
-/* pushbutton.js
- *
+/* pushbutton.js 
+ * 
+ * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * 
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free
  * Software Foundation; either version 3 of the License, or (at your option)
@@ -7,14 +9,21 @@
  *
  * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
  * more details.
  *
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+ *
+ * @module Pushbutton 
+ * @title  CometVisu Pushbutton 
+ * @version 0.9.1-RC2
  */
 
+/**
+ * @since 2013
+ */
 define( ['_common'], function( design ) {
   "use strict";
   var basicdesign = design.basicdesign;

--- a/src/structure/pure/refresh.js
+++ b/src/structure/pure/refresh.js
@@ -1,3 +1,26 @@
+/* refresh.js 
+ * 
+ * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * 
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+ *
+ * @module Refresh 
+ * @title  CometVisu Refresh 
+ * @version 0.9.1-RC2
+ */
+
 /* refresh.js (c) 2014 by Christian Mayer [CometVisu at ChristianMayer dot de]
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/src/structure/pure/refresh.js
+++ b/src/structure/pure/refresh.js
@@ -18,8 +18,8 @@
  *
  * @module Refresh 
  * @title  CometVisu Refresh 
- * @version 0.9.1-RC2
  */
+
 
 /* refresh.js (c) 2014 by Christian Mayer [CometVisu at ChristianMayer dot de]
  *

--- a/src/structure/pure/refresh.js
+++ b/src/structure/pure/refresh.js
@@ -1,6 +1,6 @@
 /* refresh.js 
  * 
- * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * copyright (c) 2010-2016, Christian Mayer and the CometVisu contributers.
  * 
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free
@@ -19,7 +19,6 @@
  * @module Refresh 
  * @title  CometVisu Refresh 
  */
-
 
 
 /**

--- a/src/structure/pure/refresh.js
+++ b/src/structure/pure/refresh.js
@@ -21,23 +21,11 @@
  */
 
 
-/* refresh.js (c) 2014 by Christian Mayer [CometVisu at ChristianMayer dot de]
- *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License as published by the Free
- * Software Foundation; either version 3 of the License, or (at your option)
- * any later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
- * more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
- */
 
+/**
+ * @author Christian Mayer
+ * @since 2014
+ */
 define( ['_common'], function( design ) {
   "use strict";
   var basicdesign = design.basicdesign;

--- a/src/structure/pure/reload.js
+++ b/src/structure/pure/reload.js
@@ -21,23 +21,10 @@
  */
 
 
-/* refresh.js (c) 2014 by Christian Mayer [CometVisu at ChristianMayer dot de]
- *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License as published by the Free
- * Software Foundation; either version 3 of the License, or (at your option)
- * any later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
- * more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+/**
+ * @author Christian Mayer
+ * @since 2014
  */
-
 define( ['_common'], function( design ) {
   "use strict";
   var basicdesign = design.basicdesign;

--- a/src/structure/pure/reload.js
+++ b/src/structure/pure/reload.js
@@ -18,8 +18,8 @@
  *
  * @module Reload 
  * @title  CometVisu Reload 
- * @version 0.9.1-RC2
  */
+
 
 /* refresh.js (c) 2014 by Christian Mayer [CometVisu at ChristianMayer dot de]
  *

--- a/src/structure/pure/reload.js
+++ b/src/structure/pure/reload.js
@@ -1,3 +1,26 @@
+/* reload.js 
+ * 
+ * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * 
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+ *
+ * @module Reload 
+ * @title  CometVisu Reload 
+ * @version 0.9.1-RC2
+ */
+
 /* refresh.js (c) 2014 by Christian Mayer [CometVisu at ChristianMayer dot de]
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/src/structure/pure/reload.js
+++ b/src/structure/pure/reload.js
@@ -1,6 +1,6 @@
 /* reload.js 
  * 
- * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * copyright (c) 2010-2016, Christian Mayer and the CometVisu contributers.
  * 
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free

--- a/src/structure/pure/rgb.js
+++ b/src/structure/pure/rgb.js
@@ -1,6 +1,6 @@
 /* rgb.js 
  * 
- * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * copyright (c) 2010-2016, Christian Mayer and the CometVisu contributers.
  * 
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free

--- a/src/structure/pure/rgb.js
+++ b/src/structure/pure/rgb.js
@@ -21,23 +21,10 @@
  */
 
 
-/* image.js (c) 2012 by Christian Mayer [CometVisu at ChristianMayer dot de]
- *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License as published by the Free
- * Software Foundation; either version 3 of the License, or (at your option)
- * any later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
- * more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+/**
+ * @author Christian Mayer
+ * @since 2012
  */
-
 define( ['_common'], function( design ) {
   "use strict";
   var basicdesign = design.basicdesign;

--- a/src/structure/pure/rgb.js
+++ b/src/structure/pure/rgb.js
@@ -18,8 +18,8 @@
  *
  * @module Rgb 
  * @title  CometVisu Rgb 
- * @version 0.9.1-RC2
  */
+
 
 /* image.js (c) 2012 by Christian Mayer [CometVisu at ChristianMayer dot de]
  *

--- a/src/structure/pure/rgb.js
+++ b/src/structure/pure/rgb.js
@@ -1,3 +1,26 @@
+/* rgb.js 
+ * 
+ * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * 
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+ *
+ * @module Rgb 
+ * @title  CometVisu Rgb 
+ * @version 0.9.1-RC2
+ */
+
 /* image.js (c) 2012 by Christian Mayer [CometVisu at ChristianMayer dot de]
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/src/structure/pure/slide.js
+++ b/src/structure/pure/slide.js
@@ -1,3 +1,26 @@
+/* slide.js 
+ * 
+ * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * 
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+ *
+ * @module Slide 
+ * @title  CometVisu Slide 
+ * @version 0.9.1-RC2
+ */
+
 /* slide.js (c) 2012 by Christian Mayer [CometVisu at ChristianMayer dot de]
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/src/structure/pure/slide.js
+++ b/src/structure/pure/slide.js
@@ -21,23 +21,10 @@
  */
 
 
-/* slide.js (c) 2012 by Christian Mayer [CometVisu at ChristianMayer dot de]
- *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License as published by the Free
- * Software Foundation; either version 3 of the License, or (at your option)
- * any later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
- * more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+/**
+ * @author Christian Mayer
+ * @since 2012
  */
-
 define( ['_common'], function( design ) {
   "use strict";
   var 

--- a/src/structure/pure/slide.js
+++ b/src/structure/pure/slide.js
@@ -1,6 +1,6 @@
 /* slide.js 
  * 
- * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * copyright (c) 2010-2016, Christian Mayer and the CometVisu contributers.
  * 
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free

--- a/src/structure/pure/slide.js
+++ b/src/structure/pure/slide.js
@@ -18,8 +18,8 @@
  *
  * @module Slide 
  * @title  CometVisu Slide 
- * @version 0.9.1-RC2
  */
+
 
 /* slide.js (c) 2012 by Christian Mayer [CometVisu at ChristianMayer dot de]
  *

--- a/src/structure/pure/switch.js
+++ b/src/structure/pure/switch.js
@@ -18,8 +18,8 @@
  *
  * @module Switch 
  * @title  CometVisu Switch 
- * @version 0.9.1-RC2
  */
+
 
 /* switch.js (c) 2012 by Christian Mayer [CometVisu at ChristianMayer dot de]
  *

--- a/src/structure/pure/switch.js
+++ b/src/structure/pure/switch.js
@@ -21,23 +21,10 @@
  */
 
 
-/* switch.js (c) 2012 by Christian Mayer [CometVisu at ChristianMayer dot de]
- *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License as published by the Free
- * Software Foundation; either version 3 of the License, or (at your option)
- * any later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
- * more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+/**
+ * @author Christian Mayer
+ * @since 2012
  */
-
 define( ['_common'], function( design ) {
   "use strict";
   var basicdesign = design.basicdesign;

--- a/src/structure/pure/switch.js
+++ b/src/structure/pure/switch.js
@@ -1,6 +1,6 @@
 /* switch.js 
  * 
- * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * copyright (c) 2010-2016, Christian Mayer and the CometVisu contributers.
  * 
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free

--- a/src/structure/pure/switch.js
+++ b/src/structure/pure/switch.js
@@ -1,3 +1,26 @@
+/* switch.js 
+ * 
+ * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * 
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+ *
+ * @module Switch 
+ * @title  CometVisu Switch 
+ * @version 0.9.1-RC2
+ */
+
 /* switch.js (c) 2012 by Christian Mayer [CometVisu at ChristianMayer dot de]
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/src/structure/pure/text.js
+++ b/src/structure/pure/text.js
@@ -18,8 +18,8 @@
  *
  * @module Text 
  * @title  CometVisu Text 
- * @version 0.9.1-RC2
  */
+
 
 /**
  * @author Christian Mayer

--- a/src/structure/pure/text.js
+++ b/src/structure/pure/text.js
@@ -1,5 +1,7 @@
-/* text.js (c) 2012-2015 by Christian Mayer [CometVisu at ChristianMayer dot de]
- *
+/* text.js 
+ * 
+ * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * 
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free
  * Software Foundation; either version 3 of the License, or (at your option)
@@ -7,14 +9,22 @@
  *
  * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
  * more details.
  *
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+ *
+ * @module Text 
+ * @title  CometVisu Text 
+ * @version 0.9.1-RC2
  */
 
+/**
+ * @author Christian Mayer
+ * @since 2012
+ */
 define( ['_common'], function( design ) {
   "use strict";
   var basicdesign = design.basicdesign;

--- a/src/structure/pure/text.js
+++ b/src/structure/pure/text.js
@@ -1,6 +1,6 @@
 /* text.js 
  * 
- * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * copyright (c) 2010-2016, Christian Mayer and the CometVisu contributers.
  * 
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free

--- a/src/structure/pure/toggle.js
+++ b/src/structure/pure/toggle.js
@@ -1,6 +1,6 @@
 /* toggle.js 
  * 
- * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * copyright (c) 2010-2016, Christian Mayer and the CometVisu contributers.
  * 
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free

--- a/src/structure/pure/toggle.js
+++ b/src/structure/pure/toggle.js
@@ -18,8 +18,8 @@
  *
  * @module Toggle 
  * @title  CometVisu Toggle 
- * @version 0.9.1-RC2
  */
+
 
 /**
  * @author Christian Mayer

--- a/src/structure/pure/toggle.js
+++ b/src/structure/pure/toggle.js
@@ -1,5 +1,7 @@
-/* toggle.js (c) 2012 by Christian Mayer [CometVisu at ChristianMayer dot de]
- *
+/* toggle.js 
+ * 
+ * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * 
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free
  * Software Foundation; either version 3 of the License, or (at your option)
@@ -7,14 +9,22 @@
  *
  * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
  * more details.
  *
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+ *
+ * @module Toggle 
+ * @title  CometVisu Toggle 
+ * @version 0.9.1-RC2
  */
 
+/**
+ * @author Christian Mayer
+ * @since 2012
+ */
 define( ['_common'], function( design ) {
   "use strict";
   var basicdesign = design.basicdesign;

--- a/src/structure/pure/trigger.js
+++ b/src/structure/pure/trigger.js
@@ -1,5 +1,7 @@
-/* trigger.js (c) 2012 by Christian Mayer [CometVisu at ChristianMayer dot de]
- *
+/* trigger.js 
+ * 
+ * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * 
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free
  * Software Foundation; either version 3 of the License, or (at your option)
@@ -7,14 +9,22 @@
  *
  * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
  * more details.
  *
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+ *
+ * @module Trigger 
+ * @title  CometVisu Trigger 
+ * @version 0.9.1-RC2
  */
 
+/**
+ * @author Christian Mayer
+ * @since 2012
+ */
 define( ['_common'], function( design ) {
   "use strict";
   var basicdesign = design.basicdesign;

--- a/src/structure/pure/trigger.js
+++ b/src/structure/pure/trigger.js
@@ -1,6 +1,6 @@
 /* trigger.js 
  * 
- * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * copyright (c) 2010-2016, Christian Mayer and the CometVisu contributers.
  * 
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free

--- a/src/structure/pure/trigger.js
+++ b/src/structure/pure/trigger.js
@@ -18,8 +18,8 @@
  *
  * @module Trigger 
  * @title  CometVisu Trigger 
- * @version 0.9.1-RC2
  */
+
 
 /**
  * @author Christian Mayer

--- a/src/structure/pure/unknown.js
+++ b/src/structure/pure/unknown.js
@@ -1,5 +1,7 @@
-/* unknown.js (c) 2012 by Christian Mayer [CometVisu at ChristianMayer dot de]
- *
+/* unknown.js 
+ * 
+ * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * 
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free
  * Software Foundation; either version 3 of the License, or (at your option)
@@ -7,14 +9,23 @@
  *
  * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
  * more details.
  *
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+ *
+ * @module Unknown 
+ * @title  CometVisu Unknown 
+ * @version 0.9.1-RC2
  */
 
+
+/**
+ * @author Christian Mayer
+ * @since 2012
+ */
 define( ['_common'], function( design ) {
   "use strict";
   var basicdesign = design.basicdesign;

--- a/src/structure/pure/unknown.js
+++ b/src/structure/pure/unknown.js
@@ -18,7 +18,6 @@
  *
  * @module Unknown 
  * @title  CometVisu Unknown 
- * @version 0.9.1-RC2
  */
 
 

--- a/src/structure/pure/unknown.js
+++ b/src/structure/pure/unknown.js
@@ -1,6 +1,6 @@
 /* unknown.js 
  * 
- * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * copyright (c) 2010-2016, Christian Mayer and the CometVisu contributers.
  * 
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free

--- a/src/structure/pure/urltrigger.js
+++ b/src/structure/pure/urltrigger.js
@@ -1,6 +1,6 @@
 /* urltrigger.js 
  * 
- * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * copyright (c) 2010-2016, Christian Mayer and the CometVisu contributers.
  * 
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free

--- a/src/structure/pure/urltrigger.js
+++ b/src/structure/pure/urltrigger.js
@@ -18,8 +18,8 @@
  *
  * @module Urltrigger 
  * @title  CometVisu Urltrigger 
- * @version 0.9.1-RC2
  */
+
 
 /**
  * @author Christian Mayer

--- a/src/structure/pure/urltrigger.js
+++ b/src/structure/pure/urltrigger.js
@@ -1,6 +1,7 @@
-/* trigger.js (c) 2012 by Christian Mayer [CometVisu at ChristianMayer dot de]
- * modified urltrigger.js (c) 2012 by mm@elabnet.de
- *
+/* urltrigger.js 
+ * 
+ * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * 
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free
  * Software Foundation; either version 3 of the License, or (at your option)
@@ -8,14 +9,22 @@
  *
  * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
  * more details.
  *
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+ *
+ * @module Urltrigger 
+ * @title  CometVisu Urltrigger 
+ * @version 0.9.1-RC2
  */
 
+/**
+ * @author Christian Mayer
+ * @since 2012
+ */
 define( ['_common'], function( design ) {
   "use strict";
   var basicdesign = design.basicdesign;

--- a/src/structure/pure/video.js
+++ b/src/structure/pure/video.js
@@ -1,6 +1,6 @@
 /* video.js 
  * 
- * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * copyright (c) 2010-2016, Christian Mayer and the CometVisu contributers.
  * 
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free

--- a/src/structure/pure/video.js
+++ b/src/structure/pure/video.js
@@ -1,5 +1,7 @@
-/* video.js (c) 2012 by Christian Mayer [CometVisu at ChristianMayer dot de]
- *
+/* video.js 
+ * 
+ * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * 
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free
  * Software Foundation; either version 3 of the License, or (at your option)
@@ -7,14 +9,22 @@
  *
  * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
  * more details.
  *
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+ *
+ * @module Video 
+ * @title  CometVisu Video 
+ * @version 0.9.1-RC2
  */
 
+/**
+ * @author Christian Mayer
+ * @since 2012
+ */
 define( ['_common'], function( design ) {
   "use strict";
   var basicdesign = design.basicdesign;

--- a/src/structure/pure/video.js
+++ b/src/structure/pure/video.js
@@ -18,8 +18,8 @@
  *
  * @module Video 
  * @title  CometVisu Video 
- * @version 0.9.1-RC2
  */
+
 
 /**
  * @author Christian Mayer

--- a/src/structure/pure/web.js
+++ b/src/structure/pure/web.js
@@ -18,8 +18,8 @@
  *
  * @module Web 
  * @title  CometVisu Web 
- * @version 0.9.1-RC2
  */
+
 
 /**
  * @author Christian Mayer

--- a/src/structure/pure/web.js
+++ b/src/structure/pure/web.js
@@ -1,5 +1,7 @@
-/* web.js (c) 2012 by Christian Mayer [CometVisu at ChristianMayer dot de]
- *
+/* web.js 
+ * 
+ * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * 
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free
  * Software Foundation; either version 3 of the License, or (at your option)
@@ -7,14 +9,22 @@
  *
  * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
  * more details.
  *
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+ *
+ * @module Web 
+ * @title  CometVisu Web 
+ * @version 0.9.1-RC2
  */
 
+/**
+ * @author Christian Mayer
+ * @since 2012
+ */
 define( ['_common'], function( design ) {
   "use strict";
   var basicdesign = design.basicdesign;

--- a/src/structure/pure/web.js
+++ b/src/structure/pure/web.js
@@ -1,6 +1,6 @@
 /* web.js 
  * 
- * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * copyright (c) 2010-2016, Christian Mayer and the CometVisu contributers.
  * 
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free

--- a/src/structure/pure/wgplugin_info.js
+++ b/src/structure/pure/wgplugin_info.js
@@ -18,8 +18,8 @@
  *
  * @module Wgplugin_info 
  * @title  CometVisu Wgplugin_info 
- * @version 0.9.1-RC2
  */
+
 
 /**
  * @author Christian Mayer

--- a/src/structure/pure/wgplugin_info.js
+++ b/src/structure/pure/wgplugin_info.js
@@ -1,5 +1,7 @@
-/* info.js (c) 2012 by Christian Mayer [CometVisu at ChristianMayer dot de]
- *
+/* wgplugin_info.js 
+ * 
+ * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * 
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free
  * Software Foundation; either version 3 of the License, or (at your option)
@@ -7,14 +9,22 @@
  *
  * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
  * more details.
  *
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+ *
+ * @module Wgplugin_info 
+ * @title  CometVisu Wgplugin_info 
+ * @version 0.9.1-RC2
  */
 
+/**
+ * @author Christian Mayer
+ * @since 2012
+ */
 define( ['_common'], function( design ) {
   "use strict";
   var basicdesign = design.basicdesign;

--- a/src/structure/pure/wgplugin_info.js
+++ b/src/structure/pure/wgplugin_info.js
@@ -1,6 +1,6 @@
 /* wgplugin_info.js 
  * 
- * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * copyright (c) 2010-2016, Christian Mayer and the CometVisu contributers.
  * 
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free

--- a/src/transforms/transform_default.js
+++ b/src/transforms/transform_default.js
@@ -18,7 +18,6 @@
  *
  * @module Transform_default 
  * @title  CometVisu Transform_default 
- * @version 0.9.1-RC2
  */
 
 

--- a/src/transforms/transform_default.js
+++ b/src/transforms/transform_default.js
@@ -1,6 +1,6 @@
 /* transform_default.js 
  * 
- * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * copyright (c) 2010-2016, Christian Mayer and the CometVisu contributers.
  * 
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free

--- a/src/transforms/transform_default.js
+++ b/src/transforms/transform_default.js
@@ -1,5 +1,7 @@
-/* transform_default.js (c) 2010 by Christian Mayer [CometVisu at ChristianMayer dot de]
- *
+/* transform_default.js 
+ * 
+ * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * 
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free
  * Software Foundation; either version 3 of the License, or (at your option)
@@ -7,14 +9,23 @@
  *
  * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
  * more details.
  *
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
-*/
+ *
+ * @module Transform_default 
+ * @title  CometVisu Transform_default 
+ * @version 0.9.1-RC2
+ */
 
+
+/**
+ * @author Christian Mayer
+ * @since 2010
+ */
 define(['jquery'], function($) {
   "use strict";
   /**

--- a/src/transforms/transform_knx.js
+++ b/src/transforms/transform_knx.js
@@ -18,7 +18,6 @@
  *
  * @module Transform_knx 
  * @title  CometVisu Transform_knx 
- * @version 0.9.1-RC2
  */
 
 

--- a/src/transforms/transform_knx.js
+++ b/src/transforms/transform_knx.js
@@ -1,5 +1,7 @@
-/* transform_knx.js (c) 2010 by Christian Mayer [CometVisu at ChristianMayer dot de]
- *
+/* transform_knx.js 
+ * 
+ * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * 
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free
  * Software Foundation; either version 3 of the License, or (at your option)
@@ -7,14 +9,23 @@
  *
  * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
  * more details.
  *
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
-*/
+ *
+ * @module Transform_knx 
+ * @title  CometVisu Transform_knx 
+ * @version 0.9.1-RC2
+ */
 
+
+/**
+ * @author Christian Mayer
+ * @since 2010
+ */
 define( ['transform_default'], function( Transform ) {
   "use strict";
   /**

--- a/src/transforms/transform_knx.js
+++ b/src/transforms/transform_knx.js
@@ -1,6 +1,6 @@
 /* transform_knx.js 
  * 
- * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * copyright (c) 2010-2016, Christian Mayer and the CometVisu contributers.
  * 
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free

--- a/src/transforms/transform_oh.js
+++ b/src/transforms/transform_oh.js
@@ -18,7 +18,6 @@
  *
  * @module Transform_oh 
  * @title  CometVisu Transform_oh 
- * @version 0.9.1-RC2
  */
 
 

--- a/src/transforms/transform_oh.js
+++ b/src/transforms/transform_oh.js
@@ -1,6 +1,6 @@
 /* transform_oh.js 
  * 
- * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * copyright (c) 2010-2016, Christian Mayer and the CometVisu contributers.
  * 
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free

--- a/src/transforms/transform_oh.js
+++ b/src/transforms/transform_oh.js
@@ -1,5 +1,7 @@
-/* transform_knx.js (c) 2010 by Christian Mayer [CometVisu at ChristianMayer dot de]
- *
+/* transform_oh.js 
+ * 
+ * copyright (c) 2010-2016 by Christian Mayer (ChristianMayer) [CometVisu at ChristianMayer dot de]
+ * 
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free
  * Software Foundation; either version 3 of the License, or (at your option)
@@ -7,14 +9,25 @@
  *
  * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
  * more details.
  *
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+ *
+ * @module Transform_oh 
+ * @title  CometVisu Transform_oh 
+ * @version 0.9.1-RC2
  */
 
+
+/**
+ * Transformations for the openHAB backend
+ * 
+ * @author Tobias Bräutigam
+ * @since 2012
+ */
 define( ['transform_default'], function( Transform ) {
   "use strict";
   


### PR DESCRIPTION
This PR updates the license header in the source files to a 'grunt usebanner' compatible version. From now on changes/updates to the license headers (e.g. updating the license year) could be done by a grunt task.

Informations from the current headers (author + year of creation) have been moved to @author + @since annotations in the file header.

Note: This PR is not so much about what the new license header contains (as we can change that later easily) but about preparing the automation without loosing information.