### PR TITLE
- introduce cv.ui.layout.States to be able to listen to events when e…

### DIFF
--- a/source/class/cv/plugins/PowerSpectrum.js
+++ b/source/class/cv/plugins/PowerSpectrum.js
@@ -294,9 +294,8 @@ qx.Class.define('cv.plugins.PowerSpectrum', {
       }.bind(this);
 
       // check if sizes are set yet, otherwise wait some time
-      // TODO: should be done with events
-      if (cv.ui.layout.ResizeHandler.invalidPagesize) {
-        qx.event.Timer.once(init, this, 10);
+      if (cv.ui.layout.ResizeHandler.states.isPageSizeInvalid()) {
+        cv.ui.layout.ResizeHandler.states.addListenerOnce('changePageSizeInvalid', init);
       } else {
         init();
       }

--- a/source/class/cv/ui/layout/ResizeHandler.js
+++ b/source/class/cv/ui/layout/ResizeHandler.js
@@ -36,11 +36,8 @@ qx.Class.define('cv.ui.layout.ResizeHandler', {
   ******************************************************
   */
   statics: {
+    states: new cv.ui.layout.States(),
 
-    invalidBackdrop: true,
-    invalidNavbar: true,
-    invalidPagesize: true,
-    invalidRowspan: true,
     $pageSize: null,
     $navbarTop: null,
     $navbarBottom: null,
@@ -51,10 +48,7 @@ qx.Class.define('cv.ui.layout.ResizeHandler', {
     validationQueue: [],
 
     reset: function() {
-      this.invalidBackdrop = true;
-      this.invalidNavbar = true;
-      this.invalidPagesize = true;
-      this.invalidRowspan = true;
+      this.states.resetAll();
       this.$pageSize = null;
       this.$navbarTop = null;
       this.$navbarBottom = null;
@@ -103,10 +97,10 @@ qx.Class.define('cv.ui.layout.ResizeHandler', {
     },
 
     makeAllSizesValid : function() {
-      if (this.invalidPagesize) { this.makePagesizeValid(); } // must be first due to dependencies
-      if (this.invalidNavbar) { this.makeNavbarValid(); }
-      if (this.invalidRowspan) { this.makeRowspanValid(); }
-      if (this.invalidBackdrop) { this.makeBackdropValid(); }
+      if (this.states.isPageSizeInvalid()) { this.makePagesizeValid(); } // must be first due to dependencies
+      if (this.states.isNavbarInvalid()) { this.makeNavbarValid(); }
+      if (this.states.isRowspanInvalid()) { this.makeRowspanValid(); }
+      if (this.states.isBackdropInvalid()) { this.makeBackdropValid(); }
     },
 
     makeBackdropValid: function () {
@@ -203,7 +197,7 @@ qx.Class.define('cv.ui.layout.ResizeHandler', {
         }, this);
       }
 
-      this.invalidBackdrop = false;
+      this.states.setBackdropInvalid(false);
     },
 
     makeNavbarValid: function () {
@@ -232,7 +226,7 @@ qx.Class.define('cv.ui.layout.ResizeHandler', {
         // the amount of columns has changed -> recalculate the widgets widths
         cv.ui.layout.Manager.applyColumnWidths();
       }
-      this.invalidNavbar = false;
+      this.states.setNavbarInvalid(false);
     },
 
     makePagesizeValid: function () {
@@ -261,7 +255,7 @@ qx.Class.define('cv.ui.layout.ResizeHandler', {
         pageSizeElement.innerHTML = '#main,.page{width:' + this.width + 'px;height:' + this.height + 'px;}';
       }
 
-      this.invalidPagesize = false;
+      this.states.setPageSizeInvalid(false);
     },
 
     makeRowspanValid: function () {
@@ -302,27 +296,32 @@ qx.Class.define('cv.ui.layout.ResizeHandler', {
       if (rowSpanStyle) {
         rowSpanStyle.innerHTML = styles;
       }
-      this.invalidRowspan = false;
+      this.states.setRowspanInvalid(false);
     },
 
     invalidateBackdrop: function () {
-      this.invalidBackdrop = true;
+      qx.log.Logger.debug(this, "backdrop");
+      this.states.setBackdropInvalid(true);
       this.makeAllSizesValid();
     },
     invalidateNavbar: function () {
-      this.invalidNavbar = true;
-      this.invalidPagesize = true;
+      qx.log.Logger.debug(this, "invalidateNavbar");
+      this.states.setNavbarInvalid(true);
+      this.states.setPageSizeInvalid(true);
       this.makeAllSizesValid();
     },
     invalidateRowspan: function () {
-      this.invalidRowspan = true;
+      this.states.setRowspanInvalid(true);
       this.makeAllSizesValid();
     },
     invalidateScreensize: function () {
-      this.invalidPagesize = true;
-      this.invalidRowspan = true;
-      this.invalidNavbar = true;
-      this.invalidBackdrop = true;
+      qx.log.Logger.debug(this, "invalidateScreensize");
+      this.states.set({
+        pageSizeInvalid: true,
+        rowspanInvalid: true,
+        navbarInvalid: true,
+        backdropInvalid: true
+      });
       this.makeAllSizesValid();
     }
   }

--- a/source/class/cv/ui/layout/States.js
+++ b/source/class/cv/ui/layout/States.js
@@ -1,0 +1,50 @@
+/**
+ * This class holds all states that are maintained by the {@link cv.ui.layout.ResizeHandler}.
+ * Other classes can use the instance of this class {@link cv.ui.layout.ResizeHandler.states} to listen to changes
+ * to the states.
+ */
+qx.Class.define('cv.ui.layout.States', {
+  extend: qx.core.Object,
+
+  /*
+  ***********************************************
+    PROPERTIES
+  ***********************************************
+  */
+  properties: {
+    pageSizeInvalid: {
+      check: 'Boolean',
+      init: true,
+      event: 'changePageSizeInvalid'
+    },
+
+    backdropInvalid: {
+      check: 'Boolean',
+      init: true,
+      event: 'changeBackdropInvalid'
+    },
+
+    navbarInvalid: {
+      check: 'Boolean',
+      init: true,
+      event: 'changeNavbarInvalid'
+    },
+
+    rowspanInvalid: {
+      check: 'Boolean',
+      init: true,
+      event: 'changeRowspanInvalid'
+    }
+  },
+
+  /*
+  ***********************************************
+    MEMBERS
+  ***********************************************
+  */
+  members: {
+    resetAll: function () {
+      ['pageSizeInvalid', 'backdropInvalid', 'navbarInvalid', 'rowspanInvalid'].forEach(this.reset, this);
+    }
+  }
+});

--- a/source/class/cv/ui/structure/AbstractBasicWidget.js
+++ b/source/class/cv/ui/structure/AbstractBasicWidget.js
@@ -119,6 +119,21 @@ qx.Class.define('cv.ui.structure.AbstractBasicWidget', {
         parent = parent.getParentWidget();
       }
       return null;
+    },
+
+    /**
+     * Get the parent element that defines if this widget is visible. Can be either a page or a navbar
+     * @return {cv.ui.structure.pure.Page|cv.ui.structure.pure.NavBar|null}
+     */
+    getVisibilityParent: function () {
+      var parent = this.getParentWidget();
+      while (parent) {
+        if (parent.get$$type() === "page" || parent.get$$type() === "navbar") {
+          return parent;
+        }
+        parent = parent.getParentWidget();
+      }
+      return null;
     }
   }
 });

--- a/source/class/cv/ui/structure/AbstractWidget.js
+++ b/source/class/cv/ui/structure/AbstractWidget.js
@@ -55,7 +55,7 @@ qx.Class.define('cv.ui.structure.AbstractWidget', {
           this.setParentWidget(parent);
         }
       }
-      var parentPage = this.get$$type() === "page" || this.get$$type() === "navbar" ? null : this.getParentPage();
+      var parentPage = this.get$$type() === "page" || this.get$$type() === "navbar" ? null : this.getVisibilityParent();
       if (parentPage) {
         parentPage.bind("visible", this, "visible");
       }

--- a/source/class/cv/ui/website/Slider.js
+++ b/source/class/cv/ui/website/Slider.js
@@ -69,9 +69,12 @@ qx.Class.define('cv.ui.website.Slider', {
   members: {
     __pointerMoveEvent: null,
     __positionKnob: null,
+    __invalidPageSizeListener: null,
+    __sizeStates: null,
 
     init: function() {
       this.base(arguments);
+      this.__sizeStates = cv.ui.layout.ResizeHandler.states;
       if (this.getChildren(".ui-slider-range").length === 0) {
         this.append(qx.ui.website.Widget.create("<div>")
           .addClass("ui-slider-range"));
@@ -102,6 +105,23 @@ qx.Class.define('cv.ui.website.Slider', {
      */
     updatePositions: function() {
       this._onWindowResize();
+    },
+
+    _onWindowResize: function () {
+      var args = arguments;
+      if (this.__sizeStates.isPageSizeInvalid()) {
+        if (!this.__invalidPageSizeListener) {
+          this.__invalidPageSizeListener = this.__sizeStates.addListener('changePageSizeInvalid', function (ev) {
+            if (ev.getData() === false) {
+              this.__sizeStates.removeListenerById(this.__invalidPageSizeListener);
+              this.__invalidPageSizeListener = null;
+              this.base(args);
+            }
+          }, this);
+        }
+      } else {
+        this.base(args);
+      }
     },
 
     //overridden
@@ -143,5 +163,14 @@ qx.Class.define('cv.ui.website.Slider', {
     isInPointerMove: function() {
       return this.__pointerMoveEvent === true;
     }
+  },
+
+  /*
+  ***********************************************
+    DESTRUCTOR
+  ***********************************************
+  */
+  destruct: function () {
+    this.__sizeStates = null;
   }
 });

--- a/source/resource/designs/designglobals.css
+++ b/source/resource/designs/designglobals.css
@@ -110,7 +110,7 @@ body
   -webkit-transform: translateZ(0);
   -webkit-overflow-scrolling:touch;
 }
-.page > .clearfix { position:relative; height: 100%; }
+.page > .clearfix:not(.navbar) { position:relative; height: 100%; }
 input, textarea, select, button { font: inherit; }
 /* 
  * colspans, each design needs to define a colspan0


### PR DESCRIPTION
….g. the pageSize is valid again

- use these events in slider to recalculate the knob position after the pageSize is valid
- same to initialize the PowerSpectrum widget

closes #701

Fixes for navbars:
- fix initialization of widgets inside navbars: all widgets are initialized when they become visible, visibility of widgets inside navbars need to be bound to the navbars visibility and not to the pages visibility where the navbar is defined
- do not set height of navbars to 100%