### PR TITLE
use a debounced function to load diagram data after pan event

### DIFF
--- a/source/class/cv/plugins/diagram/AbstractDiagram.js
+++ b/source/class/cv/plugins/diagram/AbstractDiagram.js
@@ -62,6 +62,16 @@ qx.Class.define('cv.plugins.diagram.AbstractDiagram', {
   type: "abstract",
 
   /*
+  ***********************************************
+    CONSTRUCTOR
+  ***********************************************
+  */
+  construct: function (props) {
+    this.base(arguments, props);
+    this._debouncedLoadDiagramData = qx.util.Function.debounce(this.loadDiagramData.bind(this), 200);
+  },
+
+  /*
   ******************************************************
     STATICS
   ******************************************************
@@ -600,11 +610,8 @@ qx.Class.define('cv.plugins.diagram.AbstractDiagram', {
       this.plotted = true;
 
       var that = this;
-      diagram.bind("plotpan", function(event, plot, args) {
-        // TODO and FIXME: args.dragEnded doesn't exist, so data isn't reloaded after pan end!
-        if (args.dragEnded) {
-          that.loadDiagramData( plot, isPopup, false );
-        }
+      diagram.bind("plotpan", function(event, plot) {
+        that._debouncedLoadDiagramData( plot, isPopup, false );
       }).bind("plotzoom", function() {
         that.loadDiagramData( plot, isPopup, false );
       }).bind("touchended", function() {


### PR DESCRIPTION
The debounce ensures that the backend is not "flooded" with requests during panning. The request is only send once after the last pan-event is at least 200ms ago, which has the nice side effect that the data is also loaded, when the user just stops dragging for at least 200ms, without releasing the mouse-button.

Fixes error reported here: https://knx-user-forum.de/forum/supportforen/cometvisu/1307234-test-cv11-dev?p=1314117#post1314117