### PR TITLE
check must be called outside foreach to prevent multiple calls of don…

### DIFF
--- a/source/class/cv/parser/MetaParser.js
+++ b/source/class/cv/parser/MetaParser.js
@@ -367,9 +367,9 @@ qx.Class.define("cv.parser.MetaParser", {
               // templates can only have one single root element, so we wrap it here
               '<root>' + qx.bom.element.Attribute.get(elem, 'html') + '</root>'
             );
-            check();
           }
         }, this);
+        check();
       }
     }
   }


### PR DESCRIPTION
…e callback when there are no external templates to load.

Otherwise this would be executed once for every defined template:
https://github.com/CometVisu/CometVisu/blob/develop/source/class/cv/Application.js#L470-L480

