### PR TITLE
create resource/config/media, because the empty dir is not copied and…

### DIFF
--- a/utils/commands/build.py
+++ b/utils/commands/build.py
@@ -120,6 +120,11 @@ class BuildHelper(Command):
         except Exception as e:
             print(str(e))
 
+        # create config media dir
+        media = os.path.join("build", "resource", "config", "media")
+        if not os.path.exists(media):
+            os.mkdir(media)
+
     def run(self, args):
         parser = ArgumentParser(usage="%(prog)s - CometVisu build helper scrips")
 


### PR DESCRIPTION
… the manager.php needs that directory.

Current nighly build do not contain that directory and on a fresh install the manager does not work then.