### PR TITLE
Fix slide widget on knxd backend

### DIFF
--- a/source/class/cv/ui/structure/pure/Slide.js
+++ b/source/class/cv/ui/structure/pure/Slide.js
@@ -190,7 +190,7 @@ qx.Class.define('cv.ui.structure.pure.Slide', {
         var currentValue = this.getValue();
         this.sendToBackend(value, function(addr) {
           var newValue = cv.Transform.encode(addr[0], value);
-          return newValue !== cv.Transform.encode(addr[0], currentValue);
+          return newValue !== NaN && newValue !== cv.Transform.encode(addr[0], currentValue);
         });
       }
       this.setValue(value);

--- a/source/class/cv/ui/structure/pure/Slide.js
+++ b/source/class/cv/ui/structure/pure/Slide.js
@@ -190,7 +190,7 @@ qx.Class.define('cv.ui.structure.pure.Slide', {
         var currentValue = this.getValue();
         this.sendToBackend(value, function(addr) {
           var newValue = cv.Transform.encode(addr[0], value);
-          return !isNaN(newValue) && newValue !== cv.Transform.encode(addr[0], currentValue);
+          return newValue !== cv.Transform.encode(addr[0], currentValue);
         });
       }
       this.setValue(value);


### PR DESCRIPTION
As the encoded value is a (hex) string a NaN check doesn't work properly.
This patch fixes the slugish behaviour of the live updates.

Cf. #532 issue 1