### PR TITLE
Enhancement: gacefully handle nonexistent plugins

### DIFF
--- a/src/lib/TemplateEngine.js
+++ b/src/lib/TemplateEngine.js
@@ -653,7 +653,11 @@ define([
       delete loadReady.plugins;
     }
     */
-    require( pluginsToLoad, delaySetup('plugins') );
+    var delaySetupPluginsCallback = delaySetup('plugins');
+    require( pluginsToLoad, delaySetupPluginsCallback, function( err ) {
+      console.log( 'Plugin loading error! It happend with: "' + err.requireModules[0] + '". Is the plugin available and written correctly?');
+      delaySetupPluginsCallback();
+    });
     
     // then the icons
     $('meta > icons icon-definition', xml).each(function(i) {


### PR DESCRIPTION
When the contig contains a plugin that does not exists a message will
be sent to the console (to help debugging for the user) but then
the visu will continue to load.

Note: when the plugin will not only be loaded but also be used the
usual "unknown widget" will appear there.