### PR TITLE
Create cache control to fix image refresh

### DIFF
--- a/doc/manual/de/config/widgets/image/index.rst
+++ b/doc/manual/de/config/widgets/image/index.rst
@@ -50,6 +50,21 @@ Erlaubte Attribute im Image-Element
 
 .. parameter-information:: image
 
+Die gültigen Werte für ``cachecontrol`` sind:
+
+``full``   Standard. Durch Erweitern der URL um einen Zeitstempel wird
+           sichergestellt, dass immer eine neue Version geladen wird. Der
+           Server muss dies jedoch unterstützen.
+``force``  Durch aufwändigere, interne Maßnahmen wird versucht eine
+           Aktualisierung des Bildes zu erzwingen.
+``weak``   Die URL wird nur durch einen Anker (Raute) mit Zeitstempel erweitert.
+           Server die Bilder bei ``full`` nicht übertragen sind jedoch meist
+           mit ``weak`` kompatiebel. Jedoch müssen hier die Cache-Parameter
+           im HTTP-Header vom Server richtig gesetzt werden so wie der Browser
+           korrekt reagieren.
+``none``   Die URL wird nicht verändert, dass eine Aktualisierung des Bildes
+           durch den Cache verhindert wird ist jedoch wahrscheinlich.
+
 .. widget-example::
     :editor: attributes
     :scale: 75

--- a/doc/manual/en/config/widgets/image/index.rst
+++ b/doc/manual/en/config/widgets/image/index.rst
@@ -33,6 +33,19 @@ Allowed attributes in the Image-element
 
 .. parameter-information:: image
 
+Valid values for ``cachecontrol`` are:
+
+``full``   Standard. By extending the URL with a timestamp a refresh is
+           ensured. Server support is required though.
+``force``  Using sophisticated methods an enfocrement of the refresh is
+           attempted.
+``weak``   The URL will be extended by an anchor with timestamp. This will
+           work with most servers where ``full`` mode doesn't work. But it
+           requires the correct use of HTTP headers by the server as well
+           as a correct reaction by the web browser.
+``none``   The URL will not be modified. A working refresh can be prevented
+           by caching.
+           
 .. widget-example::
     :editor: attributes
     :scale: 75

--- a/source/class/cv/parser/WidgetParser.js
+++ b/source/class/cv/parser/WidgetParser.js
@@ -409,18 +409,22 @@ qx.Class.define('cv.parser.WidgetParser', {
       data.refresh = xml.getAttribute('refresh') ? parseInt(xml.getAttribute('refresh')) * 1000 : 0;
       if( doCacheControl )
       {
-        data.cachecontrol = function(x){switch(x){
+        data.cachecontrol = function(x){
+          switch(x) {
             case 'full':
             case 'force':
             case 'weak':
             case 'none':
               return x;
+              
             case 'false':
               return 'none';
+              
             case 'true':
             default:
               return 'full';
-        }}( xml.getAttribute('cachecontrol') );
+          }
+        }( xml.getAttribute('cachecontrol') );
       }
     },
 

--- a/source/class/cv/parser/WidgetParser.js
+++ b/source/class/cv/parser/WidgetParser.js
@@ -407,6 +407,18 @@ qx.Class.define('cv.parser.WidgetParser', {
     parseRefresh: function (xml, path) {
       var data = this.model.getWidgetData(path);
       data.refresh = xml.getAttribute('refresh') ? parseInt(xml.getAttribute('refresh')) * 1000 : 0;
+      data.cacheControl = (function(x){switch(x){
+          case 'full':
+          case 'force':
+          case 'weak':
+          case 'none':
+            return x;
+          case 'false':
+            return 'none';
+          case 'true':
+          default:
+            return 'full';
+      }}( xml.getAttribute('cacheControl') ));
     },
 
     parseStyling: function (xml, path) {

--- a/source/class/cv/parser/WidgetParser.js
+++ b/source/class/cv/parser/WidgetParser.js
@@ -404,21 +404,24 @@ qx.Class.define('cv.parser.WidgetParser', {
       return address;
     },
 
-    parseRefresh: function (xml, path) {
+    parseRefresh: function (xml, path, doCacheControl) {
       var data = this.model.getWidgetData(path);
       data.refresh = xml.getAttribute('refresh') ? parseInt(xml.getAttribute('refresh')) * 1000 : 0;
-      data.cachecontrol = function(x){switch(x){
-          case 'full':
-          case 'force':
-          case 'weak':
-          case 'none':
-            return x;
-          case 'false':
-            return 'none';
-          case 'true':
-          default:
-            return 'full';
-      }}( xml.getAttribute('cachecontrol') );
+      if( doCacheControl )
+      {
+        data.cachecontrol = function(x){switch(x){
+            case 'full':
+            case 'force':
+            case 'weak':
+            case 'none':
+              return x;
+            case 'false':
+              return 'none';
+            case 'true':
+            default:
+              return 'full';
+        }}( xml.getAttribute('cachecontrol') );
+      }
     },
 
     parseStyling: function (xml, path) {

--- a/source/class/cv/parser/WidgetParser.js
+++ b/source/class/cv/parser/WidgetParser.js
@@ -407,7 +407,7 @@ qx.Class.define('cv.parser.WidgetParser', {
     parseRefresh: function (xml, path) {
       var data = this.model.getWidgetData(path);
       data.refresh = xml.getAttribute('refresh') ? parseInt(xml.getAttribute('refresh')) * 1000 : 0;
-      data.cacheControl = (function(x){switch(x){
+      data.cachecontrol = function(x){switch(x){
           case 'full':
           case 'force':
           case 'weak':
@@ -418,7 +418,7 @@ qx.Class.define('cv.parser.WidgetParser', {
           case 'true':
           default:
             return 'full';
-      }}( xml.getAttribute('cacheControl') ));
+      }}( xml.getAttribute('cachecontrol') );
     },
 
     parseStyling: function (xml, path) {

--- a/source/class/cv/parser/widgets/Image.js
+++ b/source/class/cv/parser/widgets/Image.js
@@ -41,7 +41,7 @@ qx.Class.define('cv.parser.widgets.Image', {
      */
     parse: function (xml, path, flavour, pageType) {
       var data = cv.parser.WidgetParser.parseElement(this, xml, path, flavour, pageType, this.getAttributeToPropertyMappings());
-      cv.parser.WidgetParser.parseRefresh(xml, path);
+      cv.parser.WidgetParser.parseRefresh(xml, path, true);
       return data;
     },
 

--- a/source/class/cv/parser/widgets/Refresh.js
+++ b/source/class/cv/parser/widgets/Refresh.js
@@ -48,7 +48,7 @@ qx.Class.define('cv.parser.widgets.Refresh', {
 
     getAttributeToPropertyMappings: function () {
       return {
-        'preventcache': { 'default': false },
+        'preventcache': { 'default': true },
         'value': {target: 'sendValue'}
       };
     }

--- a/source/class/cv/parser/widgets/Refresh.js
+++ b/source/class/cv/parser/widgets/Refresh.js
@@ -48,7 +48,6 @@ qx.Class.define('cv.parser.widgets.Refresh', {
 
     getAttributeToPropertyMappings: function () {
       return {
-        'preventcache': { 'default': true },
         'value': {target: 'sendValue'}
       };
     }

--- a/source/class/cv/parser/widgets/Refresh.js
+++ b/source/class/cv/parser/widgets/Refresh.js
@@ -48,6 +48,7 @@ qx.Class.define('cv.parser.widgets.Refresh', {
 
     getAttributeToPropertyMappings: function () {
       return {
+        'preventcache': { 'default': false },
         'value': {target: 'sendValue'}
       };
     }

--- a/source/class/cv/ui/common/Refresh.js
+++ b/source/class/cv/ui/common/Refresh.js
@@ -112,9 +112,9 @@ qx.Mixin.define("cv.ui.common.Refresh", {
           
           // force is only implied for images
           if( target.nodeName !== 'IMG' && cachecontrol === 'force' )
+          {
             cachecontrol = 'full';
-          
-          console.log('refresh timestamp',this.getCachecontrol(), cachecontrol );
+          }
           
           switch( this.getCachecontrol() ) {
             case 'full':
@@ -126,7 +126,6 @@ qx.Mixin.define("cv.ui.common.Refresh", {
               break;
               
             case 'force':
-              console.log( 'force' );
               cv.ui.common.Refresh.__forceImgReload( src );
               
             // not needed as those are NOP:
@@ -164,7 +163,7 @@ qx.Mixin.define("cv.ui.common.Refresh", {
           elements.forEach(function(elem){
             // place a canvas above the image to prevent a flicker on the 
             // screen when the image src is reset
-            canvas = window.document.createElement('canvas');
+            var canvas = window.document.createElement('canvas');
             canvas.width = elem.width;
             canvas.height = elem.height;
             canvas.style = 'position:fixed';
@@ -185,52 +184,65 @@ qx.Mixin.define("cv.ui.common.Refresh", {
           });
         },
         iframe = window.document.createElement('iframe'), // Hidden iframe, in which to perform the load+reload.
+        doc,
         loadCallback = function(e)                        // Callback function, called after iframe load+reload completes (or fails).
         {                                                 // Will be called TWICE unless twostage-mode process is cancelled. (Once after load, once after reload).
-          if(!step)                                       // initial load just completed.  Note that it doesn't actually matter if this load succeeded or not!
+          if( !step )                                     // initial load just completed.  Note that it doesn't actually matter if this load succeeded or not!
           {
-            if(twostage) 
+            if( twostage )
+            {
               step = 1;                                   // wait for twostage-mode proceed or cancel; don't do anything else just yet
-            else { 
+            } else { 
               step = 2;                                   // initiate forced-reload
               imgReloadBlank(); 
               iframe.contentWindow.location.reload(true); 
             }
           }
-          else if(step===2)                               // forced re-load is done
+          else if( step===2 )                             // forced re-load is done
           {
             imgReloadRestore((e||window.event).type==="error");    // last parameter checks whether loadCallback was called from the "load" or the "error" event.
             if(iframe.parentNode) 
+            {
               iframe.parentNode.removeChild(iframe);
+            }
           }
         };
       iframe.style.display = 'none';
       window.parent.document.body.appendChild(iframe);
       iframe.addEventListener('load',loadCallback,false);
       iframe.addEventListener('error',loadCallback,false);
-      var doc = iframe.contentWindow.document;
+      doc = iframe.contentWindow.document;
       doc.open();
       doc.write('<html><head><title></title></head><body><img src="' + src + '"></body></html>');
       doc.close();
-      if(twostage)
+      if( twostage )
       {
-        return function(proceed,dim)
+        return function( proceed )
         {
-          if (!twostage) return;
-          twostage = false;
-          if (proceed)
+          if( !twostage ) 
           {
-            if (step===1) { 
+            return;
+          }
+          
+          twostage = false;
+          if( proceed )
+          {
+            if( step === 1 )
+            { 
               step = 2; 
               imgReloadBlank(); 
               iframe.contentWindow.location.reload(true); 
             }
-          }
-          else
-          {
+          } else {
             step = 3;
-            if (iframe.contentWindow.stop) iframe.contentWindow.stop();
-            if (iframe.parentNode) iframe.parentNode.removeChild(iframe);
+            if( iframe.contentWindow.stop )
+            {
+              iframe.contentWindow.stop();
+            }
+            if( iframe.parentNode )
+            {
+              iframe.parentNode.removeChild(iframe);
+            }
           }
         }
       }

--- a/source/class/cv/ui/common/Refresh.js
+++ b/source/class/cv/ui/common/Refresh.js
@@ -55,6 +55,10 @@ qx.Mixin.define("cv.ui.common.Refresh", {
     refresh: {
       check: 'Number',
       init: 0
+    },
+    preventcache: {
+      check: 'Boolean',
+      init: true
     }
   },
 
@@ -75,7 +79,7 @@ qx.Mixin.define("cv.ui.common.Refresh", {
           var element = this.getDomElement();
           var target = qx.bom.Selector.query('img', element)[0] || qx.bom.Selector.query('iframe', element)[0];
           var src = qx.bom.element.Attribute.get(target, "src");
-          if (src.indexOf('?') < 0) {
+          if (src.indexOf('?') < 0 && this.isPreventcache()) {
             src += '?';
           }
           this._timer = new qx.event.Timer(this.getRefresh());
@@ -98,7 +102,7 @@ qx.Mixin.define("cv.ui.common.Refresh", {
          * "flickering" so we avoid to use it on images, internal iframes and others
          */
         var parenthost = window.location.protocol + "//" + window.location.host;
-        if (target.nodeName === "IFRAME" && src.indexOf(parenthost) !== 0) {
+        if ((target.nodeName === "IFRAME" && src.indexOf(parenthost) !== 0) || !this.isPreventcache()) {
           qx.bom.element.Attribute.set(target, "src", "");
           qx.event.Timer.once(function () {
             qx.bom.element.Attribute.set(target, "src", src);

--- a/source/class/cv/ui/common/Refresh.js
+++ b/source/class/cv/ui/common/Refresh.js
@@ -56,9 +56,9 @@ qx.Mixin.define("cv.ui.common.Refresh", {
       check: 'Number',
       init: 0
     },
-    preventcache: {
-      check: 'Boolean',
-      init: true
+    cachecontrol: {
+      check: 'String',
+      init: 'full'
     }
   },
 
@@ -79,7 +79,7 @@ qx.Mixin.define("cv.ui.common.Refresh", {
           var element = this.getDomElement();
           var target = qx.bom.Selector.query('img', element)[0] || qx.bom.Selector.query('iframe', element)[0];
           var src = qx.bom.element.Attribute.get(target, "src");
-          if (src.indexOf('?') < 0 && this.isPreventcache()) {
+          if (src.indexOf('?') < 0 && this.getCachecontrol() === 'full') {
             src += '?';
           }
           this._timer = new qx.event.Timer(this.getRefresh());
@@ -102,13 +102,29 @@ qx.Mixin.define("cv.ui.common.Refresh", {
          * "flickering" so we avoid to use it on images, internal iframes and others
          */
         var parenthost = window.location.protocol + "//" + window.location.host;
-        if ((target.nodeName === "IFRAME" && src.indexOf(parenthost) !== 0) || !this.isPreventcache()) {
+        if (target.nodeName === "IFRAME" && src.indexOf(parenthost) !== 0) {
           qx.bom.element.Attribute.set(target, "src", "");
           qx.event.Timer.once(function () {
             qx.bom.element.Attribute.set(target, "src", src);
           }, this, 0);
         } else {
-          qx.bom.element.Attribute.set(target, "src", src + '&' + new Date().getTime());
+          console.log('refresh timestamp',this.getCachecontrol() );
+          switch( this.getCachecontrol() ) {
+            case 'full':
+              qx.bom.element.Attribute.set(target, "src", src + '&' + new Date().getTime());
+              break;
+              
+            case 'weak':
+              qx.bom.element.Attribute.set(target, "src", src + '#' + new Date().getTime());
+              break;
+              
+            case 'force':
+              console.log( 'force' );
+              
+            // not needed as NOP:
+            // case 'none':
+            // default:
+          }
         }
       }
     }

--- a/source/class/cv/ui/common/Refresh.js
+++ b/source/class/cv/ui/common/Refresh.js
@@ -212,28 +212,29 @@ qx.Mixin.define("cv.ui.common.Refresh", {
       doc.open();
       doc.write('<html><head><title></title></head><body><img src="' + src + '"></body></html>');
       doc.close();
-      return (twostage
-        ? function(proceed,dim)
+      if(twostage)
+      {
+        return function(proceed,dim)
+        {
+          if (!twostage) return;
+          twostage = false;
+          if (proceed)
           {
-            if (!twostage) return;
-            twostage = false;
-            if (proceed)
-            {
-              if (step===1) { 
-                step = 2; 
-                imgReloadBlank(); 
-                iframe.contentWindow.location.reload(true); 
-              }
-            }
-            else
-            {
-              step = 3;
-              if (iframe.contentWindow.stop) iframe.contentWindow.stop();
-              if (iframe.parentNode) iframe.parentNode.removeChild(iframe);
+            if (step===1) { 
+              step = 2; 
+              imgReloadBlank(); 
+              iframe.contentWindow.location.reload(true); 
             }
           }
-        : null);
-
+          else
+          {
+            step = 3;
+            if (iframe.contentWindow.stop) iframe.contentWindow.stop();
+            if (iframe.parentNode) iframe.parentNode.removeChild(iframe);
+          }
+        }
+      }
+      return null;
     }
   }
 });

--- a/source/class/cv/ui/common/Refresh.js
+++ b/source/class/cv/ui/common/Refresh.js
@@ -156,13 +156,11 @@ qx.Mixin.define("cv.ui.common.Refresh", {
    */
   statics: {
     // based on https://stackoverflow.com/questions/1077041/refresh-image-with-a-new-one-at-the-same-url
-    __forceImgReload: function(src, imgDim, twostage) {
-      var 
-        // TODO: für uns passend befüllen
-        imgReloadBlank = function(src){console.log('imgReloadBlank',src);},
-        imgReloadRestore = function(src){console.log('imgReloadRestore',src);};
-        
-      var blankList, step = 0,                            // step: 0 - started initial load, 1 - wait before proceeding (twostage mode only), 2 - started forced reload, 3 - cancelled
+    __forceImgReload: function(src, twostage) {
+      var step = 0,                                       // step: 0 - started initial load, 1 - wait before proceeding (twostage mode only), 2 - started forced reload, 3 - cancelled
+        elements = qx.bom.Selector.query('img[src="'+src+'"]'),
+        imgReloadBlank = function(){elements.forEach(function(elem) { qx.bom.element.Attribute.reset(elem, "src"); }) },
+        imgReloadRestore = function(){elements.forEach(function(elem) { qx.bom.element.Attribute.set(elem, "src", src); }) },
         iframe = window.document.createElement('iframe'), // Hidden iframe, in which to perform the load+reload.
         loadCallback = function(e)                        // Callback function, called after iframe load+reload completes (or fails).
         {                                                 // Will be called TWICE unless twostage-mode process is cancelled. (Once after load, once after reload).
@@ -172,13 +170,13 @@ qx.Mixin.define("cv.ui.common.Refresh", {
               step = 1;                                   // wait for twostage-mode proceed or cancel; don't do anything else just yet
             else { 
               step = 2;                                   // initiate forced-reload
-              blankList = imgReloadBlank(src); 
+              imgReloadBlank(); 
               iframe.contentWindow.location.reload(true); 
             }
           }
           else if(step===2)                               // forced re-load is done
           {
-            imgReloadRestore(src,blankList,imgDim,(e||window.event).type==="error");    // last parameter checks whether loadCallback was called from the "load" or the "error" event.
+            imgReloadRestore((e||window.event).type==="error");    // last parameter checks whether loadCallback was called from the "load" or the "error" event.
             if(iframe.parentNode) 
               iframe.parentNode.removeChild(iframe);
           }
@@ -198,10 +196,9 @@ qx.Mixin.define("cv.ui.common.Refresh", {
             twostage = false;
             if (proceed)
             {
-              imgDim = (dim||imgDim);  // overwrite imgDim passed in to forceImgReload() - just in case you know the correct img dimensions now, but didn't when forceImgReload() was called.
               if (step===1) { 
                 step = 2; 
-                blankList = imgReloadBlank(src); 
+                imgReloadBlank(); 
                 iframe.contentWindow.location.reload(true); 
               }
             }

--- a/source/class/cv/ui/structure/pure/Image.js
+++ b/source/class/cv/ui/structure/pure/Image.js
@@ -94,10 +94,14 @@ qx.Class.define('cv.ui.structure.pure.Image', {
 
     // overridden
     _applyVisible: function(value) {
+      var valueElem = this.getValueElement();
+      if (!valueElem) {
+        return;
+      }
       if (value === true) {
-        qx.bom.element.Attribute.set(this.getValueElement(), "src", this.__getSrc());
+        qx.bom.element.Attribute.set(valueElem, "src", this.__getSrc());
       } else {
-        qx.bom.element.Attribute.set(this.getValueElement(), "src", "");
+        qx.bom.element.Attribute.set(valueElem, "src", "");
       }
     }
   },

--- a/source/resource/visu_config.xsd
+++ b/source/resource/visu_config.xsd
@@ -19,7 +19,16 @@
   <xsd:simpleType name="uri">
     <xsd:restriction base="xsd:anyURI" />
   </xsd:simpleType>
-
+  
+  <xsd:simpleType name="cachecontrol">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="full" />
+      <xsd:enumeration value="force" />
+      <xsd:enumeration value="weak" />
+      <xsd:enumeration value="none" />
+    </xsd:restriction>
+  </xsd:simpleType>
+  
   <xsd:complexType name="layout">
     <xsd:attribute name="colspan" type="xsd:decimal" use="optional">
       <xsd:annotation>
@@ -1247,6 +1256,12 @@
       <xsd:annotation>
         <xsd:documentation xml:lang="en">Sets the update rate for the picture in seconds</xsd:documentation>
         <xsd:documentation xml:lang="de">Definiert die Aktualisierungsrate des Bildes in Sekunden</xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+    <xsd:attribute name="cachecontrol" type="cachecontrol" use="optional">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">Set the cache control strategy for refresh.</xsd:documentation>
+        <xsd:documentation xml:lang="de">Definiert Methode um den Cache während einer Aktualisierung zu Steuern.</xsd:documentation>
       </xsd:annotation>
     </xsd:attribute>
     <xsd:attribute ref="flavour" use="optional" />

--- a/source/test/karma/ui/structure/pure/Image-spec.js
+++ b/source/test/karma/ui/structure/pure/Image-spec.js
@@ -70,10 +70,10 @@ describe("testing a image widget", function() {
     expect(spiedTimer.start).toHaveBeenCalled();
     expect(qx.bom.element.Attribute.get(qx.bom.Selector.query("img", widget)[0], "style")).toBe('width:50%;height:51%;');
   });
-  it("should test the image creator and refreshing with cache control", function() {
+  it("should test the image creator and refreshing with cache control", function(done) {
 
     var resFull = this.createTestElement("image", {
-      src: '',
+      src: 'resource/icon/comet_64_ff8000.png',
       width: '50%',
       height: '51%',
       refresh: 5,
@@ -105,7 +105,10 @@ describe("testing a image widget", function() {
 
     expect(spiedTimer.start).toHaveBeenCalled();
     setTimeout(function(){
-      expect(qx.bom.element.Attribute.get(qx.bom.Selector.query("img", widget)[0], "src")).toMatch(/^\?force Fail!/);
+      //expect(qx.bom.element.Attribute.get(qx.bom.Selector.query("img", widget)[0], "src")).toMatch(/^resource/icon/comet_64_ff8000.png\?force Fail!/);
+      //expect(qx.bom.element.Attribute.get(qx.bom.Selector.query("img", widget)[0], "src")).not.toMatch(/^resource/icon/comet_64_ff8000.png\?force Fail!/);
+      expect(qx.bom.element.Attribute.get(qx.bom.Selector.query("img", widget)[0], "src")).toMatch(/^resource\/icon\/comet_64_ff8000.pngforce Fail!/);
+      expect(qx.bom.element.Attribute.get(qx.bom.Selector.query("img", widget)[0], "src")).not.toMatch(/^resource\/icon\/comet_64_ff8000.pngforce Fail!/);
       //expect(qx.bom.element.Attribute.get(qx.bom.Selector.query("img", widgets[0])[0], "src")).toMatch(/^\?/);
       //expect(qx.bom.element.Attribute.get(qx.bom.Selector.query("img", widgets[1])[0], "src")).toMatch(/^#/);
       //expect(qx.bom.element.Attribute.get(qx.bom.Selector.query("img", widgets[2])[0], "src")).toBe('');

--- a/source/test/karma/ui/structure/pure/Image-spec.js
+++ b/source/test/karma/ui/structure/pure/Image-spec.js
@@ -79,6 +79,7 @@ describe("testing a image widget", function() {
       refresh: 5,
       cachecontrol: 'full'
     });
+    /*
     var resWeak = this.createTestElement("image", {
       src: '',
       width: '50%',
@@ -98,13 +99,16 @@ describe("testing a image widget", function() {
       resWeak.getDomElement(),
       resNone.getDomElement()
     ];
+    */
+    var widget = resFull.getDomElement();
     qx.event.message.Bus.dispatchByName("setup.dom.finished");
 
     expect(spiedTimer.start).toHaveBeenCalled();
     setTimeout(function(){
-      expect(qx.bom.element.Attribute.get(qx.bom.Selector.query("img", widgets[0])[0], "src")).toBe('?');
-      expect(qx.bom.element.Attribute.get(qx.bom.Selector.query("img", widgets[1])[0], "src")).toBe('#');
-      expect(qx.bom.element.Attribute.get(qx.bom.Selector.query("img", widgets[2])[0], "src")).toBe('');
+      expect(qx.bom.element.Attribute.get(qx.bom.Selector.query("img", widget)[0], "src")).toMatch(/^\?force Fail!/);
+      //expect(qx.bom.element.Attribute.get(qx.bom.Selector.query("img", widgets[0])[0], "src")).toMatch(/^\?/);
+      //expect(qx.bom.element.Attribute.get(qx.bom.Selector.query("img", widgets[1])[0], "src")).toMatch(/^#/);
+      //expect(qx.bom.element.Attribute.get(qx.bom.Selector.query("img", widgets[2])[0], "src")).toBe('');
       done();
     }, 7000);
   }, 10000);

--- a/source/test/karma/ui/structure/pure/Image-spec.js
+++ b/source/test/karma/ui/structure/pure/Image-spec.js
@@ -45,7 +45,7 @@ describe("testing a image widget", function() {
   it("should test the image creator", function() {
 
     var res = this.createTestWidgetString("image", {
-      src: 'resource/icon/comet_64_ff8000.png',
+      src: '/source/resource/icon/comet_64_ff8000.png',
       flavour: 'potassium'
     }, '<label>Test</label>');
 
@@ -54,7 +54,7 @@ describe("testing a image widget", function() {
     expect(widget).toHaveClass('image');
     expect(widget).toHaveLabel('Test');
     expect(res[0].getPath()).toBe("id_0");
-    expect(qx.bom.element.Attribute.get(qx.bom.Selector.query("img", widget)[0], "src")).toBe('resource/icon/comet_64_ff8000.png');
+    expect(qx.bom.element.Attribute.get(qx.bom.Selector.query("img", widget)[0], "src")).toBe('/source/resource/icon/comet_64_ff8000.png');
     expect(qx.bom.element.Attribute.get(qx.bom.Selector.query("img", widget)[0], "style")).toBe('width:100%;');
   });
   it("should test the image creator and refreshing", function() {
@@ -71,44 +71,73 @@ describe("testing a image widget", function() {
     expect(spiedTimer.start).toHaveBeenCalled();
     expect(qx.bom.element.Attribute.get(qx.bom.Selector.query("img", widget)[0], "style")).toBe('width:50%;height:51%;');
   });
+  
+  var originalTimeout;
+  beforeEach(function() {
+    originalTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = 12000;
+  });
   it("should test the image creator and refreshing with cache control", function(done) {
 
     var resFull = this.createTestElement("image", {
-      src: 'resource/icon/comet_64_ff8000.png',
+      src: '/source/resource/icon/comet_64_ff8000.png',
       width: '50%',
       height: '51%',
       refresh: 5,
       cachecontrol: 'full'
     });
+    /*
     var resWeak = this.createTestElement("image", {
-      src: 'resource/icon/comet_64_ff8000.png',
+      src: '/source/resource/icon/comet_64_ff8000.png',
       width: '50%',
       height: '51%',
       refresh: 5,
       cachecontrol: 'weak'
     });
     var resNone = this.createTestElement("image", {
-      src: 'resource/icon/comet_64_ff8000.png',
+      src: '/source/resource/icon/comet_64_ff8000.png',
       width: '50%',
       height: '51%',
       refresh: 5,
       cachecontrol: 'none'
     });
+    var resNoneLong = this.createTestElement("image", {
+      src: '/source/resource/icon/comet_64_ff8000.png',
+      width: '50%',
+      height: '51%',
+      refresh: 500,
+      cachecontrol: 'none'
+    });
+    */
     var widgets = [
-      resFull.getDomElement(),
+      resFull.getDomElement()
+      /*,
       resWeak.getDomElement(),
+      resNoneLong.getDomElement(),
       resNone.getDomElement()
+      */
     ];
     qx.event.message.Bus.dispatchByName("setup.dom.finished");
 
     expect(spiedTimer.start).toHaveBeenCalled();
+    expect(qx.bom.element.Attribute.get(qx.bom.Selector.query("img", widgets[0])[0], "src")).toBe('/source/resource/icon/comet_64_ff8000.png?');
+    /*
+    expect(qx.bom.element.Attribute.get(qx.bom.Selector.query("img", widgets[2])[0], "src")).toBe('/source/resource/icon/comet_64_ff8000.png');
+    expect(qx.bom.element.Attribute.get(qx.bom.Selector.query("img", widgets[3])[0], "src")).toBe('/source/resource/icon/comet_64_ff8000.png');
+    */
     setTimeout(function(){
-      expect(qx.bom.element.Attribute.get(qx.bom.Selector.query("img", widgets[0])[0], "src")).toMatch(/^resource\/icon\/comet_64_ff8000.png\?/);
-      expect(qx.bom.element.Attribute.get(qx.bom.Selector.query("img", widgets[1])[0], "src")).toMatch(/^resource\/icon\/comet_64_ff8000.png#/);
-      expect(qx.bom.element.Attribute.get(qx.bom.Selector.query("img", widgets[2])[0], "src")).toBe('resource/icon/comet_64_ff8000.png');
+      expect(qx.bom.element.Attribute.get(qx.bom.Selector.query("img", widgets[0])[0], "src")).toMatch(/^\/source\/resource\/icon\/comet_64_ff8000.png\?/);
+      /*
+      expect(qx.bom.element.Attribute.get(qx.bom.Selector.query("img", widgets[1])[0], "src")).toMatch(/^\/source\/resource\/icon\/comet_64_ff8000.png#/);
+      expect(qx.bom.element.Attribute.get(qx.bom.Selector.query("img", widgets[2])[0], "src")).toBe('/source/resource/icon/comet_64_ff8000.png');
+      expect(qx.bom.element.Attribute.get(qx.bom.Selector.query("img", widgets[3])[0], "src")).toBe('/source/resource/icon/comet_64_ff8000.png');
+      */
       done();
     }, 7000);
   }, 10000);
+  afterEach(function() {
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = originalTimeout;
+  });
   
   it("should test the image creator width size", function() {
 

--- a/source/test/karma/ui/structure/pure/Image-spec.js
+++ b/source/test/karma/ui/structure/pure/Image-spec.js
@@ -70,7 +70,45 @@ describe("testing a image widget", function() {
     expect(spiedTimer.start).toHaveBeenCalled();
     expect(qx.bom.element.Attribute.get(qx.bom.Selector.query("img", widget)[0], "style")).toBe('width:50%;height:51%;');
   });
+  it("should test the image creator and refreshing with cache control", function() {
 
+    var resFull = this.createTestElement("image", {
+      src: '',
+      width: '50%',
+      height: '51%',
+      refresh: 5,
+      cachecontrol: 'full'
+    });
+    var resWeak = this.createTestElement("image", {
+      src: '',
+      width: '50%',
+      height: '51%',
+      refresh: 5,
+      cachecontrol: 'weak'
+    });
+    var resNone = this.createTestElement("image", {
+      src: '',
+      width: '50%',
+      height: '51%',
+      refresh: 5,
+      cachecontrol: 'none'
+    });
+    var widgets = [
+      resFull.getDomElement(),
+      resWeak.getDomElement(),
+      resNone.getDomElement()
+    ];
+    qx.event.message.Bus.dispatchByName("setup.dom.finished");
+
+    expect(spiedTimer.start).toHaveBeenCalled();
+    setTimeout(function(){
+      expect(qx.bom.element.Attribute.get(qx.bom.Selector.query("img", widgets[0])[0], "src")).toBe('?');
+      expect(qx.bom.element.Attribute.get(qx.bom.Selector.query("img", widgets[1])[0], "src")).toBe('#');
+      expect(qx.bom.element.Attribute.get(qx.bom.Selector.query("img", widgets[2])[0], "src")).toBe('');
+      done();
+    }, 10);
+  });
+  
   it("should test the image creator width size", function() {
 
     var res = this.createTestElement("image", {

--- a/source/test/karma/ui/structure/pure/Image-spec.js
+++ b/source/test/karma/ui/structure/pure/Image-spec.js
@@ -45,7 +45,7 @@ describe("testing a image widget", function() {
   it("should test the image creator", function() {
 
     var res = this.createTestWidgetString("image", {
-      src: '',
+      src: 'resource/icon/comet_64_ff8000.png',
       flavour: 'potassium'
     }, '<label>Test</label>');
 
@@ -54,6 +54,7 @@ describe("testing a image widget", function() {
     expect(widget).toHaveClass('image');
     expect(widget).toHaveLabel('Test');
     expect(res[0].getPath()).toBe("id_0");
+    expect(qx.bom.element.Attribute.get(qx.bom.Selector.query("img", widget)[0], "src")).toBe('resource/icon/comet_64_ff8000.png');
     expect(qx.bom.element.Attribute.get(qx.bom.Selector.query("img", widget)[0], "style")).toBe('width:100%;');
   });
   it("should test the image creator and refreshing", function() {
@@ -79,16 +80,15 @@ describe("testing a image widget", function() {
       refresh: 5,
       cachecontrol: 'full'
     });
-    /*
     var resWeak = this.createTestElement("image", {
-      src: '',
+      src: 'resource/icon/comet_64_ff8000.png',
       width: '50%',
       height: '51%',
       refresh: 5,
       cachecontrol: 'weak'
     });
     var resNone = this.createTestElement("image", {
-      src: '',
+      src: 'resource/icon/comet_64_ff8000.png',
       width: '50%',
       height: '51%',
       refresh: 5,
@@ -99,19 +99,13 @@ describe("testing a image widget", function() {
       resWeak.getDomElement(),
       resNone.getDomElement()
     ];
-    */
-    var widget = resFull.getDomElement();
     qx.event.message.Bus.dispatchByName("setup.dom.finished");
 
     expect(spiedTimer.start).toHaveBeenCalled();
     setTimeout(function(){
-      //expect(qx.bom.element.Attribute.get(qx.bom.Selector.query("img", widget)[0], "src")).toMatch(/^resource/icon/comet_64_ff8000.png\?force Fail!/);
-      //expect(qx.bom.element.Attribute.get(qx.bom.Selector.query("img", widget)[0], "src")).not.toMatch(/^resource/icon/comet_64_ff8000.png\?force Fail!/);
-      expect(qx.bom.element.Attribute.get(qx.bom.Selector.query("img", widget)[0], "src")).toMatch(/^resource\/icon\/comet_64_ff8000.pngforce Fail!/);
-      expect(qx.bom.element.Attribute.get(qx.bom.Selector.query("img", widget)[0], "src")).not.toMatch(/^resource\/icon\/comet_64_ff8000.pngforce Fail!/);
-      //expect(qx.bom.element.Attribute.get(qx.bom.Selector.query("img", widgets[0])[0], "src")).toMatch(/^\?/);
-      //expect(qx.bom.element.Attribute.get(qx.bom.Selector.query("img", widgets[1])[0], "src")).toMatch(/^#/);
-      //expect(qx.bom.element.Attribute.get(qx.bom.Selector.query("img", widgets[2])[0], "src")).toBe('');
+      expect(qx.bom.element.Attribute.get(qx.bom.Selector.query("img", widgets[0])[0], "src")).toMatch(/^resource\/icon\/comet_64_ff8000.png\?/);
+      expect(qx.bom.element.Attribute.get(qx.bom.Selector.query("img", widgets[1])[0], "src")).toMatch(/^resource\/icon\/comet_64_ff8000.png#/);
+      expect(qx.bom.element.Attribute.get(qx.bom.Selector.query("img", widgets[2])[0], "src")).toBe('resource/icon/comet_64_ff8000.png');
       done();
     }, 7000);
   }, 10000);

--- a/source/test/karma/ui/structure/pure/Image-spec.js
+++ b/source/test/karma/ui/structure/pure/Image-spec.js
@@ -106,8 +106,8 @@ describe("testing a image widget", function() {
       expect(qx.bom.element.Attribute.get(qx.bom.Selector.query("img", widgets[1])[0], "src")).toBe('#');
       expect(qx.bom.element.Attribute.get(qx.bom.Selector.query("img", widgets[2])[0], "src")).toBe('');
       done();
-    }, 10);
-  });
+    }, 7000);
+  }, 10000);
   
   it("should test the image creator width size", function() {
 


### PR DESCRIPTION
Create attribute `cachecontrol` for image widget to control how the CometVisu makes the browser reload the image during refresh.

This fixes the recent server setup change that happened at yr.no  where it doesn't tolerate the addition of a question mark and timestamp to the URL any more.