### PR TITLE
fix some screenshot errors:

### DIFF
--- a/doc/manual/en/config/widgets/infoaction/index.rst
+++ b/doc/manual/en/config/widgets/infoaction/index.rst
@@ -35,29 +35,7 @@ Attributes underlined by ..... are mandatory, all the others are optional and be
 Allowed attributes in the InfoAction-element
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. parameter-information:: infoaction
-
-.. widget-example::
-    :editor: attributes
-    :scale: 75
-    :align: center
-
-    <caption>Attributes in the editor (simple view) [#f1]_</caption>
-    <infoaction>
-      <layout colspan="4" />
-      <label>InfoAction</label>
-      <widgetinfo>
-        <info>
-          <address transform="DPT:9.001">0/0/0</address>
-        </info>
-      </widgetinfo>
-      <widgetaction>
-        <switch mapping="OnOff" styling="GreyGreen">
-          <layout colspan="3"/>
-          <address transform="DPT:1.001" mode="readwrite">0/0/1</address>
-        </switch>
-      </widgetaction>
-    </infoaction>
+None.
 
 
 Allowed child-elements und their attributes

--- a/doc/manual/en/config/widgets/reload/index.rst
+++ b/doc/manual/en/config/widgets/reload/index.rst
@@ -30,17 +30,7 @@ Attributes underlined by ..... are mandatory, all the others are optional and be
 Allowed attributes in the Reload-element
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. parameter-information:: reload
-
-.. widget-example::
-    :editor: attributes
-    :scale: 75
-    :align: center
-
-    <caption>Attributes in the editor (simple view) [#f1]_</caption>
-    <reload>
-        <address transform="DPT:1.001" mode="readwrite">1/1/0</address>
-    </reload>
+None.
 
 
 Allowed child-elements und their attributes

--- a/utils/screenshots-spec.js
+++ b/utils/screenshots-spec.js
@@ -134,6 +134,7 @@ describe('generation screenshots from jsdoc examples', function () {
             mockupConfig.push(mockedConfigData);
 
             it('should create a screenshot', function () {
+              console.log(">>> processing "+filePath+"...");
               if (settings.editor) {
                 if (settings.complex) {
                   var complexButton = element(by.css(".button.expert"));
@@ -170,13 +171,12 @@ describe('generation screenshots from jsdoc examples', function () {
               }
 
               // wait for everything to be rendered
-              browser.sleep(settings.sleep || 300);
+              browser.sleep(settings.sleep || 1000);
 
               var widget = element(by.css(selectorPrefix+settings.selector));
               browser.wait(function() {
                 return widget.isDisplayed();
-              }, 1000).then(function() {
-                console.log(">>> processing "+filePath+"...");
+              }, 2000).then(function() {
                 settings.screenshots.forEach(function(setting) {
                   if (setting.data && Array.isArray(setting.data)) {
                     setting.data.forEach(function (data) {


### PR DESCRIPTION
- do not generate an editor-attribute screenshot when the widget has no attributes
- log current screenshot process directly after start to show which one failes