### PR TITLE
fix more documentation problems:

### DIFF
--- a/doc/manual/en/config/examples/swiss.rst
+++ b/doc/manual/en/config/examples/swiss.rst
@@ -31,7 +31,7 @@ The highlights at a glance
 ---------------------------
 
 Time display in the Navbar
-~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. figure:: _static/Example_Metal_swiss_02.jpg
     :alt: Screenshot Zeit/Datum

--- a/doc/manual/en/config/widgets/audio/index.rst
+++ b/doc/manual/en/config/widgets/audio/index.rst
@@ -38,8 +38,9 @@ Allowed attributes in the Audio-element
     :align: center
 
     <caption>Attributes in the editor (simple view) [#f1]_</caption>
-    <audio>
+    <audio src="sound.mp3" id="example">
         <layout colspan="4" />
+        <label>Audio</label>
     </audio>
 
 
@@ -54,7 +55,7 @@ Allowed child-elements und their attributes
     :align: center
 
     <caption>Elements in the editor</caption>
-    <audio>
+    <audio src="sound.mp3" id="example">
         <layout colspan="4" />
         <label>Audio</label>
         <address transform="DPT:1.001" mode="readwrite">1/1/0</address>

--- a/doc/manual/en/config/widgets/break/index.rst
+++ b/doc/manual/en/config/widgets/break/index.rst
@@ -14,6 +14,13 @@ A break tag is used to start in new line for a grouped and thereby tidy display 
 elements on one page.
 
 
+.. code-block:: xml
+
+    <break/>
+
+
+
+
 .. ###END-WIDGET-DESCRIPTION###
 
 Settings

--- a/doc/manual/en/config/widgets/image/index.rst
+++ b/doc/manual/en/config/widgets/image/index.rst
@@ -52,7 +52,7 @@ Valid values for ``cachecontrol`` are:
     :align: center
 
     <caption>Attributes in the editor (simple view) [#f1]_</caption>
-    <image>
+    <image src="image.jpg">
         <layout colspan="4" />
     </image>
 
@@ -68,10 +68,9 @@ Allowed child-elements und their attributes
     :align: center
 
     <caption>Elements in the editor</caption>
-    <image>
+    <image src="image.jpg">
         <layout colspan="4" />
         <label>Image</label>
-        <address transform="DPT:1.001" mode="readwrite">1/1/0</address>
     </image>
 
 Examples
@@ -89,7 +88,7 @@ for the Image widget.
 .. widget-example::
 
     
-    <image src="icon/CometVisu_orange.png" width="45px" height="32px">
+    <image src="resource/icon/CometVisu_orange.png" width="45px" height="32px">
       <layout colspan="2" />
     </image>
     

--- a/doc/manual/en/config/widgets/imagetrigger/index.rst
+++ b/doc/manual/en/config/widgets/imagetrigger/index.rst
@@ -58,7 +58,7 @@ Allowed attributes in the ImageTrigger-element
     :align: center
 
     <caption>Attributes in the editor (simple view) [#f1]_</caption>
-    <imagetrigger src="icon/CometVisu_" suffix="png">
+    <imagetrigger src="resource/icon/CometVisu_" suffix="png">
         <layout colspan="4" />
         <address transform="DPT:1.001" mode="readwrite">1/1/0</address>
     </imagetrigger>
@@ -75,7 +75,7 @@ Allowed child-elements und their attributes
     :align: center
 
     <caption>Elements in the editor</caption>
-    <imagetrigger src="icon/CometVisu_" suffix="png">
+    <imagetrigger src="resource/icon/CometVisu_" suffix="png">
         <layout colspan="4" />
         <label>ImageTrigger</label>
         <address transform="DPT:1.001" mode="readwrite">1/1/0</address>

--- a/doc/manual/en/config/widgets/imagetrigger/index.rst
+++ b/doc/manual/en/config/widgets/imagetrigger/index.rst
@@ -15,22 +15,21 @@ data and can send data to the backend by clicking on it.
 There are two modes to react on incoming data:
 
 
- type="show": Hides the image when incoming data === 0
- type="select": Changes the image by appending the incoming data to the initial configured image source,
-  or hide it when incoming data === 0
+ * ``type="show"``: Hides the image when incoming data === 0
+ * ``type="select"``: Changes the image by appending the incoming data to the initial configured image source, or hide it when incoming data === 0
 
 Example:
 
 .. code-block:: xml
 
-    <imagetrigger src="icon/comet" suffix="svg" sendValue="clicked" type="select">
-     <address transform="DPT:16.001" mode="readwrite">0/0/0</address>
+    <imagetrigger src="resource/icon/comet" suffix="svg" sendValue="clicked" type="select">
+       <address transform="DPT:16.001" mode="readwrite">0/0/0</address>
     </imagetrigger>
 
 
 
-initially shows nothing. When the CometVisu receives the string _icon in address 0/0/0,
-the image icon/comet_opt_icon.svg is shown. When the CometVisu receives '0' on address 0/0/0,
+initially shows nothing. When the CometVisu receives the string ``_icon`` in address ``0/0/0``,
+the image ``icon/comet_opt_icon.svg`` is shown. When the CometVisu receives '0' on address ``0/0/0``,
 this image is hidden.
 
 
@@ -59,8 +58,9 @@ Allowed attributes in the ImageTrigger-element
     :align: center
 
     <caption>Attributes in the editor (simple view) [#f1]_</caption>
-    <imagetrigger>
+    <imagetrigger src="icon/CometVisu_" suffix="png">
         <layout colspan="4" />
+        <address transform="DPT:1.001" mode="readwrite">1/1/0</address>
     </imagetrigger>
 
 
@@ -75,7 +75,7 @@ Allowed child-elements und their attributes
     :align: center
 
     <caption>Elements in the editor</caption>
-    <imagetrigger>
+    <imagetrigger src="icon/CometVisu_" suffix="png">
         <layout colspan="4" />
         <label>ImageTrigger</label>
         <address transform="DPT:1.001" mode="readwrite">1/1/0</address>
@@ -96,18 +96,18 @@ for the ImageTrigger widget.
 .. code-block:: xml
 
     
-    <imagetrigger src="icon/CometVisu_" suffix="png" sendValue="clicked" type="select" width="45px" height="32px">
-      <layout colspan="1"/>
-      <address transform="DPT:16.001" mode="readwrite">0/0/0</address>
-    </imagetrigger>
+    <imagetrigger src="resource/icon/CometVisu_" suffix="png" sendValue="clicked" type="select" width="45px" height="32px">
+       <layout colspan="1"/>
+       <address transform="DPT:16.001" mode="readwrite">0/0/0</address>
+     </imagetrigger>
         
 .. code-block:: xml
 
     
-    <imagetrigger src="icon/CometVisu_orange" suffix="png" sendValue="clicked" type="show" width="45px" height="32px">
-      <layout colspan="0"/>
-      <address transform="DPT:1.001" mode="readwrite">0/0/0</address>
-    </imagetrigger>
+    <imagetrigger src="resource/icon/CometVisu_orange" suffix="png" sendValue="clicked" type="show" width="45px" height="32px">
+       <layout colspan="0"/>
+       <address transform="DPT:1.001" mode="readwrite">0/0/0</address>
+     </imagetrigger>
         
     
 

--- a/doc/manual/en/config/widgets/infoaction/index.rst
+++ b/doc/manual/en/config/widgets/infoaction/index.rst
@@ -42,19 +42,19 @@ Allowed attributes in the InfoAction-element
 
     <caption>Attributes in the editor (simple view) [#f1]_</caption>
     <infoaction>
-        <layout colspan="4" />
-        <label>InfoAction</label>
-        <widgetinfo>
-           <info>
-            <address transform="DPT:9.001">0/0/0</address>
-           </info>
-        </widgetinfo>
-        <widgetaction>
-          <switch mapping="OnOff" styling="GreyGreen">
-           <layout colspan="3"/>
-           <address transform="DPT:1.001" mode="readwrite">0/0/1</address>
-          </switch>
-        </widgetaction>
+      <layout colspan="4" />
+      <label>InfoAction</label>
+      <widgetinfo>
+        <info>
+          <address transform="DPT:9.001">0/0/0</address>
+        </info>
+      </widgetinfo>
+      <widgetaction>
+        <switch mapping="OnOff" styling="GreyGreen">
+          <layout colspan="3"/>
+          <address transform="DPT:1.001" mode="readwrite">0/0/1</address>
+        </switch>
+      </widgetaction>
     </infoaction>
 
 
@@ -70,19 +70,19 @@ Allowed child-elements und their attributes
 
     <caption>Elements in the editor</caption>
     <infoaction>
-        <layout colspan="4" />
-        <label>InfoAction</label>
-        <widgetinfo>
-       <info>
-        <address transform="DPT:9.001">0/0/0</address>
-       </info>
-     </widgetinfo>
-     <widgetaction>
-      <switch mapping="OnOff" styling="GreyGreen">
-       <layout colspan="3"/>
-       <address transform="DPT:1.001" mode="readwrite">0/0/1</address>
-      </switch>
-     </widgetaction>
+      <layout colspan="4" />
+      <label>InfoAction</label>
+      <widgetinfo>
+        <info>
+          <address transform="DPT:9.001">0/0/0</address>
+        </info>
+      </widgetinfo>
+      <widgetaction>
+        <switch mapping="OnOff" styling="GreyGreen">
+          <layout colspan="3"/>
+          <address transform="DPT:1.001" mode="readwrite">0/0/1</address>
+        </switch>
+      </widgetaction>
     </infoaction>
 
 Examples

--- a/doc/manual/en/config/widgets/infoaction/index.rst
+++ b/doc/manual/en/config/widgets/infoaction/index.rst
@@ -43,6 +43,18 @@ Allowed attributes in the InfoAction-element
     <caption>Attributes in the editor (simple view) [#f1]_</caption>
     <infoaction>
         <layout colspan="4" />
+        <label>InfoAction</label>
+        <widgetinfo>
+           <info>
+            <address transform="DPT:9.001">0/0/0</address>
+           </info>
+        </widgetinfo>
+        <widgetaction>
+          <switch mapping="OnOff" styling="GreyGreen">
+           <layout colspan="3"/>
+           <address transform="DPT:1.001" mode="readwrite">0/0/1</address>
+          </switch>
+        </widgetaction>
     </infoaction>
 
 
@@ -60,7 +72,17 @@ Allowed child-elements und their attributes
     <infoaction>
         <layout colspan="4" />
         <label>InfoAction</label>
-        <address transform="DPT:1.001" mode="readwrite">1/1/0</address>
+        <widgetinfo>
+       <info>
+        <address transform="DPT:9.001">0/0/0</address>
+       </info>
+     </widgetinfo>
+     <widgetaction>
+      <switch mapping="OnOff" styling="GreyGreen">
+       <layout colspan="3"/>
+       <address transform="DPT:1.001" mode="readwrite">0/0/1</address>
+      </switch>
+     </widgetaction>
     </infoaction>
 
 Examples

--- a/doc/manual/en/config/widgets/notificationcenterbadge/index.rst
+++ b/doc/manual/en/config/widgets/notificationcenterbadge/index.rst
@@ -29,7 +29,7 @@ The screenshots show, how both can be edited in the :ref:`editor <editor>`.
 Attributes underlined by ..... are mandatory, all the others are optional and can be omitted.
 
 Allowed attributes in the NotificationCenterBadge-element
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. parameter-information:: notificationcenterbadge
 

--- a/doc/manual/en/config/widgets/plugins/link/index.rst
+++ b/doc/manual/en/config/widgets/plugins/link/index.rst
@@ -65,10 +65,8 @@ Allowed child-elements und their attributes
             <plugin name="link" />
         </plugins>
     </meta>
-    <link>
+    <link text="Link" href="https://www.cometvisu.org">
         <layout colspan="4" />
-        <label>link</label>
-        <address transform="DPT:1.001" mode="readwrite">1/1/0</address>
     </link>
 
 Examples

--- a/doc/manual/en/config/widgets/plugins/rss/index.rst
+++ b/doc/manual/en/config/widgets/plugins/rss/index.rst
@@ -56,7 +56,7 @@ Allowed attributes in the rss-element
             <plugin name="rss" />
         </plugins>
     </meta>
-    <rss>
+    <rss src="rss.xml" header="true">
         <layout colspan="4" />
     </rss>
 
@@ -77,10 +77,9 @@ Allowed child-elements und their attributes
             <plugin name="rss" />
         </plugins>
     </meta>
-    <rss>
+    <rss src="rss.xml" header="true">
         <layout colspan="4" />
         <label>rss</label>
-        <address transform="DPT:1.001" mode="readwrite">1/1/0</address>
     </rss>
 
 Examples

--- a/doc/manual/en/config/widgets/plugins/speech/index.rst
+++ b/doc/manual/en/config/widgets/plugins/speech/index.rst
@@ -82,7 +82,7 @@ Allowed attributes in the speech-element
         </plugins>
     </meta>
     <speech>
-        <layout colspan="4" />
+        <address transform="DPT:1.001" mode="readwrite">1/1/0</address>
     </speech>
 
 
@@ -103,8 +103,6 @@ Allowed child-elements und their attributes
         </plugins>
     </meta>
     <speech>
-        <layout colspan="4" />
-        <label>speech</label>
         <address transform="DPT:1.001" mode="readwrite">1/1/0</address>
     </speech>
 

--- a/doc/manual/en/config/widgets/plugins/timeout/index.rst
+++ b/doc/manual/en/config/widgets/plugins/timeout/index.rst
@@ -44,32 +44,13 @@ Allowed attributes in the timeout-element
             <plugin name="timeout" />
         </plugins>
     </meta>
-    <timeout>
-        <layout colspan="4" />
-    </timeout>
+    <timeout target="id_"/>
 
 
 Allowed child-elements und their attributes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. elements-information:: timeout
-
-.. widget-example::
-    :editor: elements
-    :scale: 75
-    :align: center
-
-    <caption>Elements in the editor</caption>
-    <meta>
-        <plugins>
-            <plugin name="timeout" />
-        </plugins>
-    </meta>
-    <timeout>
-        <layout colspan="4" />
-        <label>timeout</label>
-        <address transform="DPT:1.001" mode="readwrite">1/1/0</address>
-    </timeout>
+The timeout widget has no child elements.
 
 Examples
 --------

--- a/doc/manual/en/config/widgets/pushbutton/index.rst
+++ b/doc/manual/en/config/widgets/pushbutton/index.rst
@@ -40,7 +40,7 @@ Allowed attributes in the PushButton-element
     :align: center
 
     <caption>Attributes in the editor (simple view) [#f1]_</caption>
-    <pushbutton>
+    <pushbutton downValue="1" upValue="0">
         <layout colspan="4" />
     </pushbutton>
 
@@ -56,7 +56,7 @@ Allowed child-elements und their attributes
     :align: center
 
     <caption>Elements in the editor</caption>
-    <pushbutton>
+    <pushbutton downValue="1" upValue="0">
         <layout colspan="4" />
         <label>PushButton</label>
         <address transform="DPT:1.001" mode="readwrite">1/1/0</address>

--- a/doc/manual/en/config/widgets/refresh/index.rst
+++ b/doc/manual/en/config/widgets/refresh/index.rst
@@ -38,7 +38,7 @@ Allowed attributes in the Refresh-element
     :align: center
 
     <caption>Attributes in the editor (simple view) [#f1]_</caption>
-    <refresh>
+    <refresh value="1">
         <layout colspan="4" />
     </refresh>
 
@@ -54,10 +54,9 @@ Allowed child-elements und their attributes
     :align: center
 
     <caption>Elements in the editor</caption>
-    <refresh>
+    <refresh value="1">
         <layout colspan="4" />
         <label>Refresh</label>
-        <address transform="DPT:1.001" mode="readwrite">1/1/0</address>
     </refresh>
 
 Examples

--- a/doc/manual/en/config/widgets/reload/index.rst
+++ b/doc/manual/en/config/widgets/reload/index.rst
@@ -39,7 +39,7 @@ Allowed attributes in the Reload-element
 
     <caption>Attributes in the editor (simple view) [#f1]_</caption>
     <reload>
-        <layout colspan="4" />
+        <address transform="DPT:1.001" mode="readwrite">1/1/0</address>
     </reload>
 
 
@@ -55,8 +55,6 @@ Allowed child-elements und their attributes
 
     <caption>Elements in the editor</caption>
     <reload>
-        <layout colspan="4" />
-        <label>Reload</label>
         <address transform="DPT:1.001" mode="readwrite">1/1/0</address>
     </reload>
 

--- a/doc/manual/en/config/widgets/rgb/index.rst
+++ b/doc/manual/en/config/widgets/rgb/index.rst
@@ -40,6 +40,9 @@ Allowed attributes in the Rgb-element
     <caption>Attributes in the editor (simple view) [#f1]_</caption>
     <rgb>
         <layout colspan="4" />
+        <address transform="DPT:5.001" mode="readwrite" variant="r">1/1/0</address>
+        <address transform="DPT:5.001" mode="readwrite" variant="g">1/1/1</address>
+        <address transform="DPT:5.001" mode="readwrite" variant="b">1/1/2</address>
     </rgb>
 
 
@@ -57,7 +60,9 @@ Allowed child-elements und their attributes
     <rgb>
         <layout colspan="4" />
         <label>Rgb</label>
-        <address transform="DPT:1.001" mode="readwrite">1/1/0</address>
+        <address transform="DPT:5.001" mode="readwrite" variant="r">1/1/0</address>
+        <address transform="DPT:5.001" mode="readwrite" variant="g">1/1/1</address>
+        <address transform="DPT:5.001" mode="readwrite" variant="b">1/1/2</address>
     </rgb>
 
 Examples

--- a/doc/manual/en/config/widgets/text/index.rst
+++ b/doc/manual/en/config/widgets/text/index.rst
@@ -40,6 +40,7 @@ Allowed attributes in the Text-element
     <caption>Attributes in the editor (simple view) [#f1]_</caption>
     <text>
         <layout colspan="4" />
+        <label>Text</label>
     </text>
 
 
@@ -57,7 +58,6 @@ Allowed child-elements und their attributes
     <text>
         <layout colspan="4" />
         <label>Text</label>
-        <address transform="DPT:1.001" mode="readwrite">1/1/0</address>
     </text>
 
 Examples

--- a/doc/manual/en/config/widgets/trigger/index.rst
+++ b/doc/manual/en/config/widgets/trigger/index.rst
@@ -41,7 +41,7 @@ Allowed attributes in the Trigger-element
     :align: center
 
     <caption>Attributes in the editor (simple view) [#f1]_</caption>
-    <trigger>
+    <trigger value="1">
         <layout colspan="4" />
     </trigger>
 
@@ -57,7 +57,7 @@ Allowed child-elements und their attributes
     :align: center
 
     <caption>Elements in the editor</caption>
-    <trigger>
+    <trigger value="1">
         <layout colspan="4" />
         <label>Trigger</label>
         <address transform="DPT:1.001" mode="readwrite">1/1/0</address>

--- a/doc/manual/en/config/widgets/urltrigger/index.rst
+++ b/doc/manual/en/config/widgets/urltrigger/index.rst
@@ -38,7 +38,7 @@ Allowed attributes in the UrlTrigger-element
     :align: center
 
     <caption>Attributes in the editor (simple view) [#f1]_</caption>
-    <urltrigger>
+    <urltrigger url="">
         <layout colspan="4" />
     </urltrigger>
 
@@ -54,10 +54,9 @@ Allowed child-elements und their attributes
     :align: center
 
     <caption>Elements in the editor</caption>
-    <urltrigger>
+    <urltrigger url="">
         <layout colspan="4" />
         <label>UrlTrigger</label>
-        <address transform="DPT:1.001" mode="readwrite">1/1/0</address>
     </urltrigger>
 
 Examples

--- a/doc/manual/en/config/widgets/urltrigger/index.rst
+++ b/doc/manual/en/config/widgets/urltrigger/index.rst
@@ -38,7 +38,7 @@ Allowed attributes in the UrlTrigger-element
     :align: center
 
     <caption>Attributes in the editor (simple view) [#f1]_</caption>
-    <urltrigger url="">
+    <urltrigger url="https://example.com/rest/activate">
         <layout colspan="4" />
     </urltrigger>
 
@@ -54,7 +54,7 @@ Allowed child-elements und their attributes
     :align: center
 
     <caption>Elements in the editor</caption>
-    <urltrigger url="">
+    <urltrigger url="https://example.com/rest/activate">
         <layout colspan="4" />
         <label>UrlTrigger</label>
     </urltrigger>

--- a/doc/manual/en/config/widgets/video/index.rst
+++ b/doc/manual/en/config/widgets/video/index.rst
@@ -38,7 +38,7 @@ Allowed attributes in the Video-element
     :align: center
 
     <caption>Attributes in the editor (simple view) [#f1]_</caption>
-    <video>
+    <video src="video.mpg">
         <layout colspan="4" />
     </video>
 
@@ -54,10 +54,9 @@ Allowed child-elements und their attributes
     :align: center
 
     <caption>Elements in the editor</caption>
-    <video>
+    <video src="video.mpg">
         <layout colspan="4" />
         <label>Video</label>
-        <address transform="DPT:1.001" mode="readwrite">1/1/0</address>
     </video>
 
 Examples

--- a/doc/manual/en/config/widgets/web/index.rst
+++ b/doc/manual/en/config/widgets/web/index.rst
@@ -38,7 +38,7 @@ Allowed attributes in the Web-element
     :align: center
 
     <caption>Attributes in the editor (simple view) [#f1]_</caption>
-    <web>
+    <web src="https://www.cometvisu.org">
         <layout colspan="4" />
     </web>
 
@@ -54,10 +54,9 @@ Allowed child-elements und their attributes
     :align: center
 
     <caption>Elements in the editor</caption>
-    <web>
+    <web src="https://www.cometvisu.org">
         <layout colspan="4" />
         <label>Web</label>
-        <address transform="DPT:1.001" mode="readwrite">1/1/0</address>
     </web>
 
 Examples

--- a/doc/manual/en/config/widgets/wgplugininfo/index.rst
+++ b/doc/manual/en/config/widgets/wgplugininfo/index.rst
@@ -12,6 +12,10 @@ Description
 
 Adds an dynamic field to the visu that shows live information from a WireGate plugin.
 
+Note: The service helper from
+https://raw.githubusercontent.com/OpenAutomationProject/Wiregate/master/tools/wg-plugindb/wg-plugindb.php
+must be "installed" in the directory /var/www/ (i.e. the web root)
+
 
 .. ###END-WIDGET-DESCRIPTION###
 
@@ -38,9 +42,10 @@ Allowed attributes in the WgPluginInfo-element
     :align: center
 
     <caption>Attributes in the editor (simple view) [#f1]_</caption>
-    <wgplugininfo>
+    <wgplugin_info>
         <layout colspan="4" />
-    </wgplugininfo>
+        <address transform="DPT:1.001" mode="readwrite">1/1/0</address>
+    </wgplugin_info>
 
 
 Allowed child-elements und their attributes
@@ -54,11 +59,11 @@ Allowed child-elements und their attributes
     :align: center
 
     <caption>Elements in the editor</caption>
-    <wgplugininfo>
+    <wgplugin_info>
         <layout colspan="4" />
         <label>WgPluginInfo</label>
         <address transform="DPT:1.001" mode="readwrite">1/1/0</address>
-    </wgplugininfo>
+    </wgplugin_info>
 
 Examples
 --------

--- a/source/class/cv/ui/structure/pure/Image.js
+++ b/source/class/cv/ui/structure/pure/Image.js
@@ -23,7 +23,7 @@
  * a camera picture.
  *
  * @widgetexample
- * <image src="icon/CometVisu_orange.png" width="45px" height="32px">
+ * <image src="resource/icon/CometVisu_orange.png" width="45px" height="32px">
  *   <layout colspan="2" />
  * </image>
  *

--- a/source/class/cv/ui/structure/pure/ImageTrigger.js
+++ b/source/class/cv/ui/structure/pure/ImageTrigger.js
@@ -25,13 +25,12 @@
  *
  * <ul>
  *  <li><code>type="show"</code>: Hides the image when incoming data === 0</li>
- *  <li><code>type="select"</code>: Changes the image by appending the incoming data to the initial configured image source,
- *   or hide it when incoming data === 0</li>
+ *  <li><code>type="select"</code>: Changes the image by appending the incoming data to the initial configured image source, or hide it when incoming data === 0</li>
  * </ul>
  * Example:
  * <pre class="sunlight-highlight-xml">
- * &lt;imagetrigger src="icon/comet" suffix="svg" sendValue="clicked" type="select"&gt;
- *  &lt;address transform="DPT:16.001" mode="readwrite"&gt;0/0/0&lt;/address&gt;
+ * &lt;imagetrigger src="resource/icon/comet" suffix="svg" sendValue="clicked" type="select"&gt;
+ *    &lt;address transform="DPT:16.001" mode="readwrite"&gt;0/0/0&lt;/address&gt;
  * &lt;/imagetrigger&gt;
  * </pre>
  *
@@ -48,22 +47,22 @@
  *     <caption>Image changed by incoming data 'grey'</caption>
  *     <data address="0/0/0">grey</data>
  *   </screenshot>
- * </settings>
- * <imagetrigger src="icon/CometVisu_" suffix="png" sendValue="clicked" type="select" width="45px" height="32px">
- *   <layout colspan="1" />
- *   <address transform="DPT:16.001" mode="readwrite">0/0/0</address>
- * </imagetrigger>
+ *  </settings>
+ *  <imagetrigger src="resource/icon/CometVisu_" suffix="png" sendValue="clicked" type="select" width="45px" height="32px">
+ *    <layout colspan="1" />
+ *    <address transform="DPT:16.001" mode="readwrite">0/0/0</address>
+ *  </imagetrigger>
  *
  * @widgetexample <settings>
  *   <caption>Disable layout width by settings it to '0', to have widget with === image width</caption>
  *   <screenshot name="image_trigger_colspan0">
  *     <data address="0/0/0">1</data>
  *   </screenshot>
- * </settings>
- * <imagetrigger src="icon/CometVisu_orange" suffix="png" sendValue="clicked" type="show" width="45px" height="32px">
- *   <layout colspan="0" />
- *   <address transform="DPT:1.001" mode="readwrite">0/0/0</address>
- * </imagetrigger>
+ *  </settings>
+ *  <imagetrigger src="resource/icon/CometVisu_orange" suffix="png" sendValue="clicked" type="show" width="45px" height="32px">
+ *    <layout colspan="0" />
+ *    <address transform="DPT:1.001" mode="readwrite">0/0/0</address>
+ *  </imagetrigger>
  *
  *
  * @author Christian Mayer

--- a/source/resource/visu_config.xsd
+++ b/source/resource/visu_config.xsd
@@ -531,6 +531,7 @@
       <xsd:element name="timeout" type="timeout" />
       <xsd:element name="calllist" type="calllist" />
       <xsd:element name="upnpcontroller" type="upnpcontroller" />
+      <xsd:element name="link" type="link" />
     </xsd:choice>
   </xsd:group>
 
@@ -1947,6 +1948,25 @@
     <xsd:attribute name="player_port" type="xsd:string" use="optional" />
     <xsd:attribute name="refresh" type="xsd:string" use="required" />
     <xsd:attribute name="debug" type="xsd:boolean" use="optional" />
+  </xsd:complexType>
+
+  <xsd:complexType name="link">
+    <xsd:sequence>
+      <xsd:element name="layout" type="layout" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="class" type="xsd:string"/>
+    <xsd:attribute name="text" type="xsd:string">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">The link text.</xsd:documentation>
+        <xsd:documentation xml:lang="de">Der Link Text.</xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+    <xsd:attribute name="href" type="xsd:string">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">URL of the link.</xsd:documentation>
+        <xsd:documentation xml:lang="de">Die URL des Links.</xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
   </xsd:complexType>
 
   <xsd:complexType name="timeout">

--- a/utils/commands/doc.py
+++ b/utils/commands/doc.py
@@ -338,6 +338,11 @@ class DocGenerator(Command):
                             if section == "WIDGET-EXAMPLES" or example:
                                 indent = "    "
                             else:
+                                line_content = line_content.replace("<code>", "``")
+                                line_content = line_content.replace("</code>", "``")
+                                line_content = line_content.replace("<li>", "* ")
+                                line_content = line_content.replace("</li>", "")
+
                                 if line_content.strip() in ["```", "<pre class=\"sunlight-highlight-xml\">", "</pre>"]:
                                     if not code_block:
                                         if line_content.strip() == "<pre class=\"sunlight-highlight-xml\">":


### PR DESCRIPTION
- link plugins schema definition added
- fixed rest of the en doc widget examples syntax errors
- add conversion from jsdoc lists to rst lists and inline code blocks
- fix some headline marker lengths

refs #798