### PR TITLE
Fix index during restart

### DIFF
--- a/src/lib/cometvisu-client.js
+++ b/src/lib/cometvisu-client.js
@@ -314,7 +314,7 @@ define( 'cometvisu-client', ['jquery'], function( $ ) {
          */
         this.restart = function( doFullReload ) {
           if( doFullReload )
-            thislastIndex = -1; // reload all data
+            this.lastIndex = -1; // reload all data
 
           self.doRestart = true;
           self.abort();


### PR DESCRIPTION
Typo as `thislastIndex` doesn't exists and `this.lastIndex` is the correct variable to set.