### PR TITLE
use the last version of grunt-bump which does not require grunt versi…

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "csso": "^1.5.4",
     "grunt": "^0.4.0",
     "grunt-banner": "^0.6.0",
-    "grunt-bump": "^0.7.0",
+    "grunt-bump": "0.7.0",
     "grunt-chmod": "latest",
     "grunt-contrib-clean": "^1.0.0",
     "grunt-contrib-compress": "^1.0.0",


### PR DESCRIPTION
…on >1.0.0 as this conflicts with other dependencies