### PR TITLE
make examples loadable with current lib

### DIFF
--- a/doc/manual/de/config/examples/_static/visu_config_metal_haegar80.xml
+++ b/doc/manual/de/config/examples/_static/visu_config_metal_haegar80.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<pages xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" design="metal" enable_column_adjustment="false" xsi:noNamespaceSchemaLocation="../visu_config.xsd" lib_version="5">
+<pages xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" design="metal" xsi:noNamespaceSchemaLocation="../visu_config.xsd" lib_version="8">
   <meta>
     <plugins>
       <plugin name="colorchooser"/>

--- a/doc/manual/de/config/examples/_static/visu_config_metal_merlin123.xml
+++ b/doc/manual/de/config/examples/_static/visu_config_metal_merlin123.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<pages xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" design="metal" xsi:noNamespaceSchemaLocation="./visu_config.xsd" enable_column_adjustment="true" min_column_width="70">
+<pages xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" lib_version="8" design="metal" xsi:noNamespaceSchemaLocation="../visu_config.xsd" min_column_width="70">
 	<meta>
 		<plugins>
 			<plugin name="colorchooser"/>

--- a/doc/manual/de/config/examples/_static/visu_config_metal_swiss.xml
+++ b/doc/manual/de/config/examples/_static/visu_config_metal_swiss.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<pages design="metal" enable_column_adjustment="true" lib_version="5" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../visu_config.xsd">
+<pages design="metal" lib_version="8" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../visu_config.xsd">
   <meta>
     <mappings>
       <mapping name="OpenClose">


### PR DESCRIPTION
refs #454 

This PR only makes the examples loadable with the current CV-Version. As two of the examples used the old automatic column-adjustment feature, they might not look as before. But in order to get closer to the old look the layout has to be adjustet with colspan-m/-s by someone who known how it should look like, e.g. be the ones who contributed the examples (haegar80 and swiss).