### PR TITLE
fix api-doc references to use the full classname and replace the year…

### DIFF
--- a/doc/manual/de/config/widgets/plugins/colorchooser/index.rst
+++ b/doc/manual/de/config/widgets/plugins/colorchooser/index.rst
@@ -10,7 +10,7 @@
 Das ColorChooser Plugin
 =======================
 
-.. api-doc:: colorchooser
+.. api-doc:: cv.plugins.ColorChooser
 
 Beschreibung
 ------------

--- a/doc/manual/de/config/widgets/plugins/diagram/index.rst
+++ b/doc/manual/de/config/widgets/plugins/diagram/index.rst
@@ -6,7 +6,7 @@
 Das Diagram Plugin
 ==================
 
-.. api-doc:: diagram
+.. api-doc:: cv.plugins.diagram.AbstractDiagram
 
 .. TODO::
 

--- a/doc/manual/de/config/widgets/plugins/diagram_info/index.rst
+++ b/doc/manual/de/config/widgets/plugins/diagram_info/index.rst
@@ -5,7 +5,7 @@
 Das Diagramm_Info Plugin
 ========================
 
-.. api-doc:: diagram
+.. api-doc:: cv.plugins.diagram.AbstractDiagram
 
 .. TODO::
 

--- a/doc/manual/de/config/widgets/plugins/gauge/index.rst
+++ b/doc/manual/de/config/widgets/plugins/gauge/index.rst
@@ -5,7 +5,7 @@
 Das Gauge Plugin
 ================
 
-.. api-doc:: gauge
+.. api-doc:: cv.plugins.Gauge
 
 Beschreibung
 ------------

--- a/doc/manual/de/config/widgets/plugins/openhab/index.rst
+++ b/doc/manual/de/config/widgets/plugins/openhab/index.rst
@@ -3,7 +3,7 @@
 Das openHAB2 Plugin
 ===================
 
-.. api-doc:: openhab
+.. api-doc:: cv.plugins.openhab.Openhab
 
 Beschreibung
 ------------

--- a/doc/manual/de/config/widgets/plugins/powerspectrum/index.rst
+++ b/doc/manual/de/config/widgets/plugins/powerspectrum/index.rst
@@ -3,7 +3,7 @@
 Das PowerSpectrum Plugin
 ========================
 
-.. api-doc:: powerspectrum
+.. api-doc:: cv.plugins.PowerSpectrum
 
 Beschreibung
 ------------

--- a/doc/manual/de/config/widgets/plugins/speech/index.rst
+++ b/doc/manual/de/config/widgets/plugins/speech/index.rst
@@ -3,7 +3,7 @@
 Das Speech Plugin
 =================
 
-.. api-doc:: speech
+.. api-doc:: cv.plugins.Speech
 
 Beschreibung
 ------------

--- a/doc/manual/de/config/widgets/plugins/strftime/index.rst
+++ b/doc/manual/de/config/widgets/plugins/strftime/index.rst
@@ -8,7 +8,7 @@
 Das Strftime Plugin
 ===================
 
-.. api-doc:: strftime
+.. api-doc:: cv.plugins.Strftime
 
 Beschreibung
 ------------

--- a/doc/manual/de/config/widgets/plugins/timeout/index.rst
+++ b/doc/manual/de/config/widgets/plugins/timeout/index.rst
@@ -3,7 +3,7 @@
 Das Timeout Plugin
 ==================
 
-.. api-doc:: timeout
+.. api-doc:: cv.plugins.Timeout
 
 Beschreibung
 ------------

--- a/doc/manual/de/config/widgets/plugins/tr064/index.rst
+++ b/doc/manual/de/config/widgets/plugins/tr064/index.rst
@@ -3,7 +3,7 @@
 Das tr064 Plugin
 =================
 
-.. api-doc:: tr064
+.. api-doc:: cv.plugins.tr064.CallList
 
 .. TODO::
 

--- a/source/class/cv/plugins/diagram/AbstractDiagram.js
+++ b/source/class/cv/plugins/diagram/AbstractDiagram.js
@@ -52,7 +52,7 @@
  * </ul>
  *
  * @author Michael Hausl [michael at hausl dot com]
- * @since 2014
+ * @since 0.6.0
  *
  * @asset(plugins/diagram/dep/flot/*.min.js)
  */


### PR DESCRIPTION
… with the release version for diagram plugin.

This adds the "available since" and "author" parts (which are taken from the source code docs) to the documentation again.