### PR TITLE
add dockerfile and nightly builds of docker images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: required
 language: python
 dist: trusty
 services:
-  - docker
+- docker
 python:
 - '3.5'
 cache:
@@ -10,60 +10,109 @@ cache:
   - node_modules
   - "$HOME/.cache/pip"
   - downloads
-env:
-  - CV_BUILD="test" CV_BROWSER=Chrome_travis CV_VERSION=stable
-  - CV_BUILD="test" CV_BROWSER=Chrome_travis CV_VERSION=beta
-  - CV_BUILD="test" CV_BROWSER=Chrome_travis CV_VERSION=unstable
-  - CV_BUILD="docs" ENCRYPTION_LABEL="4c79fec0aeb9" COMMIT_AUTHOR_EMAIL="generator@cometvisu.org" CV_BROWSER=Chrome_travis CV_VERSION=stable
 before_install:
-- if [ "$CV_BUILD" == "docs" ]; then docker pull cometvisu/dev-helper; fi
 - mkdir -p downloads
 - nvm install 6.9
-- sudo ./utils/travis/browser-setup.sh
-- export CHROME_BIN=`pwd`/chrome/google-chrome
-- export PATH=`pwd`/firefox:`pwd`/chrome:$PATH
-- google-chrome --version
-- firefox --version
 - mkdir cache
 install:
 - npm install -g grunt-cli
 - npm install
 - sudo pip install -r utils/requirements.txt
 - virtualenv -p /usr/bin/python2.7 --distribute temp-python --system-site-packages
-- source temp-python/bin/activate
-- if [ "$CV_BUILD" == "test" ]; then ./generate.py source -sI; fi
-- if [ "$CV_BUILD" == "docs" ]; then ./generate.py build -sI; fi
-- deactivate
-- "./node_modules/protractor/bin/webdriver-manager update"
-- if [ "$CV_BUILD" == "docs" ]; then sudo apt-get install python-lxml python3-lxml; fi
-script:
-- if [ "$CV_BUILD" == "test" ]; then source temp-python/bin/activate; fi
-- if [ "$CV_BUILD" == "test" ]; then grunt jscs; fi
-- if [ "$CV_BUILD" == "test" ]; then ./generate.py lint; fi
-- if [ "$CV_BUILD" == "test" ]; then deactivate; fi
-- export PATH=`pwd`/firefox:$PATH
-- if [ "$CV_BUILD" == "test" ]; then grunt karma:travis --browser $CV_BROWSER; fi
-- if [ "$CV_BUILD" == "test" ] && [ "$CV_BROWSER" == "Chrome_travis" ]; then grunt e2e-chrome; fi
-- if [ "$CV_BUILD" == "docs" ]; then utils/travis/deploy.sh; fi
-after_success:
-- if [ "$CV_BUILD" == "test" ] && [ "$CV_VERSION" == "stable" ] ; then grunt coveralls; fi
-- "CLIENT_CHANGES=`git log --pretty=format: --name-only --since=\"1 days ago\" ${TRAVIS_BUILD_DIR}/client/ | sort | uniq | sed '/^$/d' | wc -l`"
-- "CORE_CHANGES=`git log --pretty=format: --name-only --since=\"1 days ago\" ${TRAVIS_BUILD_DIR}/source/ | sort | uniq | sed '/^$/d' | wc -l`"
-- echo "$CORE_CHANGES changes in core, $CLIENT_CHANGES changes in client, $CV_BUILD build, $CV_VERSION version, $TRAVIS_EVENT_TYPE event type"
-- export DEPLOY_NIGHTLY=0
-- if [[ $CV_BUILD == test && $CV_VERSION == stable && $TRAVIS_EVENT_TYPE == cron && ($CORE_CHANGES -gt 0 || $CLIENT_CHANGES -gt 0) ]]; then export DEPLOY_NIGHTLY=1; fi
-- if [[ $CV_BUILD == test && $CV_VERSION == stable && ${TRAVIS_COMMIT_MESSAGE:0:12} = "[ci nightly]" ]]; then export DEPLOY_NIGHTLY=1; export CORE_CHANGES=1; fi
-before_deploy:
-- if [ $CORE_CHANGES -gt 0 ]; then grunt release-cv; fi
-- if [ $CLIENT_CHANGES -gt 0 ]; then grunt release-client; fi
-deploy:
-  on:
-    branch: develop
-    condition: $DEPLOY_NIGHTLY = 1
-  provider: bintray
-  file: "./deploy.json"
-  user: peuter
-  key:
-    secure: dnqHD0ynwCvyxeniG5ee+ImtnQPP02c4WkV8EVgVwSKcEQ5xtdlfy9/6M4znDMlEKcfwvUr9O8JVtrmTqyLNlcwxiIgnrzfIUBrzwPRhSrDgAbUUHOy4bpES58rGKZvwvavhaRhMnd5nQivG4w7ltKdVX4MY8ht4gGLVIlK5RSA=
-  dry-run: false
-  skip_cleanup: true
+stages:
+- name: lint
+- name: test
+- name: deploy
+  if: repo = CometVisu/CometVisu AND (NOT type IN (pull_request)) AND ( branch = docker OR tag =~ ^v[0-9] )
+jobs:
+  include:
+  - stage: lint
+    name: Lint
+    script:
+    - source temp-python/bin/activate
+    - grunt jscs
+    - "./generate.py lint"
+  - stage: test
+    name: 'Unit Tests: Chrome stable'
+    env: CV_BUILD=test CV_BROWSER=Chrome_travis CV_VERSION=stable
+    script: &1
+    - sudo ./utils/travis/browser-setup.sh
+    - export CHROME_BIN=`pwd`/chrome/google-chrome
+    - export PATH=`pwd`/firefox:`pwd`/chrome:$PATH
+    - google-chrome --version
+    - source temp-python/bin/activate
+    - "./generate.py source -sI"
+    - deactivate
+    - grunt karma:travis --browser $CV_BROWSER
+    - if [ "$CV_BUILD" == "test" ] && [ "$CV_VERSION" == "stable" ] ; then grunt coveralls; fi
+  - stage: test
+    name: 'Unit Tests: Chrome beta'
+    env: CV_BUILD=test CV_BROWSER=Chrome_travis CV_VERSION=beta
+    script: *1
+  - stage: test
+    name: 'Unit Tests: Chrome unstable'
+    env: CV_BUILD=test CV_BROWSER=Chrome_travis CV_VERSION=unstable
+    script: *1
+  - name: 'End-to-end Tests: Chrome stable'
+    env: CV_BUILD=test CV_BROWSER=Chrome_travis CV_VERSION=stable
+    script: &2
+    - sudo ./utils/travis/browser-setup.sh
+    - export CHROME_BIN=`pwd`/chrome/google-chrome
+    - source temp-python/bin/activate
+    - "./generate.py source -sI"
+    - deactivate
+    - "node ./node_modules/protractor/bin/webdriver-manager update --gecko=false"
+    - grunt e2e-chrome
+  - name: 'End-to-end Tests: Chrome beta'
+    env: CV_BUILD=test CV_BROWSER=Chrome_travis CV_VERSION=beta
+    script: *2
+  - name: 'End-to-end Tests: Chrome unstable'
+    env: CV_BUILD=test CV_BROWSER=Chrome_travis CV_VERSION=unstable
+    script: *2
+  - stage: deploy
+    name: "[DOCS] - Generate and publish manual and API-viewer"
+    env: CV_BUILD=docs ENCRYPTION_LABEL=4c79fec0aeb9 COMMIT_AUTHOR_EMAIL=generator@cometvisu.org CV_BROWSER=Chrome_travis CV_VERSION=stable
+    script:
+    - docker pull cometvisu/dev-helper
+    - source temp-python/bin/activate
+    - "./generate.py build -sI"
+    - deactivate
+    - "node ./node_modules/protractor/bin/webdriver-manager update --gecko=false"
+    - sudo apt-get install python-lxml python3-lxml
+    - utils/travis/deploy.sh
+  - name: "[NIGHTLY] - Build and push Nightly Build"
+    if: type = cron
+    script: &3
+    - 'CLIENT_CHANGES=`git log --pretty=format: --name-only --since="1 days ago" ${TRAVIS_BUILD_DIR}/client/ | sort | uniq | sed ''/^$/d'' | wc -l`'
+    - 'CORE_CHANGES=`git log --pretty=format: --name-only --since="1 days ago" ${TRAVIS_BUILD_DIR}/source/ | sort | uniq | sed ''/^$/d'' | wc -l`'
+    - echo "$CORE_CHANGES changes in core, $CLIENT_CHANGES changes in client, $CV_BUILD build, $CV_VERSION version, $TRAVIS_EVENT_TYPE event type"
+    - export DEPLOY_NIGHTLY=0
+    - if [[ ($CORE_CHANGES -gt 0 || $CLIENT_CHANGES -gt 0) ]]; then export DEPLOY_NIGHTLY=1; fi
+    - if [[ ${TRAVIS_COMMIT_MESSAGE:0:12} = "[ci nightly]" ]]; then export DEPLOY_NIGHTLY=1; export CORE_CHANGES=1; fi
+    before_deploy:
+    - if [ $CORE_CHANGES -gt 0 ]; then grunt release-cv; fi
+    - if [ $CLIENT_CHANGES -gt 0 ]; then grunt release-client; fi
+    deploy:
+      on:
+        branch: develop
+        condition: "$DEPLOY_NIGHTLY = 1"
+      provider: bintray
+      file: "./deploy.json"
+      user: peuter
+      key:
+        secure: dnqHD0ynwCvyxeniG5ee+ImtnQPP02c4WkV8EVgVwSKcEQ5xtdlfy9/6M4znDMlEKcfwvUr9O8JVtrmTqyLNlcwxiIgnrzfIUBrzwPRhSrDgAbUUHOy4bpES58rGKZvwvavhaRhMnd5nQivG4w7ltKdVX4MY8ht4gGLVIlK5RSA=
+      dry-run: false
+      skip_cleanup: true
+  - name: "[DOCKER] - Build and push Docker Container"
+    if: type = cron
+    script: *3
+    before_deploy:
+    - grunt release-cv
+    - mv release build # move back to build because the dockerfile is expecting the build here
+    deploy:
+      on:
+        branch: docker
+        condition: "$DEPLOY_NIGHTLY = 1"
+      provider: script
+      script: utils/travis/docker_push.sh
+      skip_cleanup: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,151 @@
+FROM php:7.2-apache as builder
+
+##################
+# Compile knxd 0.0.5.1
+RUN apt-get -qq update \
+ && apt-get install -y python python-dev python-pip python-virtualenv \
+ && apt-get install -y build-essential gcc git rsync cmake make g++ binutils automake flex bison patch wget libtool \
+ && apt-get clean; rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/*
+
+ENV KNXDIR /usr
+ENV INSTALLDIR $KNXDIR/local
+ENV SOURCEDIR  $KNXDIR/src
+ENV LD_LIBRARY_PATH $INSTALLDIR/lib
+
+WORKDIR $SOURCEDIR
+
+# build pthsem
+ENV PTHSEM_DOWNLOAD_SHA256 4024cafdd5d4bce2b1778a6be5491222c3f6e7ef1e43971264c451c0012c5c01
+RUN wget -O pthsem_2.0.8.tar.gz "https://osdn.net/frs/g_redir.php?m=kent&f=bcusdk%2Fpthsem%2Fpthsem_2.0.8.tar.gz" \
+ && echo "$PTHSEM_DOWNLOAD_SHA256 pthsem_2.0.8.tar.gz" | sha256sum -c - \
+ && tar -xzf pthsem_2.0.8.tar.gz \
+ && cd pthsem-2.0.8 && ./configure --prefix=$INSTALLDIR/ && make && make test && make install
+
+# build knxd
+ENV KNXD_DOWNLOAD_SHA256 f47a02efd8618dc1ec5837e08017dabbaa2712a9b9c36af7784426cc9429455e
+RUN wget -O knxd_0.0.5.1.tar.gz "https://github.com/knxd/knxd/archive/0.0.5.1.tar.gz" \
+ && echo "$KNXD_DOWNLOAD_SHA256 knxd_0.0.5.1.tar.gz" | sha256sum -c - \
+ && tar -xzf knxd_0.0.5.1.tar.gz \
+ && cd knxd-0.0.5.1 && ./bootstrap.sh \
+ && ./configure --enable-onlyeibd --enable-eibnetip --enable-eibnetiptunnel --disable-eibnetipserver \
+    --disable-ft12 --disable-pei16 --disable-tpuart --disable-pei16s  --disable-tpuarts --disable-usb --disable-ncn5120 \
+    --enable-groupcache --disable-java \
+    --disable-shared --enable-static \
+    --prefix=$INSTALLDIR/ --with-pth=$INSTALLDIR/ \
+ && make && make install
+
+##############
+# Run environment
+FROM php:7.2-apache
+
+# Own labels
+LABEL maintainer="http://www.cometvisu.org/"
+LABEL org.cometvisu.version="0.11.0"
+LABEL org.cometvisu.knxd.version="0.0.5.1"
+# Labels according to http://label-schema.org/rc1/
+LABEL org.label-schema.schema-version="1.0"
+LABEL org.label-schema.build-date=$BUILD_DATE
+LABEL org.label-schema.name="CometVisu"
+LABEL org.label-schema.description="The CometVisu visualistion"
+LABEL org.label-schema.usage="README.md"
+LABEL org.label-schema.url="http://www.cometvisu.org"
+LABEL org.label-schema.vcs-url="https://github.com/CometVisu/CometVisu"
+LABEL org.label-schema.vcs-ref="<...>"
+LABEL org.label-schema.vendor="The CometVisu project"
+LABEL org.label-schema.version="0.11.0"
+
+# just for testing automated variables
+ARG SOURCE_BRANCH
+ARG SOURCE_COMMIT
+ARG COMMIT_MSG
+ARG DOCKER_REPO
+ARG DOCKERFILE_PATH
+ARG CACHE_TAG
+ARG IMAGE_NAME
+ARG MYTEST
+LABEL test.SOURCE_BRANCH=$SOURCE_BRANCH
+LABEL test.SOURCE_COMMIT=$SOURCE_COMMIT
+LABEL test.COMMIT_MSG=$COMMIT_MSG
+LABEL test.DOCKER_REPO=$DOCKER_REPO
+LABEL test.DOCKERFILE_PATH=$DOCKERFILE_PATH
+LABEL test.CACHE_TAG=$CACHE_TAG
+LABEL test.IMAGE_NAME=$IMAGE_NAME
+RUN MYTEST=`date`
+LABEL test.test=$MYTEST
+
+COPY --from=builder /usr/local/bin/knxd /usr/bin/knxd
+COPY --from=builder /usr/local/lib/libpthsem.so.20 /usr/lib/
+COPY --from=builder /usr/src/knxd-0.0.5.1/src/examples/busmonitor1 /usr/src/knxd-0.0.5.1/src/examples/vbusmonitor1 /usr/src/knxd-0.0.5.1/src/examples/vbusmonitor1time /usr/src/knxd-0.0.5.1/src/examples/vbusmonitor2 /usr/src/knxd-0.0.5.1/src/examples/groupswrite /usr/src/knxd-0.0.5.1/src/examples/groupwrite /usr/src/knxd-0.0.5.1/src/examples/groupread /usr/src/knxd-0.0.5.1/src/examples/groupreadresponse /usr/src/knxd-0.0.5.1/src/examples/groupcacheread /usr/src/knxd-0.0.5.1/src/examples/groupsocketread /usr/local/bin/
+COPY --from=builder /usr/src/knxd-0.0.5.1/src/examples/eibread-cgi /usr/lib/cgi-bin/r
+COPY --from=builder /usr/src/knxd-0.0.5.1/src/examples/eibwrite-cgi /usr/lib/cgi-bin/w
+
+## The knxd port:
+#EXPOSE 6720
+##################
+
+# Overwrite package default - allow index
+RUN { \
+    echo '<FilesMatch \.php$>'; \
+    echo '\tSetHandler application/x-httpd-php'; \
+    echo '</FilesMatch>'; \
+    echo; \
+    echo 'DirectoryIndex enabled'; \
+    echo 'DirectoryIndex index.php index.html'; \
+    echo; \
+    echo '<Directory /var/www/>'; \
+    echo '\tOptions +Indexes'; \
+    echo '\tAllowOverride All'; \
+    echo '</Directory>'; \
+    } | tee "$APACHE_CONFDIR/conf-available/cm-docker-php.conf" \
+ && a2disconf docker-php \
+ && a2enconf cm-docker-php \
+ && { \
+    echo "#!/bin/sh"; \
+    echo "echo Content-Type: text/plain"; \
+    echo "echo"; \
+    echo 'echo "{ \"v\":\"0.0.1\", \"s\":\"SESSION\" }"'; \
+    } | tee "/usr/lib/cgi-bin/l" \
+ && chmod +x /usr/lib/cgi-bin/l \
+ && a2enmod cgi \
+ && a2enmod headers
+
+COPY build/ /var/www/html/
+
+# Options - especially for development.
+# DO NOT USE for running a real server!
+#RUN pecl install xdebug-2.6.0 \
+# && docker-php-ext-enable xdebug \
+# && { \
+#    echo 'xdebug.remote_enable=1'; \
+#    echo 'xdebug.remote_connect_back=1'; \
+#    echo 'xdebug.remote_port=9000'; \
+#    echo 'display_errors=Off'; \
+#    echo 'log_errors=On'; \
+#    echo 'error_log=/dev/stderr'; \
+#    echo 'file_uploads=On'; \
+#    } | tee "/usr/local/etc/php/php.ini"
+RUN { \
+    echo "export LS_OPTIONS='--color=auto'"; \
+    echo "eval \"`dircolors`\""; \
+    echo "alias ls='ls \$LS_OPTIONS'"; \
+    echo "alias ll='ls \$LS_OPTIONS -l'"; \
+    echo "alias l='ls \$LS_OPTIONS -lA'"; \
+    } | tee -a "/root/.bashrc"
+
+COPY utils/docker/entrypoint /usr/local/bin/entrypoint
+ENTRYPOINT ["entrypoint"]
+
+VOLUME /var/www/html/resource/config
+
+ENV KNX_INTERFACE iptn:172.17.0.1:3700
+ENV KNX_PA 1.1.238
+ENV KNXD_PARAMETERS -u -d/var/log/eibd.log -c
+
+ENV CGI_URL_PATH /cgi-bin/
+ENV BACKEND_PROXY_SOURCE ""
+ENV BACKEND_PROXY_TARGET ""
+
+# TODO:
+# HEALTHCHECK
+
+CMD ["apache2-foreground"]

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -484,7 +484,7 @@ module.exports = function(grunt) {
       buildClient: {
         command: [
           'cd client',
-          './generate.py build',
+          './generate.py build -sI',
           'cd ..'
         ].join('&&')
       },
@@ -498,7 +498,7 @@ module.exports = function(grunt) {
         command: './generate.py lint'
       },
       build: {
-        command: './generate.py build'
+        command: './generate.py build -sI'
       }
     },
 

--- a/source/class/cv/ui/NotificationCenter.js
+++ b/source/class/cv/ui/NotificationCenter.js
@@ -307,10 +307,14 @@ qx.Class.define("cv.ui.NotificationCenter", {
         this.__blocker.block();
         qx.bom.element.Style.reset(this.__element, "visibility");
         qx.event.Registration.addListener(this.__blocker.getBlockerElement(), "tap", this.hide, this);
-        var anim = qx.bom.element.Animation.animate(this.__element, cv.ui.NotificationCenter.SLIDE);
-        anim.on("end", function () {
+        if (cv.ui.NotificationCenter.SLIDE.duration > 0) {
+          var anim = qx.bom.element.Animation.animate(this.__element, cv.ui.NotificationCenter.SLIDE);
+          anim.on("end", function () {
+            qx.bom.element.Transform.translate(this.__element, "-300px");
+          }, this);
+        } else {
           qx.bom.element.Transform.translate(this.__element, "-300px");
-        }, this);
+        }
       }
     },
 
@@ -332,11 +336,16 @@ qx.Class.define("cv.ui.NotificationCenter", {
       if (this.__visible) {
         this.__visible = false;
         qx.event.Registration.removeListener(this.__blocker.getBlockerElement(), "tap", this.hide, this);
-        var anim = qx.bom.element.Animation.animateReverse(this.__element, cv.ui.NotificationCenter.SLIDE);
-        anim.on("end", function () {
+        if (cv.ui.NotificationCenter.SLIDE.duration > 0) {
+          var anim = qx.bom.element.Animation.animateReverse(this.__element, cv.ui.NotificationCenter.SLIDE);
+          anim.on("end", function () {
+            qx.bom.element.Transform.translate(this.__element, "-0px");
+            this.__blocker.unblock();
+          }, this);
+        } else {
           qx.bom.element.Transform.translate(this.__element, "-0px");
           this.__blocker.unblock();
-        }, this);
+        }
       }
     }
   },

--- a/source/test/karma/plugins/tr064-spec.js
+++ b/source/test/karma/plugins/tr064-spec.js
@@ -63,12 +63,12 @@ describe("testing a TR-064 plugin", function() {
     var widget = widgetInstance.getDomElement();
     qx.event.message.Bus.dispatchByName("setup.dom.finished");
 
-    setTimeout(function () {
+    widgetInstance.addListener('tr064ListRefreshed', function () {
       expect(widgetInstance._displayCalllist).toHaveBeenCalled();
       expect(widget.querySelector('tr').childElementCount).toBe(6); // expect 6 columns
       expect(widget.querySelectorAll('tr').length).toBe(3);         // expect 2 rows
       done();
-    }, 500);
+    });
   });
 
   it("should test the TR-064:calllist refresh", function(done) {

--- a/source/test/karma/ui/NotificationCenter-spec.js
+++ b/source/test/karma/ui/NotificationCenter-spec.js
@@ -27,6 +27,9 @@ describe('test the NotificationCenter', function () {
 
     expect(element).not.toBeUndefined();
 
+    // no animation for test
+    cv.ui.NotificationCenter.SLIDE.duration = 0;
+
     expect(qx.bom.element.Style.get(element, "transform")).toEqual("none");
     center.toggleVisibility();
     setTimeout(function() {
@@ -34,6 +37,7 @@ describe('test the NotificationCenter', function () {
       center.toggleVisibility();
       setTimeout(function() {
         expect(qx.bom.element.Style.get(element, "transform")).toEqual("matrix(1, 0, 0, 1, 0, 0)");
+        cv.ui.NotificationCenter.SLIDE.duration = 350;
         done();
       }, 100);
     }, 100);

--- a/utils/docker/entrypoint
+++ b/utils/docker/entrypoint
@@ -1,0 +1,36 @@
+#!/bin/sh
+set -e
+
+if [ "${KNX_INTERFACE}" != "" ]; then
+    echo "starting knxd"
+    knxd -i $KNX_INTERFACE -e $KNX_PA $KNXD_PARAMETERS
+    chmod a+w /tmp/eib
+fi
+
+CGI_URL_PATH=${CGI_URL_PATH:-/cgi-bin/}
+if [ "${CGI_URL_PATH:-/cgi-bin/}" != "/cgi-bin/" ]; then
+    echo "Non default CGI_URL_PATH detected: '$CGI_URL_PATH'"
+
+    # Tell the CometVisu to path to the login
+    echo '<FilesMatch "visu_config.*xml$">'                             >  /var/www/html/.htaccess
+    echo "    Header set X-CometVisu-Backend-LoginUrl ${CGI_URL_PATH}l" >> /var/www/html/.htaccess
+    echo '</FilesMatch>'                                                >> /var/www/html/.htaccess
+
+    # Pass CometVisu the resource path during the login
+    sed -i 's@\\\"s\\\":\\\"SESSION\\\".*}\"@\\\"s\\\":\\\"SESSION\\\", \\\"c\\\": {\\\"baseURL\\\": \\\"'"$CGI_URL_PATH"'\\\"} }"@' /usr/lib/cgi-bin/l
+fi
+
+if [ "${BACKEND_PROXY_SOURCE}" != "" ] && [ "${BACKEND_PROXY_TARGET}" != "" ]; then
+    echo "proxying ${BACKEND_PROXY_SOURCE} -> ${BACKEND_PROXY_TARGET}"
+    echo "ProxyPass ${BACKEND_PROXY_SOURCE} ${BACKEND_PROXY_TARGET}"        >> $APACHE_CONFDIR/conf-available/cm-docker-php.conf
+    echo "ProxyPassReverse ${BACKEND_PROXY_TARGET} ${BACKEND_PROXY_SOURCE}" >> $APACHE_CONFDIR/conf-available/cm-docker-php.conf
+
+    a2enmod proxy_http > /dev/null
+fi
+
+# first arg is `-f` or `--some-option`
+if [ "${1#-}" != "$1" ]; then
+    set -- apache2-foreground "$@"
+fi
+
+exec "$@"

--- a/utils/travis/docker_push.sh
+++ b/utils/travis/docker_push.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+VERSION=`cat build/version`
+
+echo "$DOCKER_PASS" | docker login -u "$DOCKER_USER" --password-stdin
+
+IMAGE_NAME=`echo $TRAVIS_REPO_SLUG | awk '{print tolower($0)}'`
+
+IMAGE_TAG="nightly"
+if [[ $TRAVIS_TAG != "" ]]; then
+    IMAGE_TAG=$TRAVIS_TAG
+fi
+
+echo "building docker container for ${IMAGE_NAME}:${IMAGE_TAG},${VERSION} ..."
+
+docker build -t $IMAGE_NAME:$VERSION .
+docker tag "${IMAGE_NAME}:${VERSION}" "${IMAGE_NAME}:${IMAGE_TAG}"
+docker push "${IMAGE_NAME}:${IMAGE_TAG}"
+docker push "${IMAGE_NAME}:${VERSION}"


### PR DESCRIPTION
- this PR introduces build stages: lint, test and deploy
- a deploy job for creating and pushing a docker image for nightly builds have been added.
- as the unit tests are a but picky some changes for them are included too, but is still can happen that the test fails, needs further investigation, but this PR improves the situation already

Whats is needed to make the docker builds/pushes work is a dedicated docker-hub account that is allowed to push to cometvisu/cometvisu. The credentials of this account need to be added as encrypted envronment variables to travis, like this (travis cli client is needed):

```
travis env set DOCKER_USER myusername
travis env set DOCKER_PASS secretsecret
```

This command line need to be executes in the local clone of the cometvisu-repo.