### PR TITLE
Enhance sendToBackend

### DIFF
--- a/source/class/cv/ui/common/Operate.js
+++ b/source/class/cv/ui/common/Operate.js
@@ -71,28 +71,33 @@ qx.Mixin.define("cv.ui.common.Operate", {
      *
      * @param value {var} value to send
      * @param filter {Function} optional filter function for addresses
-     * @param currentBusValue {var} optional: the (assumed) last encoded value
-     *          that was sent on the bus. When the encoding of the new value
-     *          to send is equal to the currentBusValue a transmission will 
-     *          be suppressed.
-     * @return the encoded value that was sent last
+     * @param currentBusValues {Object} optional: the (assumed) last encoded values
+     *          that were sent on the bus. When the encoding of the new value
+     *          to send is equal to the currentBusValues a transmission will 
+     *          be suppressed. The object is a hash with the encoding as a key
+     *          for the encoded value
+     * @return the object/hash of encoded values that were sent last time
      */
-    sendToBackend: function (value, filter, currentBusValue) {
-      var encodedValue;
+    sendToBackend: function (value, filter, currentBusValues) {
+      var 
+        encodedValues = {},
+        encodedCurrentBusValues = currentBusValues || {};
+      
       if (this.getAddress) {
         var list = this.getAddress();
         for (var id in list) {
           if (list.hasOwnProperty(id)) {
             var address = list[id];
             if (cv.data.Model.isWriteAddress(address) && (!filter || filter(address))) {
-              encodedValue = cv.Transform.encode(address[0], value);
-              if( encodedValue !== currentBusValue )
+              var encodedValue = cv.Transform.encode(address[0], value);
+              if( encodedValue !== encodedCurrentBusValues[address[0]] )
                 cv.TemplateEngine.getInstance().visu.write(id, encodedValue);
+              encodedValues[address[0]] = encodedValue;
             }
           }
         }
       }
-      return encodedValue;
+      return encodedValues;
     }
   }
 });

--- a/source/class/cv/ui/common/Operate.js
+++ b/source/class/cv/ui/common/Operate.js
@@ -79,20 +79,19 @@ qx.Mixin.define("cv.ui.common.Operate", {
      * @return the object/hash of encoded values that were sent last time
      */
     sendToBackend: function (value, filter, currentBusValues) {
-      var 
-        encodedValues = {},
-        encodedCurrentBusValues = currentBusValues || {};
-      
+      var encodedValues = {};
       if (this.getAddress) {
         var list = this.getAddress();
         for (var id in list) {
           if (list.hasOwnProperty(id)) {
             var address = list[id];
             if (cv.data.Model.isWriteAddress(address) && (!filter || filter(address))) {
-              var encodedValue = cv.Transform.encode(address[0], value);
-              if( encodedValue !== encodedCurrentBusValues[address[0]] )
+              var
+                encoding = address[0],
+                encodedValue = cv.Transform.encode(encoding, value);
+              if( !currentBusValues || encodedValue !== currentBusValues[encoding] )
                 cv.TemplateEngine.getInstance().visu.write(id, encodedValue);
-              encodedValues[address[0]] = encodedValue;
+              encodedValues[encoding] = encodedValue;
             }
           }
         }

--- a/source/class/cv/ui/common/Operate.js
+++ b/source/class/cv/ui/common/Operate.js
@@ -75,21 +75,24 @@ qx.Mixin.define("cv.ui.common.Operate", {
      *          that was sent on the bus. When the encoding of the new value
      *          to send is equal to the currentBusValue a transmission will 
      *          be suppressed.
+     * @return the encoded value that was sent last
      */
     sendToBackend: function (value, filter, currentBusValue) {
+      var encodedValue;
       if (this.getAddress) {
         var list = this.getAddress();
         for (var id in list) {
           if (list.hasOwnProperty(id)) {
             var address = list[id];
             if (cv.data.Model.isWriteAddress(address) && (!filter || filter(address))) {
-              var encodedValue = cv.Transform.encode(address[0], value);
+              encodedValue = cv.Transform.encode(address[0], value);
               if( encodedValue !== currentBusValue )
                 cv.TemplateEngine.getInstance().visu.write(id, encodedValue);
             }
           }
         }
       }
+      return encodedValue;
     }
   }
 });

--- a/source/class/cv/ui/common/Operate.js
+++ b/source/class/cv/ui/common/Operate.js
@@ -71,15 +71,21 @@ qx.Mixin.define("cv.ui.common.Operate", {
      *
      * @param value {var} value to send
      * @param filter {Function} optional filter function for addresses
+     * @param currentBusValue {var} optional: the (assumed) last encoded value
+     *          that was sent on the bus. When the encoding of the new value
+     *          to send is equal to the currentBusValue a transmission will 
+     *          be suppressed.
      */
-    sendToBackend: function (value, filter) {
+    sendToBackend: function (value, filter, currentBusValue) {
       if (this.getAddress) {
         var list = this.getAddress();
         for (var id in list) {
           if (list.hasOwnProperty(id)) {
             var address = list[id];
             if (cv.data.Model.isWriteAddress(address) && (!filter || filter(address))) {
-              cv.TemplateEngine.getInstance().visu.write(id, cv.Transform.encode(address[0], value));
+              var encodedValue = cv.Transform.encode(address[0], value);
+              if( encodedValue !== currentBusValue )
+                cv.TemplateEngine.getInstance().visu.write(id, encodedValue);
             }
           }
         }

--- a/source/class/cv/ui/structure/pure/Slide.js
+++ b/source/class/cv/ui/structure/pure/Slide.js
@@ -186,11 +186,7 @@ qx.Class.define('cv.ui.structure.pure.Slide', {
     _onChangeValue: function(value) {
       if (!this.__initialized || this.__skipUpdatesFromSlider === true) { return; }
       if (this.isSendOnFinish() === false || this.__slider.isInPointerMove()) {
-        var currentValue = this.getValue();
-        this.sendToBackend(value, function(addr) {
-          var newValue = cv.Transform.encode(addr[0], value);
-          return (newValue !== cv.Transform.encode(addr[0], currentValue));
-        });
+        this._lastBusValue = this.sendToBackend(value, false, this._lastBusValue );
       }
       this.setValue(value);
     },


### PR DESCRIPTION
Add optional third parameter currentBusValue that can be used to prevent retransmission of already known values on the bus.

Usecase are widgets that are continuusly sending like a slider.