### PR TITLE
- load config icons directly after parsing, as they might be used in …

### DIFF
--- a/source/class/cv/Application.js
+++ b/source/class/cv/Application.js
@@ -470,7 +470,6 @@ qx.Class.define("cv.Application",
           this.loadPlugins();
           this.loadStyles();
           this.loadScripts();
-          this.loadIcons();
           this.debug("done");
 
           if (cv.Config.enableCache) {
@@ -487,7 +486,7 @@ qx.Class.define("cv.Application",
      * Adds icons which were defined in the current configuration to the {@link cv.IconHandler}
      */
     loadIcons: function() {
-      cv.Config.iconsFromConfig.forEach(function(icon) {
+      cv.Config.configSettings.iconsFromConfig.forEach(function(icon) {
         cv.IconHandler.getInstance().insert(icon.name, icon.uri, icon.type, icon.flavour, icon.color, icon.styling, icon.dynamic);
       }, this);
     },

--- a/source/class/cv/Config.js
+++ b/source/class/cv/Config.js
@@ -131,14 +131,14 @@ qx.Class.define('cv.Config', {
        * @type {Map} of rowspan-value as key and true as value
        */
       usedRowspans: {},
-      pluginsToLoad: []
-    },
+      pluginsToLoad: [],
 
-    /**
-     * Array with alls icons defined in the current config file
-     * @type {Array}
-     */
-    iconsFromConfig: [],
+      /**
+       * Array with alls icons defined in the current config file
+       * @type {Array}
+       */
+      iconsFromConfig: []
+    },
 
     /**
      * Store last visited page in LocalStorage

--- a/source/class/cv/IconHandler.js
+++ b/source/class/cv/IconHandler.js
@@ -173,11 +173,7 @@ qx.Class.define('cv.IconHandler', {
         if (typeof i === 'function') {
           i.icon = i(arguments[3], styling, classes, false);
         } else {
-          i.icon = qx.dom.Element.create('img', {
-            'class': classes,
-            src: qx.util.ResourceManager.getInstance().toUri(i.uri),
-            style: styling
-          });
+          i.icon = '<img class="' + classes + '" src="' + qx.util.ResourceManager.getInstance().toUri(i.uri) +'" style="' + (styling ? styling : '') + '"/>';
         }
         return i.icon;
       }

--- a/source/class/cv/parser/MetaParser.js
+++ b/source/class/cv/parser/MetaParser.js
@@ -84,7 +84,8 @@ qx.Class.define("cv.parser.MetaParser", {
     },
 
     parseIcons: function(elem) {
-      cv.Config.iconsFromConfig.push(this.__parseIconDefinition(elem));
+      cv.Config.configSettings.iconsFromConfig.push(this.__parseIconDefinition(elem));
+      qx.core.Init.getApplication().loadIcons();
     },
 
     parseMappings: function(elem) {


### PR DESCRIPTION
…the mappings

- add custom icons to cache data
- do not create element in the IconHandler, because they cannot be cached

fixes error reported here: https://knx-user-forum.de/forum/supportforen/cometvisu/1317642-info-widget-mit-eigenen-icons