### PR TITLE
use abbreviations instead of citations to avoid the linking problem.

### DIFF
--- a/.doc/docutils/directives/common.py
+++ b/.doc/docutils/directives/common.py
@@ -82,8 +82,6 @@ class BaseXsdDirective(BaseDirective):
 
     def generate_table(self, element_name, include_name=False, mandatory=False):
         table_body = []
-        has_required_attribute = False
-        has_required_element = False
         attributes = schema.get_widget_attributes(element_name)
         if include_name:
             rowspan = len(attributes)-1
@@ -109,15 +107,13 @@ class BaseXsdDirective(BaseDirective):
 
             #name = ":ref:`%s <%s>`" % (name, name)
             if attr.get('use', 'optional') == "required":
-                name += " [i]_"
-                has_required_attribute = True
+                name += " :abbr:`*(%s)`" % _('mandatory')
 
             atype = self.normalize_type(atype) if len(values) == 0 else self.normalize_values(values)
             if include_name:
                 if line == 0:
                     if mandatory:
-                        element_name += " [i]_ "
-                        has_required_element = True
+                        element_name += "*"
 
                     row = [(rowspan, 0, 0, statemachine.StringList(element_name.splitlines())), self.get_cell_data(name), self.get_cell_data(atype), self.get_cell_data(description)]
                 else:
@@ -145,17 +141,6 @@ class BaseXsdDirective(BaseDirective):
 
         table_node = self.state.build_table(table, self.content_offset)
         table_node['classes'] += self.options.get('class', [])
-        footnotes = []
-        if has_required_attribute or has_required_element:
-            footnotes.append('.. [i] %s' % _('mandatory'))
-
-        if len(footnotes):
-            cnode = nodes.Element()  # anonymous container for parsing
-            sl = statemachine.StringList(footnotes, source='')
-            self.state.nested_parse(sl, self.content_offset, cnode)
-            footnote_node = nodes.inline('', '', *cnode)
-
-            table_node += footnote_node
 
         return table_node
 
@@ -164,9 +149,6 @@ class BaseXsdDirective(BaseDirective):
         """ needs to be fixed """
         if table_body is None:
             table_body = []
-
-        has_required_attribute = False
-        has_required_element = False
 
         if not element_name == "#text":
             attributes = schema.get_widget_attributes(element_name)
@@ -196,8 +178,7 @@ class BaseXsdDirective(BaseDirective):
 
                 #name = ":ref:`%s <%s>`" % (name, name)
                 if attr.get('use', 'optional') == "required":
-                    name += " [i]_ "
-                    has_required_attribute = True
+                    name += " :abbr:`*(%s)`" % _('mandatory')
 
                 atype = self.normalize_type(atype) if len(values) == 0 else self.normalize_values(values)
                 if include_name:
@@ -206,7 +187,7 @@ class BaseXsdDirective(BaseDirective):
                         if parent:
                             element_title = "%s\n  * **%s**" % (parent, element_title)
                         if mandatory:
-                            element_title += " [i]_ "
+                            element_title += " :abbr:`*(%s)`" % _('mandatory')
                             has_required_element = True
                         row = [(rowspan, 0, 0,
                                 statemachine.StringList(element_title.splitlines())),
@@ -273,16 +254,5 @@ class BaseXsdDirective(BaseDirective):
             table_node = self.state.build_table(table, self.content_offset)
             table_node['classes'] += self.options.get('class', [])
             table_node['classes'] += ["schema-table"]
-            footnotes = []
-            if has_required_attribute or has_required_element:
-                footnotes.append('.. [i] %s' % _('mandatory'))
-
-            if len(footnotes):
-                cnode = nodes.Element()  # anonymous container for parsing
-                sl = statemachine.StringList(footnotes, source='')
-                self.state.nested_parse(sl, self.content_offset, cnode)
-                footnote_node = nodes.inline('', '', *cnode)
-
-                table_node += footnote_node
 
             return table_node

--- a/.doc/docutils/directives/common.py
+++ b/.doc/docutils/directives/common.py
@@ -113,7 +113,7 @@ class BaseXsdDirective(BaseDirective):
             if include_name:
                 if line == 0:
                     if mandatory:
-                        element_name += "*"
+                        element_name += " :abbr:`*(%s)`" % _('mandatory')
 
                     row = [(rowspan, 0, 0, statemachine.StringList(element_name.splitlines())), self.get_cell_data(name), self.get_cell_data(atype), self.get_cell_data(description)]
                 else:


### PR DESCRIPTION
Mandatory hint is shown as Tooltip in HTML now.