### PR TITLE
several fixes for safari 5.1:

### DIFF
--- a/source/class/cv/parser/MetaParser.js
+++ b/source/class/cv/parser/MetaParser.js
@@ -61,7 +61,7 @@ qx.Class.define("cv.parser.MetaParser", {
           var v = origin[i];
           if (qx.dom.Node.isElement(v) && qx.dom.Node.getName(v).toLowerCase() === 'icon') {
             var icon = this.__parseIconDefinition(v);
-            value.push(cv.IconHandler.getInstance().getIconElement(icon.name, icon.type, icon.flavour, icon.color, icon.styling, icon.class));
+            value.push(cv.IconHandler.getInstance().getIconElement(icon.name, icon.type, icon.flavour, icon.color, icon.styling, icon["class"]));
           }
           else if (qx.dom.Node.getText(v).trim().length) {
             value.push(qx.dom.Node.getText(v).trim());

--- a/source/class/cv/ui/PageHandler.js
+++ b/source/class/cv/ui/PageHandler.js
@@ -97,6 +97,11 @@ qx.Class.define('cv.ui.PageHandler', {
 
       var direction = null;
       var animationEnabled = speed > 0 || this.getAnimationType() !== "none";
+
+      // browser check
+      if (qx.core.Environment.get("browser.name") === "safari" && parseInt(qx.core.Environment.get("browser.version")) <= 5) {
+        animationEnabled = false;
+      }
       if (animationEnabled) {
         var currentDepth = currentPath.split("_").length;
         var targetDepth = target.split("_").length;

--- a/source/class/cv/ui/structure/pure/PageLink.js
+++ b/source/class/cv/ui/structure/pure/PageLink.js
@@ -46,6 +46,10 @@ qx.Class.define('cv.ui.structure.pure.PageLink', {
     address : {
       check: "Object",
       init: {}
+    },
+    bindClickToWidget: {
+      refine: true,
+      init: true
     }
   },
 


### PR DESCRIPTION
- syntax error fixed (do no use .class)
- disable animations as they are broken
- use bindClickToWidget for pageLinks as otherwise they do not work in this browser

refs #569, refs #547