### PR TITLE
Allow external files to be loaded:

### DIFF
--- a/doc/manual/de/config/customizing.rst
+++ b/doc/manual/de/config/customizing.rst
@@ -69,6 +69,7 @@ Hier wurden vorher die Icons in einem eigenen Unterverzeichnis abgelegt.
         </text>
     </pages>
 
+.. _custom_css:
 
 Einzelne Widgets durch CSS-Klassen verändern
 --------------------------------------------
@@ -121,6 +122,8 @@ Ein CometVisu Design besteht mindestens aus folgenden Dateien:
     Diese erhält man in dem man das Git-Repository klont, `./generate source` ausführt (einmalig nach klonen und jedesmal,
     wenn eine neue Datei für das Design hinzugefügt wird).
 
+
+.. _custom_plugins:
 
 Eigene Widgets schreiben über Plugins
 -------------------------------------

--- a/doc/manual/de/config/customizing.rst
+++ b/doc/manual/de/config/customizing.rst
@@ -12,7 +12,7 @@ werden die verschiedenen Möglichkeiten - sortiert nach Komplexitätsgrad - im D
 1.    Eigene CSS-Regeln                Optisch             Überschreiben der vorhandenen CSS-Regeln eines Designs durch das Laden von zusätzlichen CSS-Dateien.
 2.    Eigene Icons einbinden           Optisch             Neben den mitgelieferten Icons können eigene Icons über die Konfigurationsdatei hinzugefügt werden.
 3.    Widgets durch ``class``          Optisch             Viele Widgets können individualisiert werden durch Hinzufügen des ``class`` Attributs und dazu passenden CSS-Regeln.
-4.    Eigenes Design schreiben         Optisch             Sollten zusätzliche CSS-Regeln nicht ausreichen, kann ein neuen Design erstellt werden.
+4.    Eigenes Design schreiben         Optisch             Sollten zusätzliche CSS-Regeln nicht ausreichen, kann ein neues Design erstellt werden.
 5.    Eigene Widgets schreiben         Inhaltlich          Hinzufügen neuer Widgets durch Plugins.
 6.    Eigene Struktur schreiben        Inhaltlich          Die Umwandlung der Konfigurationsdateien in HTML-Code, kann durch erstellen einer neuen Struktur komplett verändert werden.
 ===   =============================    ================    ===================================================
@@ -29,8 +29,8 @@ können dazu Pfade zu CSS-Dateien angegben werden, die zusätzlich zu den CSS-Da
     <pages... design="metal">
         <meta>
             <files>
-                <file type="css">resource/my-custom-style.css</file>
-                <file type="css">resource/my-other-custom-style.css</file>
+                <file type="css">resource/config/media/my-custom-style.css</file>
+                <file type="css">resource/config/media/my-other-custom-style.css</file>
                 ...
             </files>
             ...

--- a/doc/manual/de/config/customizing.rst
+++ b/doc/manual/de/config/customizing.rst
@@ -9,12 +9,12 @@ werden die verschiedenen Möglichkeiten - sortiert nach Komplexitätsgrad - im D
 ===   =============================    ================    ===================================================
 \     Anpassung                        Veränderung          Beschreibung
 ===   =============================    ================    ===================================================
-1.    Eigene CSS-Regeln                Optisch             Überschreiben der vorhandenen CSS-Regeln eines Designs durch das Laden von zusätzlichen CSS-Dateien
-2.    Eigene Icons einbinden           Optisch             Neben den mitgelieferten Icons können eigenen Icons über die Konfigurationsdatei hinzugefügt werden
-3.    Widgets durch ``class``          Optisch             Viele Widgets können individualisiert werden durch Hinzufügen des ``class`` Attributs und dazu passenden CSS-Regeln
-4.    Eigenes Design schreiben         Optisch             Sollten zusätzliche CSS-Regeln nicht ausreichen, kann ein neuen Design erstellt werden
+1.    Eigene CSS-Regeln                Optisch             Überschreiben der vorhandenen CSS-Regeln eines Designs durch das Laden von zusätzlichen CSS-Dateien.
+2.    Eigene Icons einbinden           Optisch             Neben den mitgelieferten Icons können eigene Icons über die Konfigurationsdatei hinzugefügt werden.
+3.    Widgets durch ``class``          Optisch             Viele Widgets können individualisiert werden durch Hinzufügen des ``class`` Attributs und dazu passenden CSS-Regeln.
+4.    Eigenes Design schreiben         Optisch             Sollten zusätzliche CSS-Regeln nicht ausreichen, kann ein neuen Design erstellt werden.
 5.    Eigene Widgets schreiben         Inhaltlich          Hinzufügen neuer Widgets durch Plugins.
-6.    Eigene Struktur schreiben        Inhaltlich          Die Umwandlung der Konfigurationsdateien in HTML-Code, kann durch erstellen einer neuen Struktur komplett verändert werden
+6.    Eigene Struktur schreiben        Inhaltlich          Die Umwandlung der Konfigurationsdateien in HTML-Code, kann durch erstellen einer neuen Struktur komplett verändert werden.
 ===   =============================    ================    ===================================================
 
 Vorhandenes Design verändern
@@ -41,15 +41,16 @@ können dazu Pfade zu CSS-Dateien angegben werden, die zusätzlich zu den CSS-Da
 .. HINT::
     In früheren CometVisu-Versionen (<= 0.10.x) mussten die CSS-Regeln in die ``custom.css`` Datei des jeweiligen
     Designs eingetragen werden. Auch wenn dies weiterhin funktioniert, wird empfohlen diese Regeln in eine neue Datei zu kopieren
-    und über den hier beschriebenen Weg einzubinden.
+    und über den hier beschriebenen Weg einzubinden. Der alte Weg wird nur aus kompabilitätsgründen aufrecht erhalten und
+    in zukünftigen Versionen entfernt werden.
 
 
 Eigene Icons einbinden
 ----------------------
 
-Mit dieser Option wird der Name des Icons definiert, welches sich unter dem in uri angegebenen Verzeichnis befindet.
+Mit dieser Option wird der Name des Icons definiert, welches sich unter dem in ``uri`` angegebenen Verzeichnis befindet.
 Auf die so definierten Icons kann dann im weiteren Verlauf über den einfacher zu merkenden Namen zugegriffen werden.
-Die Verzeichnisangabe ist im Beispiel relativ zur CV installation.
+Die Verzeichnisangabe ist im Beispiel relativ zur CV Installation.
 Hier wurden vorher die Icons in einem eigenen Unterverzeichnis abgelegt.
 
 .. code-block:: xml
@@ -59,7 +60,7 @@ Hier wurden vorher die Icons in einem eigenen Unterverzeichnis abgelegt.
         <meta>
             ...
             <icons>
-                <icon-definition name="Icon1" uri="./icon/unterverzeichnis/icon1.png"/>
+                <icon-definition name="Icon1" uri="./resource/config/media/icon1.png"/>
             </icons>
             ...
         </meta>
@@ -88,7 +89,7 @@ CSS-Regeln benutzt werden kann. Hierdurch hat man die Möglichkeit etwas gezielt
     <pages... design="metal">
         <meta>
             <files>
-                <file type="css">resource/my-custom-style.css</file>
+                <file type="css">resource/config/media/my-custom-style.css</file>
             </files>
             ...
         </meta>
@@ -98,7 +99,7 @@ CSS-Regeln benutzt werden kann. Hierdurch hat man die Möglichkeit etwas gezielt
     </pages>
 
 .. code-block:: css
-    :caption: CSS-Regeln für das Switch-Widget in der `resource/my-custom-style.css` Datei
+    :caption: CSS-Regeln für das Switch-Widget in der `resource/config/media/my-custom-style.css` Datei
 
     .switch.custom_fancy {
         color: pink;
@@ -114,7 +115,7 @@ komplett neues Design zu schreiben.
 Ein CometVisu Design besteht mindestens aus folgenden Dateien:
 
 * *basic.css*: Haupt CSS Datei mit allen Regeln, die für das Design benötigt werden
-* *mobile.css*: CSS-Regeln für Mobilgeräte mit kleinem Bildschirm
+* *mobile.css*: CSS-Regeln für Mobilgeräte mit kleinem Bildschirm (kann leer sein)
 * *design_setup.js*: Optionale Javascript Datei, die Anpassungen vornehmen kann die über CSS nicht möglich sind (kann leer sein)
 
 .. HINT::
@@ -130,7 +131,7 @@ Eigene Widgets schreiben über Plugins
 
 Neue Widgets können über Plugins hinzugefügt werden. Dies ist ein guter Einstiegspunkt in die CometVisu Entwicklung,
 da man die Möglichkeiten des Systems kennen lernt. Als Dokumentation der Möglichkeiten eines eigenen Widgets kann der
-Source-Code der vorhandenen Plugins. In diesem Kapitel soll es eher darum gehen, auf welche Wege man ein solches Plugin
+Source-Code der vorhandenen Plugins dienen. In diesem Kapitel soll es eher darum gehen, auf welche Wege man ein solches Plugin
 in die CometVisu einbinden kann.
 
 Hier wird zwischen zwei Wegen unterschieden, wie Plugins in die CometVisu eingebunden werden.
@@ -170,9 +171,9 @@ Aufbau eines Widgets
 Um ein neues Widget hinzuzufügen werden drei Dinge benötigt:
 
 1. Ein *Parser*, der die Widgetdefinition aus der XML-Konfigurationsdatei auslesen kann
-2. Eine *Widgetklasse*, die die Daten von Parser erhält und daraus HTML-Code erzeugt, der in die GUI eingebunden wird.
+2. Eine *Widgetklasse*, die die Daten vom Parser erhält und daraus HTML-Code erzeugt, der in die GUI eingebunden wird.
    Außerdem wird in der Klasse alles behandelt, was das Widget benötigt. Dazu gehört z.B. das Erkennen von Benutzerinteraktionen
-   und daraus resultierenden Statusupdates, die zum Backend gesendet werden, oder aber auch das darstellen von Statusupdates, die
+   und daraus resultierenden Statusupdates, die zum Backend gesendet werden, oder aber auch das Darstellen von Statusupdates, die
    vom Backend empfangen werden.
 3. Eine *XSD-Schema* Definition, die die Struktur des Widgets in der XML-Konfigurationsdatei beschreibt (bei Eigenständigen Plugins nicht erforderlich)
 
@@ -230,10 +231,10 @@ Ein einfaches Beispiel, für ein neuen Widget, welches per Plugin eingebunden we
 
 Diese Datei stellt ein Widget zur Verfügung, welches der GUI ein Überschriftelement mit beliebigem Text hinzufügt.
 Es kann in der Konfigurationsdatei als ``<headline>...</headline>`` benutzt werden. Wichtig ist hier, dass das
-Widget in der Konfigurationsdatei immer in ein ``<custom>`` Element eingebettet wird. Da für dieses Eigenständige
+Widget in der Konfigurationsdatei immer in ein ``<custom>`` Element eingebettet wird. Da für dieses eigenständige
 Plugin keine Schema-Definition existiert, ist dieser zusätzliche Schritt nötig, damit die Konfigurationsdatei von
 einem Schema-Validator nicht als ungültig markiert wird.
-Um dieses Plugin benutzen zu können sind, muss die Datei geladen werden.
+Um dieses Plugin benutzen zu können, muss die Datei geladen werden.
 
 .. code-block:: xml
 
@@ -264,7 +265,7 @@ Bisher existiert nur die ``pure``-Struktur in der CometVisu unter dem Pfad ``cv.
 alle Widgetklassen zu finden, die die CometVisu zur Verfügung stellt. Diese sind dafür verantwortlich aus einer
 von den *Parsern* ausgelesenen Konfigurationsdatei HTML-Code zu generieren.
 
-Durch eine neue Struktur der erzeugte HTML-Code ändern, muss man zusätzlich auch immer ein neues Design für diese
+Durch eine neue Struktur ändert sich der erzeugte HTML-Code, daher muss man zusätzlich auch immer ein neues Design für diese
 Struktur schreiben.
 
 .. HINT::

--- a/doc/manual/de/config/customizing.rst
+++ b/doc/manual/de/config/customizing.rst
@@ -10,10 +10,11 @@ werden die verschiedenen Möglichkeiten - sortiert nach Komplexitätsgrad - im D
 \     Anpassung                        Veränderung          Beschreibung
 ===   =============================    ================    ===================================================
 1.    Eigene CSS-Regeln                Optisch             Überschreiben der vorhandenen CSS-Regeln eines Designs durch das Laden von zusätzlichen CSS-Dateien
-2.    Widgets durch ``class``          Optisch             Viele Widgets können individualisiert werden durch Hinzufügen des ``class`` Attributs und dazu passenden CSS-Regeln
-3.    Eigene Widgets schreiben         Inhaltlich          Hinzufügen neuer Widgets durch Plugins.
+2.    Eigene Icons einbinden           Optisch             Neben den mitgelieferten Icons können eigenen Icons über die Konfigurationsdatei hinzugefügt werden
+3.    Widgets durch ``class``          Optisch             Viele Widgets können individualisiert werden durch Hinzufügen des ``class`` Attributs und dazu passenden CSS-Regeln
 4.    Eigenes Design schreiben         Optisch             Sollten zusätzliche CSS-Regeln nicht ausreichen, kann ein neuen Design erstellt werden
-5.    Eigene Struktur schreiben        Inhaltlich          Die Umwandlung der Konfigurationsdateien in HTML-Code, kann durch erstellen einer neuen Struktur komplett verändert werden
+5.    Eigene Widgets schreiben         Inhaltlich          Hinzufügen neuer Widgets durch Plugins.
+6.    Eigene Struktur schreiben        Inhaltlich          Die Umwandlung der Konfigurationsdateien in HTML-Code, kann durch erstellen einer neuen Struktur komplett verändert werden
 ===   =============================    ================    ===================================================
 
 Vorhandenes Design verändern
@@ -36,6 +37,38 @@ können dazu Pfade zu CSS-Dateien angegben werden, die zusätzlich zu den CSS-Da
         </meta>
         ...
     </pages>
+
+.. HINT::
+    In früheren CometVisu-Versionen (<= 0.10.x) mussten die CSS-Regeln in die ``custom.css`` Datei des jeweiligen
+    Designs eingetragen werden. Auch wenn dies weiterhin funktioniert, wird empfohlen diese Regeln in eine neue Datei zu kopieren
+    und über den hier beschriebenen Weg einzubinden.
+
+
+Eigene Icons einbinden
+----------------------
+
+Mit dieser Option wird der Name des Icons definiert, welches sich unter dem in uri angegebenen Verzeichnis befindet.
+Auf die so definierten Icons kann dann im weiteren Verlauf über den einfacher zu merkenden Namen zugegriffen werden.
+Die Verzeichnisangabe ist im Beispiel relativ zur CV installation.
+Hier wurden vorher die Icons in einem eigenen Unterverzeichnis abgelegt.
+
+.. code-block:: xml
+    :caption: Hinzufügen eines zusätzlichen Icons
+
+    <pages...>
+        <meta>
+            ...
+            <icons>
+                <icon-definition name="Icon1" uri="./icon/unterverzeichnis/icon1.png"/>
+            </icons>
+            ...
+        </meta>
+        ...
+        <text>
+          <label><icon name="Icon1"></icon></label>
+        </text>
+    </pages>
+
 
 Einzelne Widgets durch CSS-Klassen verändern
 --------------------------------------------
@@ -71,7 +104,167 @@ CSS-Regeln benutzt werden kann. Hierdurch hat man die Möglichkeit etwas gezielt
     }
 
 
+Eigenes Design schreiben
+------------------------
+
+Neben den bereits beschriebenen Möglichkeiten der optischen Anpassungen, besteht als weitergehende Möglichkeit ein
+komplett neues Design zu schreiben.
+
+Ein CometVisu Design besteht mindestens aus folgenden Dateien:
+
+* *basic.css*: Haupt CSS Datei mit allen Regeln, die für das Design benötigt werden
+* *mobile.css*: CSS-Regeln für Mobilgeräte mit kleinem Bildschirm
+* *design_setup.js*: Optionale Javascript Datei, die Anpassungen vornehmen kann die über CSS nicht möglich sind (kann leer sein)
+
+.. HINT::
+    Um ein neues Design entwickeln und testen zu können, ist die Source-Version der CometVisu erfolderlich.
+    Diese erhält man in dem man das Git-Repository klont, `./generate source` ausführt (einmalig nach klonen und jedesmal,
+    wenn eine neue Datei für das Design hinzugefügt wird).
+
+
 Eigene Widgets schreiben über Plugins
 -------------------------------------
 
-Neue Widgets können über Plugins
+Neue Widgets können über Plugins hinzugefügt werden. Dies ist ein guter Einstiegspunkt in die CometVisu Entwicklung,
+da man die Möglichkeiten des Systems kennen lernt. Als Dokumentation der Möglichkeiten eines eigenen Widgets kann der
+Source-Code der vorhandenen Plugins. In diesem Kapitel soll es eher darum gehen, auf welche Wege man ein solches Plugin
+in die CometVisu einbinden kann.
+
+Hier wird zwischen zwei Wegen unterschieden, wie Plugins in die CometVisu eingebunden werden.
+
+1. **Eingebettete Plugins**: Plugins, die mit der CometVisu ausgeliefert werden und deren Build-Prozess mit durchlaufen
+
+    *Vorteile:*
+
+    * Sind Teil der CometVisu und stehen somit allen Benutzern zur Verfügung. Kompabilität mit zukünftigen CometVisu-Versionen ist in der Regel gewährleistet.
+    * Der Code wird beim Erstellen des CometVisu-Releases optimiert und minifiziert, was die Ladezeit verkürzt
+    * Die Benutzung weiterer Hilfsklassen aus dem Qooxdoo-Framework ist problemlos möglich.
+    * Teil der Versionsverwaltung Git: alle Änderungen am Code werden erfasst und können bei Fehler wieder rückgängig gemacht werden.
+
+    *Nachteile:*
+
+    * Zusätzliche Konfiguration nötig, damit die Plugins mit der CometVisu ausgeliefert werden können
+    * Zur Entwicklung wird die Source-Version der CometVisu benötigt
+    * Git-Kenntnisse erforderlich
+
+2. **Eigenständige Plugins**: Hierbei handelt es sich um Javascript-Dateien, die von der CometVisu beim Initialisieren nachgeladen werden
+
+    *Vorteile:*
+
+    * Einfache Einbindung
+    * Kann mit einem Release der CometVisu benutzt und entwickelt werden
+
+    *Nachteile:*
+
+    * Sind nicht Teil der CometVisu, der Benutzer muss sich selbst um Kompabilität mit zukünftigen CometVisu-Versionen kümmern.
+    * Keine Code-Optimierungen möglich
+    * Zusätzliche Abhängigkeiten zu Qooxdoo-Klassen nicht möglich (was nicht Teil der CometVisu ist, kann nicht benutzt werden)
+
+
+Aufbau eines Widgets
+~~~~~~~~~~~~~~~~~~~~
+
+Um ein neues Widget hinzuzufügen werden drei Dinge benötigt:
+
+1. Ein *Parser*, der die Widgetdefinition aus der XML-Konfigurationsdatei auslesen kann
+2. Eine *Widgetklasse*, die die Daten von Parser erhält und daraus HTML-Code erzeugt, der in die GUI eingebunden wird.
+   Außerdem wird in der Klasse alles behandelt, was das Widget benötigt. Dazu gehört z.B. das Erkennen von Benutzerinteraktionen
+   und daraus resultierenden Statusupdates, die zum Backend gesendet werden, oder aber auch das darstellen von Statusupdates, die
+   vom Backend empfangen werden.
+3. Eine *XSD-Schema* Definition, die die Struktur des Widgets in der XML-Konfigurationsdatei beschreibt (bei Eigenständigen Plugins nicht erforderlich)
+
+Jedes Widget in der CometVisu besteht aus diesen drei Dingen. Bei den Standard-Widgets sind der *Parser* und die *Widgetklasse* in zwei verschiedenen
+Dateien aufgeteilt, bei Plugins ist beides in einer Datei. Die Schemadefinitionen finden sich alle in der ``visu_config.xsd`` Datei.
+
+.. HINT::
+    Die Aufteilung der *Parser* und *Widgetklassen* in zwei Dateien bietet den Vorteil, dass es so einfacher möglich ist, die Widgetklassen auszutauschen.
+    Alle Standard-Widgetklassen sind zusammengefasst in einer Struktur namens ``Pure``. Es besteht die Möglichkeit diese Struktur durch eine andere auszutauschen.
+    Damit man in einem solchen Fall nicht auch alle Parser neu programmieren muss, wurde diese Trennung vorgenommen.
+
+
+Beispielplugin
+~~~~~~~~~~~~~~
+
+Ein einfaches Beispiel, für ein neuen Widget, welches per Plugin eingebunden werden kann ist in der ``resource/config/structure_custom.js`` zu finden.
+
+.. code-block:: javascript
+
+    qx.Class.define('cv.ui.structure.pure.Headline', {
+      extend: cv.ui.structure.AbstractWidget,
+
+      statics: {
+        // parse element from visu_config*.xml
+        parse: function (xml, path, flavour, pageType) {
+          var data = cv.parser.WidgetParser.parseElement(this, xml, path, flavour, pageType);
+          data.content = xml.textContent;
+          return data;
+        }
+      },
+
+      properties: {
+        content: {
+          check: 'String',
+            init: ''
+        }
+      },
+
+      members: {
+        // generate the DOM string to be added to the GUI
+        getDomString: function () {
+          return '<h1 ' + (this.getClasses() ? 'class="'+this.getClasses()+'"' : '') + '>' + this.getContent() + '</h1>';
+        }
+      },
+
+      // this function is executed when this file is loaded
+      defer: function(statics) {
+        // register the parser
+        cv.parser.WidgetParser.addHandler("headline", cv.ui.structure.pure.Headline);
+        // register the widget
+        cv.ui.structure.WidgetFactory.registerClass("headline", statics);
+      }
+    });
+
+
+Diese Datei stellt ein Widget zur Verfügung, welches der GUI ein Überschriftelement mit beliebigem Text hinzufügt.
+Es kann in der Konfigurationsdatei als ``<headline>...</headline>`` benutzt werden. Wichtig ist hier, dass das
+Widget in der Konfigurationsdatei immer in ein ``<custom>`` Element eingebettet wird. Da für dieses Eigenständige
+Plugin keine Schema-Definition existiert, ist dieser zusätzliche Schritt nötig, damit die Konfigurationsdatei von
+einem Schema-Validator nicht als ungültig markiert wird.
+Um dieses Plugin benutzen zu können sind, muss die Datei geladen werden.
+
+.. code-block:: xml
+
+    <pages...>
+        <meta>
+            <files>
+                <file type="js" content="plugin">resource/config/structure_custom.js</file>
+                ...
+            </files>
+            ...
+        </meta>
+        ...
+        <custom>
+            <headline>Mein neues Widget!</headline>
+        </custom>
+    </pages>
+
+Damit die CometVisu erkennt, dass die Datei ein Eigenständiges Plugin bereitstellt muss diese mit den Attributen
+``type="js" content="plugin"`` angegeben werden. Geschieht dies nicht, kann es passieren, dass die Datei zu einem falschen
+Zeitpunkt geladen wird und dann aufgrund eines Fehlers nicht nutzbar ist.
+
+
+Eigene Struktur schreiben
+-------------------------
+
+Wenn der von der CometVisu erzeugte HTML-Code geändert werden soll, muss man eine neue Struktur schreiben.
+Bisher existiert nur die ``pure``-Struktur in der CometVisu unter dem Pfad ``cv.ui.structure.pure``. Darin sind
+alle Widgetklassen zu finden, die die CometVisu zur Verfügung stellt. Diese sind dafür verantwortlich aus einer
+von den *Parsern* ausgelesenen Konfigurationsdatei HTML-Code zu generieren.
+
+Durch eine neue Struktur der erzeugte HTML-Code ändern, muss man zusätzlich auch immer ein neues Design für diese
+Struktur schreiben.
+
+.. HINT::
+  Das Schreiben einer neuen Struktur ist zwar vorgesehen, wurde aber bisher noch nie umgesetzt.
+  Daher ist es durchaus möglich, dass hier weitere Vorarbeiten erforderlich sind, um die Strukturen einfach austauschen
+  zu können.

--- a/doc/manual/de/config/customizing.rst
+++ b/doc/manual/de/config/customizing.rst
@@ -1,0 +1,77 @@
+.. _customizing:
+
+Anpassungen vornehmen
+=====================
+
+Die CometVisu kann auf viele verschiedene Weisen an die eigenen Bedürfnisse angepasst werden. Im Folgenden
+werden die verschiedenen Möglichkeiten - sortiert nach Komplexitätsgrad - im Detail beschrieben.
+
+===   =============================    ================    ===================================================
+\     Anpassung                        Veränderung          Beschreibung
+===   =============================    ================    ===================================================
+1.    Eigene CSS-Regeln                Optisch             Überschreiben der vorhandenen CSS-Regeln eines Designs durch das Laden von zusätzlichen CSS-Dateien
+2.    Widgets durch ``class``          Optisch             Viele Widgets können individualisiert werden durch Hinzufügen des ``class`` Attributs und dazu passenden CSS-Regeln
+3.    Eigene Widgets schreiben         Inhaltlich          Hinzufügen neuer Widgets durch Plugins.
+4.    Eigenes Design schreiben         Optisch             Sollten zusätzliche CSS-Regeln nicht ausreichen, kann ein neuen Design erstellt werden
+5.    Eigene Struktur schreiben        Inhaltlich          Die Umwandlung der Konfigurationsdateien in HTML-Code, kann durch erstellen einer neuen Struktur komplett verändert werden
+===   =============================    ================    ===================================================
+
+Vorhandenes Design verändern
+----------------------------
+
+Die vorhandenen Designs können durch eigene CSS-Regeln angepasst werden. Im Meta-Bereich der Konfigurationsdatei
+können dazu Pfade zu CSS-Dateien angegben werden, die zusätzlich zu den CSS-Dateien des CometVisu-Designs geladen werden.
+
+.. code-block:: xml
+    :caption: Auszug einer Konfigurationsdatei, die 2 zusätzliche CSS-Dateien lädt:
+
+    <pages... design="metal">
+        <meta>
+            <files>
+                <file type="css">resource/my-custom-style.css</file>
+                <file type="css">resource/my-other-custom-style.css</file>
+                ...
+            </files>
+            ...
+        </meta>
+        ...
+    </pages>
+
+Einzelne Widgets durch CSS-Klassen verändern
+--------------------------------------------
+
+Bei vielen Widgets ist es möglich in der Konfigurationsdatei ein ``class`` Attribut anzugeben, welches dann für eigene
+CSS-Regeln benutzt werden kann. Hierdurch hat man die Möglichkeit etwas gezielter einzelne Widgets optisch zu verändern.
+
+.. HINT::
+    Der Wert des in der Konfigurationsdatei angegebenen ``class`` Attribut wird mit einem ``custom_`` Präfix versehen.
+    Also aus ``<switch class="fancy"..`` wird der HTML-Code ``<div class="switch custom_fancy"...``
+
+
+.. code-block:: xml
+    :caption: Ein individualisiertes Switch-Widget
+
+    <pages... design="metal">
+        <meta>
+            <files>
+                <file type="css">resource/my-custom-style.css</file>
+            </files>
+            ...
+        </meta>
+        <page>
+            <switch class="fancy">...</switch>
+        </page>
+    </pages>
+
+.. code-block:: css
+    :caption: CSS-Regeln für das Switch-Widget in der `resource/my-custom-style.css` Datei
+
+    .switch.custom_fancy {
+        color: pink;
+    }
+
+
+Eigene Widgets schreiben über Plugins
+-------------------------------------
+
+Neue Widgets können über Plugins

--- a/doc/manual/de/config/index.rst
+++ b/doc/manual/de/config/index.rst
@@ -238,3 +238,4 @@ sonstiges
     notifications
     rrd_examples
     hydraulik
+    customizing

--- a/doc/manual/de/config/xml-format.rst
+++ b/doc/manual/de/config/xml-format.rst
@@ -59,8 +59,8 @@ Option                       Beschreibung                                   Wert
 
     <meta>
         <files>
-            <file type="css">resource/style.css</file>
-            <file type="js" content="plugin">resource/MyCustomWidget.js</file>
+            <file type="css">resource/config/media/style.css</file>
+            <file type="js" content="plugin">resource/config/media/MyCustomWidget.js</file>
         </plugins>
         ...
     </meta>

--- a/doc/manual/de/config/xml-format.rst
+++ b/doc/manual/de/config/xml-format.rst
@@ -43,6 +43,30 @@ einzuhalten!
 
 Nachstehend wird werden der Reihe nach ein Überblick über die Optionen im meta-tag gegeben.
 
+.. _xml-format_files:
+
+Zusätzliche Dateien einbinden
+-----------------------------
+
+===========================  ============================================   =================================  ===============
+Option                       Beschreibung                                   Werte                              Zwingend
+===========================  ============================================   =================================  ===============
+``<file type=" "></file>``   Mit dieser Option können zusätzliche Dateien   Pfad zur Datei                     NEIN
+                             (CSS oder Javascript) geladen werden
+===========================  ============================================   =================================  ===============
+
+.. code-block:: xml
+
+    <meta>
+        <files>
+            <file type="css">resource/style.css</file>
+            <file type="js" content="plugin">resource/MyCustomWidget.js</file>
+        </plugins>
+        ...
+    </meta>
+
+Siehe auch :ref:`custom_css` und :ref:`custom_plugins`.
+
 .. _xml-format_plugins:
 
 Plugins

--- a/source/class/cv/Application.js
+++ b/source/class/cv/Application.js
@@ -84,6 +84,15 @@ qx.Class.define("cv.Application",
   properties: {
     root: {
       nullable: true
+    },
+
+    /**
+     * true when structure part has been loaded
+     */
+    structureLoaded: {
+      check: 'Boolean',
+      init: false,
+      event: 'changeStructureLoaded'
     }
   },
 
@@ -418,8 +427,10 @@ qx.Class.define("cv.Application",
           engine.loadParts([structure], function(states) {
             if (states === "complete") {
               this.debug(structure + " has been loaded");
+              this.setStructureLoaded(true);
             } else {
               this.error(structure + " could not be loaded");
+              this.setStructureLoaded(false);
             }
           }, this);
 
@@ -512,31 +523,59 @@ qx.Class.define("cv.Application",
     loadPlugins: function() {
       var plugins = cv.Config.configSettings.pluginsToLoad;
       if (plugins.length > 0) {
+        var standalonePlugins = [];
+        var partsLoaded = false;
+        var allPluginsQueued = false;
         this.debug("loading plugins");
         var engine = cv.TemplateEngine.getInstance();
         engine.addListener("changePartsLoaded", function(ev) {
           if (ev.getData() === true) {
             this.debug("plugins loaded");
-            qx.event.Timer.once(function() {
-              cv.util.ScriptLoader.getInstance().setAllQueued(true);
-            }, this, 0);
+            partsLoaded = true;
+            if (allPluginsQueued) {
+              qx.event.Timer.once(function () {
+                cv.util.ScriptLoader.getInstance().setAllQueued(true);
+              }, this, 0);
+            }
           }
         }, this);
         var parts = qx.Part.getInstance().getParts();
         var partPlugins = [];
-        var standalonePlugins = [];
         var path = qx.util.LibraryManager.getInstance().get('cv', 'resourceUri');
         plugins.forEach(function(plugin) {
           if (parts.hasOwnProperty(plugin)) {
             partPlugins.push(plugin);
+          } else if (!plugin.startsWith('plugin-')) {
+            // a real path
+            standalonePlugins.push(plugin);
           } else {
             standalonePlugins.push(path + "/plugins/" + plugin.replace("plugin-", "") + "/index.js");
           }
         });
         // load part plugins
         engine.loadParts(partPlugins);
-        // load script plugins
-        cv.util.ScriptLoader.getInstance().addScripts(standalonePlugins);
+
+        if (standalonePlugins.length > 0) {
+          // load standalone plugins after the structure parts has been loaded
+          // because they use need the classes provided by it
+          if (this.getStructureLoaded()) {
+            cv.util.ScriptLoader.getInstance().addScripts(standalonePlugins);
+          } else {
+            var lid = this.addListener('changeStructureLoaded', function (ev) {
+              if (ev.getData() === true) {
+                allPluginsQueued = true;
+                this.debug('loading standalone plugins');
+                cv.util.ScriptLoader.getInstance().addScripts(standalonePlugins);
+                if (partsLoaded) {
+                  cv.util.ScriptLoader.getInstance().setAllQueued(true);
+                }
+                this.removeListenerById(lid);
+              }
+            }, this);
+          }
+        } else {
+          allPluginsQueued = true;
+        }
       } else {
         this.debug("no plugins to load => all scripts queued");
         cv.util.ScriptLoader.getInstance().setAllQueued(true);

--- a/source/class/cv/TemplateEngine.js
+++ b/source/class/cv/TemplateEngine.js
@@ -144,6 +144,9 @@ qx.Class.define('cv.TemplateEngine', {
           if (states[idx] === "complete") {
             this.__partQueue.remove(part);
             this.debug("successfully loaded part "+part);
+            if (part.startsWith('structure-')) {
+              qx.core.Init.getApplication().setStructureLoaded(true);
+            }
           } else {
             this.error("error loading part "+part);
           }

--- a/source/class/cv/parser/MetaParser.js
+++ b/source/class/cv/parser/MetaParser.js
@@ -29,6 +29,9 @@ qx.Class.define("cv.parser.MetaParser", {
   members: {
 
     parse: function(xml) {
+      // parse external files
+      this.parseFiles(xml);
+
       // parse the icons
       qx.bom.Selector.query('meta > icons icon-definition', xml).forEach(this.parseIcons, this);
 
@@ -42,6 +45,40 @@ qx.Class.define("cv.parser.MetaParser", {
       qx.bom.Selector.query('meta > statusbar status', xml).forEach(this.parseStatusBar, this);
 
       this.parseStateNotifications(xml);
+    },
+
+    parseFiles: function (xml) {
+      var files = {
+        css: [],
+        js: []
+      };
+      qx.bom.Selector.query('meta > files file', xml).forEach(function (elem) {
+        var type = qx.bom.element.Attribute.get(elem, 'type');
+        var content = qx.bom.element.Attribute.get(elem, 'content');
+        switch (type) {
+          case 'css':
+            files.css.push(qx.bom.element.Attribute.get(elem, 'text'));
+            break;
+
+          case 'js':
+            if (content === 'plugin') {
+              cv.Config.configSettings.pluginsToLoad.push(qx.bom.element.Attribute.get(elem, 'text'));
+            } else {
+              files.js.push(qx.bom.element.Attribute.get(elem, 'text'));
+            }
+            break;
+
+          default:
+            this.warn('ignoring unknown file type', type);
+            break;
+        }
+      }, this);
+      if (files.css.length > 0) {
+        cv.util.ScriptLoader.getInstance().addStyles(files.css);
+      }
+      if (files.js.length > 0) {
+        cv.util.ScriptLoader.getInstance().addScripts(files.js);
+      }
     },
 
     parseIcons: function(elem) {

--- a/source/class/cv/parser/WidgetParser.js
+++ b/source/class/cv/parser/WidgetParser.js
@@ -52,12 +52,18 @@ qx.Class.define('cv.parser.WidgetParser', {
      * @return {Map} widget data
      */
     parse: function (xml, path, flavour, pageType) {
-      var parser = this.getHandler(xml.nodeName);
+      var tag = xml.nodeName.toLowerCase();
+      if (tag === 'custom') {
+        // use the child of the custom element
+        xml = xml.children[0];
+        tag = xml.nodeName.toLowerCase();
+      }
+      var parser = this.getHandler(tag);
       var result = null;
       if (parser) {
         result = parser.parse(xml, path, flavour, pageType);
       } else {
-        qx.log.Logger.debug(this, "no parse handler registered for type: "+ xml.nodeName.toLowerCase());
+        qx.log.Logger.debug(this, "no parse handler registered for type: "+ tag.toLowerCase());
       }
       return result;
     },

--- a/source/class/cv/util/ScriptLoader.js
+++ b/source/class/cv/util/ScriptLoader.js
@@ -31,6 +31,7 @@ qx.Class.define('cv.util.ScriptLoader', {
     this.base(arguments);
     this.__scriptQueue = new qx.data.Array();
     this.__loaders = new qx.data.Array();
+    this.__delayedScriptQueue = new qx.data.Array();
   },
 
   /*
@@ -179,10 +180,15 @@ qx.Class.define('cv.util.ScriptLoader', {
         } else if (!this.__listener) {
           this.debug("script loader waiting for all scripts beeing queued");
 
-          this.__listener = this.addListenerOnce("changeAllQueued", function() {
-            this.debug("script loader finished");
-            this.fireEvent("finished");
-            this.__listener = null;
+          this.__listener = this.addListener("changeAllQueued", function(ev) {
+            if (ev.getData() === true) {
+              if (this.__scriptQueue.length === 0) {
+                this.debug("script loader finished");
+                this.fireEvent("finished");
+              }
+              this.removeListenerById(this.__listener);
+              this.__listener = null;
+            }
           }, this);
         }
       } else {

--- a/source/editor/lib/Configuration.js
+++ b/source/editor/lib/Configuration.js
@@ -432,8 +432,12 @@ var ConfigurationElement = function (node, parent) {
         var childName = child.name;
         // find the SchemaElement for this child
         var childSchemaElement = schemaElement.getSchemaElementForElementName(childName);
-                
-        if (childSchemaElement == undefined) {
+        if (childSchemaElement === undefined && schemaElement.name==='custom') {
+          // custom element allows any content so we just re-use the schemeElement here
+          childSchemaElement = schemaElement;
+        }
+
+        if (childSchemaElement === undefined) {
           // the xsd does not match, we are invalid
           throw 'xsd does not match this configuration, or configuration is not valid for ' + childName;
         }

--- a/source/editor/lib/Schema.js
+++ b/source/editor/lib/Schema.js
@@ -2062,6 +2062,11 @@ var SchemaSequence = function (node, schema) {
           subObject = new SchemaGroup(this, _schema)
           subGroupings.push(subObject);
           break;
+        case 'xsd:any':
+        case 'any':
+          subObject = new SchemaAny(this, _schema)
+          subGroupings.push(subObject);
+          break;
       }
             
       sortedContent.push(subObject);
@@ -2403,6 +2408,207 @@ var SchemaSequence = function (node, schema) {
 }
 
 
+/**
+ * any content.
+ *
+ * @param   node    DOMNode the group-node
+ * @param   schema  Schema  the corresponding schema
+ */
+var SchemaAny = function (node, schema) {
+  /**
+   * us
+   * @var object
+   */
+  var _group = this;
+
+  /**
+   * type of this object
+   * @var string
+   */
+  _group.type = 'any';
+
+
+
+  /**
+   * there are no elements in a group...
+   * @var boolean
+   */
+  _group.elementsHaveOrder = undefined;
+
+  /**
+   * parse a list of elements in this group.
+   * Group is allowed (all|choice|sequence)? as per the definition.
+   * We do all of those (except for 'all')
+   */
+  var parse = function () {
+    bounds = {
+      min: $n.attr('minOccurs') != undefined ? $n.attr('minOccurs') : 1, // default is 1
+      max: $n.attr('maxOccurs') != undefined ? $n.attr('maxOccurs') : 1, // default is 1
+    };
+
+    var $group = $n;
+    if ($group.is('[ref]')) {
+      // if this is a reference, unravel it.
+      $group = _schema.getReferencedNode('group', $group.attr('ref'));
+    }
+
+    // we are allowed choice and sequence, but only ONE AT ALL is allowed
+    $.each($group.find(fixNamespace('> xsd\\:choice')), function (i, grouping) {
+      subGroupings.push(new SchemaChoice(grouping, _schema));
+    });
+
+    // sequences
+    $.each($group.find(fixNamespace('> xsd\\:sequence')), function (i, grouping) {
+      subGroupings.push(new SchemaSequence(grouping, _schema));
+    });
+
+    // there may be only one, so we simply us the first we found
+    if (subGroupings.length > 0) {
+      subGroupings = [subGroupings[0]];
+    }
+  }
+
+  /**
+   * is an element (specified by its name) allowed in this group?
+   * Goes recursive.
+   * Does NOT check bounds! Does NOT check dependencies!
+   *
+   * @param   element string  the element we check for
+   * @return  boolean         is it allowed?
+   */
+  _group.isElementAllowed = function (element) {
+     return true;
+  }
+
+  /**
+   * get the SchemaElement-object for a certain element-name.
+   * May return undefined if no element is found, so you might be interested in checking isElementAllowed beforehand.
+   *
+   * @param   elementName string  name of the element to find the SchemaElement for
+   * @return  object              SchemaElement-object, or undefined if none is found
+   */
+  _group.getSchemaElementForElementName = function (elementName) {
+    // can not find any reason why elementName is allowed with us...
+    return undefined;
+  }
+
+
+  /**
+   * get a list of required elements.
+   * if an element is required multiple times, it is listed multiple times
+   *
+   * @return  array   list of required elements
+   */
+  _group.getRequiredElements = function () {
+    return [];
+  };
+
+  /**
+   * get the elements allowed for this group
+   *
+   * @return  object      list of allowed elements, key is the name
+   */
+  _group.getAllowedElements = function () {
+    return [];
+  }
+
+  /**
+   * get the sorting of the allowed elements.
+   * For a group, all elements have the same sorting, so they will all have the
+   * same sortnumber
+   *
+   * Warning: this only works if any element can have only ONE position in the parent.
+   *
+   * @param   sortnumber  integer the sortnumber of a parent (only used when recursive)
+   * @return  object              list of allowed elements, with their sort-number as value
+   */
+  _group.getAllowedElementsSorting = function (sortnumber) {
+    return {};
+  }
+
+  /**
+   * cache for getRegex
+   * @var string
+   */
+  var regexCache = undefined;
+
+  /**
+   * get a regex (string) describing this choice
+   *
+   * @param   separator   string  the string used to separate different elements, e.g. ';'
+   * @param   nocapture   bool    when set to true non capturing groups are used
+   * @return  string  regex
+   */
+  _group.getRegex = function (separator, nocapture) {
+    return '.*';
+  };
+
+
+  /**
+   * find out if this Grouping has multi-level-bounds, i.e. sub-groupings with bounds.
+   * This makes it more or less impossible to know in advance which elements might be needed
+   *
+   * @return  boolean does it?
+   */
+  _group.hasMultiLevelBounds = function () {
+    return true;
+  };
+
+
+  /**
+   * get the bounds of this very grouping
+   *
+   * @return  object  like {min: x, max: y}
+   */
+  _group.getBounds = function () {
+    return bounds;
+  }
+
+
+  /**
+   * get bounds for a specific element.
+   * Take into account the bounds of the element and/or our own bounds
+   *
+   * @param   childName   string  name of the child-to-be
+   * @return  object              {max: x, min: y}, or undefined if none found
+   */
+  _group.getBoundsForElementName = function (childName) {
+    return bounds;
+  };
+
+  /**
+   * our node
+   * @var object
+   */
+  var $n = $(node);
+
+  /**
+   * the schema we belong to
+   * @var object
+   */
+  var _schema = schema;
+  if (_schema == undefined) {
+    throw 'programming error, schema is not defined';
+  }
+
+  /**
+   * array of sub-choices, -sequences, -groups that are defined
+   * @var array
+   */
+  var subGroupings = [];
+
+  /**
+   * bounds for this choice
+   * @var object
+   */
+  var bounds = {
+    min: undefined,
+    max: undefined
+  };
+
+  // fill ourselves with data
+  parse();
+}
 
 
 /**

--- a/source/editor/lib/Schema.js
+++ b/source/editor/lib/Schema.js
@@ -808,6 +808,10 @@ var SchemaElement = function (node, schema) {
         case 'group':
           allowedContent._grouping = new SchemaGroup(tmpDOMGrouping, _schema);
           break;
+        case 'xsd:any':
+        case 'any':
+          allowedContent._grouping = new SchemaAny(tmpDOMGrouping, _schema)
+          break;
       }
             
       delete tmpDOMGrouping;

--- a/source/resource/config/structure_custom.js
+++ b/source/resource/config/structure_custom.js
@@ -23,14 +23,38 @@
 * Custom changes could go here and look e.g. like
 *
 ***************************************
-qx.Class.define('cv.ui.structure.pure.Line', {
+qx.Class.define('cv.ui.structure.pure.Headline', {
   extend: cv.ui.structure.AbstractWidget,
 
-  members: {
-    // overridden
-    getDomString: function () {
-      return '<hr ' + (this.getClasses() ? 'class="'+this.getClasses()+'"' : '') + '/>';
+  statics: {
+    // parse element from visu_config*.xml
+    parse: function (xml, path, flavour, pageType) {
+      var data = cv.parser.WidgetParser.parseElement(this, xml, path, flavour, pageType);
+      data.content = xml.textContent;
+      return data;
     }
+  },
+
+  properties: {
+    content: {
+      check: 'String',
+        init: ''
+    }
+  },
+
+  members: {
+    // generate the DOM string to be added to the GUI
+    getDomString: function () {
+      return '<h1 ' + (this.getClasses() ? 'class="'+this.getClasses()+'"' : '') + '>' + this.getContent() + '</h1>';
+    }
+  },
+
+  // this function is executed when this file is loaded
+  defer: function(statics) {
+    // register the parser
+    cv.parser.WidgetParser.addHandler("headline", cv.ui.structure.pure.Headline);
+    // register the widget
+    cv.ui.structure.WidgetFactory.registerClass("headline", statics);
   }
 });
 ****************************************

--- a/source/resource/visu_config.xsd
+++ b/source/resource/visu_config.xsd
@@ -1037,7 +1037,7 @@
 
   <!-- more fun part - all widgets - if you add a new widget, you need to define it here -->
 
-  <xsd:complexType name="custom">
+  <xsd:complexType name="custom" mixed="true">
     <xsd:sequence>
       <xsd:any processContents="lax"/>
     </xsd:sequence>

--- a/source/resource/visu_config.xsd
+++ b/source/resource/visu_config.xsd
@@ -465,36 +465,40 @@
     </xsd:choice>
   </xsd:complexType>
 
-  <xsd:complexType name="file" mixed="true">
-    <xsd:attribute name="type" use="required">
-      <xsd:annotation>
-        <xsd:documentation xml:lang="en">The type of the file to load</xsd:documentation>
-        <xsd:documentation xml:lang="de">Der Dateityp der zu ladenden Datei</xsd:documentation>
-      </xsd:annotation>
-      <xsd:simpleType>
-        <xsd:restriction base="xsd:string">
-          <xsd:enumeration value="css" />
-          <xsd:enumeration value="js" />
-        </xsd:restriction>
-      </xsd:simpleType>
-    </xsd:attribute>
-    <xsd:attribute name="content" use="optional">
-      <xsd:annotation>
-        <xsd:documentation xml:lang="en">Describes the content provided by the file to load. Important to determine the loading order of Javascript files</xsd:documentation>
-        <xsd:documentation xml:lang="de">Beschreibt den Inhalt der zu ladenden Datei. Dies ist wichtig für die Ladereihenfolge der Dateien</xsd:documentation>
-      </xsd:annotation>
-      <xsd:simpleType>
-        <xsd:restriction base="xsd:string">
-          <xsd:enumeration value="plugin">
-            <xsd:annotation>
-              <xsd:documentation xml:lang="en">Contains a new Widget.</xsd:documentation>
-              <xsd:documentation xml:lang="de">Enthält ein neues Widget</xsd:documentation>
-            </xsd:annotation>
-          </xsd:enumeration>
-          <xsd:enumeration value="js" />
-        </xsd:restriction>
-      </xsd:simpleType>
-    </xsd:attribute>
+  <xsd:complexType name="file">
+    <xsd:simpleContent>
+      <xsd:extension base="xsd:string">
+        <xsd:attribute name="type" use="required">
+          <xsd:annotation>
+            <xsd:documentation xml:lang="en">The type of the file to load</xsd:documentation>
+            <xsd:documentation xml:lang="de">Der Dateityp der zu ladenden Datei</xsd:documentation>
+          </xsd:annotation>
+          <xsd:simpleType>
+            <xsd:restriction base="xsd:string">
+              <xsd:enumeration value="css" />
+              <xsd:enumeration value="js" />
+            </xsd:restriction>
+          </xsd:simpleType>
+        </xsd:attribute>
+        <xsd:attribute name="content" use="optional">
+        <xsd:annotation>
+          <xsd:documentation xml:lang="en">Describes the content provided by the file to load. Important to determine the loading order of Javascript files</xsd:documentation>
+          <xsd:documentation xml:lang="de">Beschreibt den Inhalt der zu ladenden Datei. Dies ist wichtig für die Ladereihenfolge der Dateien</xsd:documentation>
+        </xsd:annotation>
+        <xsd:simpleType>
+          <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="plugin">
+              <xsd:annotation>
+                <xsd:documentation xml:lang="en">Contains a new Widget.</xsd:documentation>
+                <xsd:documentation xml:lang="de">Enthält ein neues Widget</xsd:documentation>
+              </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="js" />
+          </xsd:restriction>
+        </xsd:simpleType>
+      </xsd:attribute>
+      </xsd:extension>
+    </xsd:simpleContent>
   </xsd:complexType>
 
   <xsd:complexType name="plugins">

--- a/source/resource/visu_config.xsd
+++ b/source/resource/visu_config.xsd
@@ -1031,10 +1031,17 @@
       <xsd:element name="wgplugin_info" type="wgplugin_info"/>
       <xsd:element name="mobilemenu" type="mobilemenu"/>
       <xsd:element name="notificationcenterbadge" type="notificationcenterbadge"/>
+      <xsd:element name="custom" type="custom"/>
     </xsd:choice>
   </xsd:group>
 
   <!-- more fun part - all widgets - if you add a new widget, you need to define it here -->
+
+  <xsd:complexType name="custom">
+    <xsd:sequence>
+      <xsd:any processContents="lax"/>
+    </xsd:sequence>
+  </xsd:complexType>
 
   <xsd:complexType name="text">
     <xsd:sequence>

--- a/source/resource/visu_config.xsd
+++ b/source/resource/visu_config.xsd
@@ -465,7 +465,7 @@
     </xsd:choice>
   </xsd:complexType>
 
-  <xsd:complexType name="file">
+  <xsd:complexType name="file" mixed="true">
     <xsd:attribute name="type" use="required">
       <xsd:annotation>
         <xsd:documentation xml:lang="en">The type of the file to load</xsd:documentation>

--- a/source/resource/visu_config.xsd
+++ b/source/resource/visu_config.xsd
@@ -455,7 +455,46 @@
       <xsd:element name="stylings" type="stylings" />
       <xsd:element name="statusbar" type="statusbar" />
       <xsd:element name="notifications" type="notifications" />
+      <xsd:element name="files" type="files" />
     </xsd:choice>
+  </xsd:complexType>
+
+  <xsd:complexType name="files">
+    <xsd:choice minOccurs="0" maxOccurs="unbounded">
+      <xsd:element name="file" type="file" />
+    </xsd:choice>
+  </xsd:complexType>
+
+  <xsd:complexType name="file">
+    <xsd:attribute name="type" use="required">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">The type of the file to load</xsd:documentation>
+        <xsd:documentation xml:lang="de">Der Dateityp der zu ladenden Datei</xsd:documentation>
+      </xsd:annotation>
+      <xsd:simpleType>
+        <xsd:restriction base="xsd:string">
+          <xsd:enumeration value="css" />
+          <xsd:enumeration value="js" />
+        </xsd:restriction>
+      </xsd:simpleType>
+    </xsd:attribute>
+    <xsd:attribute name="content" use="optional">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">Describes the content provided by the file to load. Important to determine the loading order of Javascript files</xsd:documentation>
+        <xsd:documentation xml:lang="de">Beschreibt den Inhalt der zu ladenden Datei. Dies ist wichtig für die Ladereihenfolge der Dateien</xsd:documentation>
+      </xsd:annotation>
+      <xsd:simpleType>
+        <xsd:restriction base="xsd:string">
+          <xsd:enumeration value="plugin">
+            <xsd:annotation>
+              <xsd:documentation xml:lang="en">Contains a new Widget.</xsd:documentation>
+              <xsd:documentation xml:lang="de">Enthält ein neues Widget</xsd:documentation>
+            </xsd:annotation>
+          </xsd:enumeration>
+          <xsd:enumeration value="js" />
+        </xsd:restriction>
+      </xsd:simpleType>
+    </xsd:attribute>
   </xsd:complexType>
 
   <xsd:complexType name="plugins">


### PR DESCRIPTION
Currently implemented for CSS and Javascript files.
 Can also be used to load standalone plugins. Includes fixes to load the standalone plugins after structure-pure to be sure that all files are available.

closes #683