### PR TITLE
add simple text to speech plugin

### DIFF
--- a/src/lib/CometVisuClient.js
+++ b/src/lib/CometVisuClient.js
@@ -175,9 +175,7 @@ define( ['jquery'], function( $ ) {
             this.readResendHeaderValues();
             session.update(data);
             this.retryCounter = 0;
-            if (!session.dataReceived) {
-              session.dataReceived = true;
-            }
+            session.dataReceived = true;
           }
 
           if (self.running) { // keep the requests going

--- a/src/lib/CometVisuClient.js
+++ b/src/lib/CometVisuClient.js
@@ -211,9 +211,7 @@ define( ['jquery'], function( $ ) {
           if (json && !this.doRestart) {
             this.readResendHeaderValues();
             session.update(json.d);
-            if (!session.dataReceived) {
-              session.dataReceived = true;
-            }
+            session.dataReceived = true;
           }
           if (self.running) { // keep the requests going, but only
             // request
@@ -398,9 +396,7 @@ define( ['jquery'], function( $ ) {
           var data = json.d;
           session.watchdog.ping();
           session.update(data);
-          if (!session.dataReceived) {
-            session.dataReceived = true;
-          }
+          session.dataReceived = true;
         };
 
         /**

--- a/src/lib/CometVisuClient.js
+++ b/src/lib/CometVisuClient.js
@@ -175,6 +175,9 @@ define( ['jquery'], function( $ ) {
             this.readResendHeaderValues();
             session.update(data);
             this.retryCounter = 0;
+            if (!session.dataReceived) {
+              session.dataReceived = true;
+            }
           }
 
           if (self.running) { // keep the requests going
@@ -210,6 +213,9 @@ define( ['jquery'], function( $ ) {
           if (json && !this.doRestart) {
             this.readResendHeaderValues();
             session.update(json.d);
+            if (!session.dataReceived) {
+              session.dataReceived = true;
+            }
           }
           if (self.running) { // keep the requests going, but only
             // request
@@ -394,6 +400,9 @@ define( ['jquery'], function( $ ) {
           var data = json.d;
           session.watchdog.ping();
           session.update(data);
+          if (!session.dataReceived) {
+            session.dataReceived = true;
+          }
         };
 
         /**
@@ -539,7 +548,8 @@ define( ['jquery'], function( $ ) {
       callbackAfterLoggedIn : null,
       context : null,
       loginOnlyMode : false // login only for backend configuration, do not start address subscription
-    }
+    };
+    this.dataReceived = false; // needed to be able to check if the incoming update is the initial answer or a successing update
 
     Object.defineProperty(this, 'backend', {
       get: function () {
@@ -674,6 +684,7 @@ define( ['jquery'], function( $ ) {
       if (json.c) {
         self.backend = $.extend(self.backend, json.c); // assign itself to run setter
       }
+      this.dataReceived = false;
       if (this.loginSettings.loginOnly) {
         this.currentTransport.handleSession(json, false);
       } else {

--- a/src/lib/TemplateEngine.js
+++ b/src/lib/TemplateEngine.js
@@ -199,8 +199,9 @@ define([
               var children = element.children;
               if( children[0] )
                 updateFn.call( children[0], key, data );
-              else
-                console.log( element, children, type ); // DEBUG FIXME
+              else {
+                updateFn.call( element, key, data );
+              }
             }
             //console.log( element, type, updateFn );
           } else if( typeof id === 'function' ) {

--- a/src/plugins/speech/structure_plugin.js
+++ b/src/plugins/speech/structure_plugin.js
@@ -28,7 +28,7 @@
 define( ['structure_custom' ], function( VisuDesign_Custom ) {
   "use strict";
 
-  var lastSpeech = null;
+  var lastSpeech = {};
   /**
    * This is a custom function that extends the available widgets.
    * It's purpose is to change the design of the visu during runtime
@@ -64,11 +64,12 @@ define( ['structure_custom' ], function( VisuDesign_Custom ) {
         return;
       }
 
-      if (lastSpeech == text) {
+      if (lastSpeech[address] == text) {
         // do not repeat
+        console.log("skipping TTS because of repetition "+text);
         return;
       }
-      lastSpeech = text;
+      lastSpeech[address] = text;
 
       var element = $(this);
       var path = element.attr('id');

--- a/src/plugins/speech/structure_plugin.js
+++ b/src/plugins/speech/structure_plugin.js
@@ -19,17 +19,22 @@
  * Use the Web Speech API (https://developer.mozilla.org/en-US/docs/Web/API/Web_Speech_API)
  * to make text-to-speech service available. This plugin listens to a address and forwards the
  * incoming data to the browser TTS engine (if the browser supports it)
+ *
+ * Example:
+ * <speech lang="de">
+ *  <address transform="OH:string" mode="read">Speak</address>
+ * </speech>
  */
 define( ['structure_custom' ], function( VisuDesign_Custom ) {
   "use strict";
 
+  var lastSpeech = null;
   /**
    * This is a custom function that extends the available widgets.
    * It's purpose is to change the design of the visu during runtime
    * to demonstrate all available
    */
   VisuDesign_Custom.prototype.addCreator("speech", {
-    that: this,
 
     create: function( element, path) {
       if (!window.speechSynthesis) {
@@ -39,8 +44,7 @@ define( ['structure_custom' ], function( VisuDesign_Custom ) {
       var $e = $(element);
       var address = templateEngine.design.makeAddressList($e, false, path);
 
-      var lang = null;
-      var data = templateEngine.widgetDataInsert( path, {
+      templateEngine.widgetDataInsert( path, {
         'language'   : $e.attr('lang') ? $e.attr('lang').toLowerCase() : null,
         'address' : address,
         'type'    : 'speech'
@@ -49,10 +53,23 @@ define( ['structure_custom' ], function( VisuDesign_Custom ) {
     },
 
     update: function(address, text) {
+      if (!templateEngine.visu.dataReceived) {
+        // first call -> skipping
+        console.log("skipping initial TTS for "+text);
+        return;
+      }
+
       if (!text || text.length === 0) {
         // nothing to say
         return;
       }
+
+      if (lastSpeech == text) {
+        // do not repeat
+        return;
+      }
+      lastSpeech = text;
+
       var element = $(this);
       var path = element.attr('id');
       var data = templateEngine.widgetDataGet(path);

--- a/src/plugins/speech/structure_plugin.js
+++ b/src/plugins/speech/structure_plugin.js
@@ -1,0 +1,83 @@
+/* structure_plugin.js (c) 2010 by Christian Mayer [CometVisu at ChristianMayer dot de]
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+*/
+
+/**
+ * Use the Web Speech API (https://developer.mozilla.org/en-US/docs/Web/API/Web_Speech_API)
+ * to make text-to-speech service available. This plugin listens to a address and forwards the
+ * incoming data to the browser TTS engine (if the browser supports it)
+ */
+define( ['structure_custom' ], function( VisuDesign_Custom ) {
+  "use strict";
+
+  /**
+   * This is a custom function that extends the available widgets.
+   * It's purpose is to change the design of the visu during runtime
+   * to demonstrate all available
+   */
+  VisuDesign_Custom.prototype.addCreator("speech", {
+    that: this,
+
+    create: function( element, path) {
+      if (!window.speechSynthesis) {
+        console.log("this browser does not support the Web Speech API");
+        return "";
+      }
+      var $e = $(element);
+      var address = templateEngine.design.makeAddressList($e, false, path);
+
+      var lang = null;
+      var data = templateEngine.widgetDataInsert( path, {
+        'language'   : $e.attr('lang') ? $e.attr('lang').toLowerCase() : null,
+        'address' : address,
+        'type'    : 'speech'
+      });
+      return "";
+    },
+
+    update: function(address, text) {
+      if (!text || text.length === 0) {
+        // nothing to say
+        return;
+      }
+      var element = $(this);
+      var path = element.attr('id');
+      var data = templateEngine.widgetDataGet(path);
+
+      var synth = window.speechSynthesis;
+
+      // speak
+      var utterThis = new SpeechSynthesisUtterance(text);
+
+      var selectedVoice, defaultVoice;
+      var voices = synth.getVoices();
+      for (var i = 0, l = voices.length; i < l; i++) {
+        if (data.language && voices[i].lang.substr(0, 2).toLowerCase() === data.language) {
+          selectedVoice = voices[i];
+        }
+        if (voices[i].default) {
+          defaultVoice = voices[i];
+        }
+      }
+      if (!selectedVoice) {
+        selectedVoice = defaultVoice;
+      }
+      utterThis.voice = selectedVoice;
+      synth.speak(utterThis);
+    }
+  });
+
+});

--- a/src/visu_config.xsd
+++ b/src/visu_config.xsd
@@ -472,6 +472,7 @@
       <xsd:element name="gauge" type="gauge" />
       <xsd:element name="calendarlist" type="calendarlist" />
       <xsd:element name="infoaction" type="infoaction" />
+      <xsd:element name="speech" type="speech" />
     </xsd:choice>
   </xsd:group>
 
@@ -1752,5 +1753,18 @@
       <xsd:element name="pagejump" type="pagejump" />
       <xsd:element name="info" type="info" />
     </xsd:choice>
+  </xsd:complexType>
+
+  <xsd:complexType name="speech">
+    <xsd:sequence>
+      <xsd:element name="address" type="address" minOccurs="1"  maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="lang" use="optional">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">The language that should be used to speak the text.</xsd:documentation>
+        <xsd:documentation xml:lang="de">Die Stimme die benutzt werden soll, um den Text zu sprechen.</xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
   </xsd:complexType>
 </xsd:schema>


### PR DESCRIPTION
currently chrome + firefox supports this. Should be tested with chrome as the german voice in firefox sounds like crap.

To test, add this to your config:

```
<speech lang="de">
  <address transform="OH:string" mode="read">Speak</address>
</speech>
```

Load the config with url param ?testMode=1 and execute `templateEngine.visu.write("Speak", "Hallo hier ist die Cometvisu")` in the browsers javascript console.