### PR TITLE
another minor style fix for pagejump->widgetinfo usage in navbars

### DIFF
--- a/src/designs/metal/basic.css
+++ b/src/designs/metal/basic.css
@@ -728,6 +728,7 @@ background-color: #000;
 	font-size: 0.7em;
 	float: left;
 	margin: 0 auto;
+    padding: 0;
 }
 
 #navbarTop .navbar .pagejump .actor, 


### PR DESCRIPTION
Ok this was the only styling fix regarding the widgetinfo that as applyable to a bugfix release. The rest includes the moving of the infoaction from plugin to widget. There were also some styling fixes included in that commit, but I am not able to seperate them from the rest, so I leave it by this tiny change.