### PR TITLE
fix triggers

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -357,7 +357,7 @@ module.exports = function(grunt) {
       debug: {
         configFile: 'source/test/karma/karma.conf.js',
         singleRun: !grunt.option('no-single'),
-        browsers: [grunt.option('browser') || 'Chrome'],
+        browsers: [grunt.option('browser') || 'Chrome_travis'],
         reporters: ['spec']
       }
     },

--- a/source/class/cv/parser/widgets/Trigger.js
+++ b/source/class/cv/parser/widgets/Trigger.js
@@ -50,7 +50,7 @@ qx.Class.define('cv.parser.widgets.Trigger', {
       return {
         'value'      : { target: 'sendValue' , "default": "0" },
         'shorttime'  : { target: 'shortThreshold', "default": -1, transform: parseFloat},
-        'shortValue' : { target: 'shortValue', "default": "0" }
+        'shortvalue' : { target: 'shortValue', "default": "0" }
       };
     },
 

--- a/source/class/cv/ui/structure/AbstractWidget.js
+++ b/source/class/cv/ui/structure/AbstractWidget.js
@@ -115,6 +115,7 @@ qx.Class.define('cv.ui.structure.AbstractWidget', {
   members: {
     $$domReady: null,
     __pointerDownElement: null,
+    __pointerDownTime: null,
     _skipNextEvent: null,
 
     // property apply
@@ -241,6 +242,7 @@ qx.Class.define('cv.ui.structure.AbstractWidget', {
     _onPointerDown: function(ev) {
       // listen to pointerup globally
       this.__pointerDownElement = ev.getCurrentTarget();
+      this.__pointerDownTime = Date.now();
       qx.event.Registration.addListener(document, "pointerup", this._onPointerUp, this);
     },
 
@@ -256,9 +258,18 @@ qx.Class.define('cv.ui.structure.AbstractWidget', {
       if (upElement && upElement === this.__pointerDownElement) {
         // both events happened on the same element
         ev.setCurrentTarget(upElement);
-        this.action(ev);
+        if (this._onLongTap &&
+          qx.Class.hasMixin(this.constructor, cv.ui.common.HandleLongpress) &&
+          this.getShortThreshold() > 0 &&
+          (Date.now() - this.__pointerDownTime) >= this.getShortThreshold()) {
+          // this is a longpress
+          this._onLongTap(ev);
+        } else {
+          this.action(ev);
+        }
         this._skipNextEvent = "tap";
       }
+      this.__pointerDownTime = null;
     },
 
     /**

--- a/source/class/cv/ui/structure/pure/InfoTrigger.js
+++ b/source/class/cv/ui/structure/pure/InfoTrigger.js
@@ -143,15 +143,6 @@ qx.Class.define('cv.ui.structure.pure.InfoTrigger', {
     // overridden
     initListeners: function() {
       this.getActors().forEach(function(actor) {
-        qx.bom.element.Dataset.set(actor, "longtapable", true);
-        if (this.getShortThreshold() > 0) {
-          qx.event.Registration.addListener(actor, "tap", this.action, this);
-          qx.event.Registration.addListener(actor, "longtap", this._onLongTap, this);
-        } else {
-          // no short tap treat all taps as long
-          qx.event.Registration.addListener(actor, "tap", this._onLongTap, this);
-          qx.event.Registration.addListener(actor, "longtap", this._onLongTap, this);
-        }
         qx.event.Registration.addListener(actor, "pointerdown", this._onPointerDown, this);
       }, this);
 

--- a/source/class/cv/ui/structure/pure/Trigger.js
+++ b/source/class/cv/ui/structure/pure/Trigger.js
@@ -59,14 +59,6 @@ qx.Class.define('cv.ui.structure.pure.Trigger', {
     },
 
     // overridden
-    initListeners: function() {
-      this.base(arguments);
-      if (this.getShortThreshold() > 0) {
-        this.addElementListener("longtap", this._onLongTap, this);
-      }
-    },
-
-    // overridden
     _getInnerDomString: function () {
       return '<div class="actor switchUnpressed"><div class="value">-</div></div>';
     },

--- a/source/test/karma/ui/structure/pure/Trigger-spec.js
+++ b/source/test/karma/ui/structure/pure/Trigger-spec.js
@@ -86,38 +86,141 @@ describe("testing a trigger", function() {
 
   });
 
-  it('should trigger the trigger downaction', function() {
+  it('should trigger the trigger shortpress', function(done) {
 
     var res = this.createTestElement("trigger", {
-      value:"1",
-      shortvalue: "0",
+      value: "1",
+      shortvalue: "2",
       shorttime: "100",
       flavour: "potassium"
-    }, '<label>Test</label>');
+    }, '<label>Test</label>', ['1/0/0', '1/0/1'], [
+      {'transform': 'DPT:1.001', 'mode': 'write', 'variant': 'button'},
+      {'transform': 'DPT:1.001', 'mode': 'write', 'variant': 'short'}
+    ]);
 
     this.initWidget(res);
 
-    spyOn(res, "sendToBackend");
-    var actor = res.getActor();
+    var spy = spyOn(cv.TemplateEngine.getInstance().visu, "write");
+    var actor = res.getInteractionElement();
     expect(actor).not.toBe(null);
 
     var Reg = qx.event.Registration;
 
-    // longpress
-    Reg.fireEvent(actor, "longtap", qx.event.type.Event, []);
-    expect(res.sendToBackend).toHaveBeenCalledWith('1', jasmine.any(Function));
-
-    //shortpress
-    Reg.fireEvent(actor, "tap", qx.event.type.Event, []);
-    expect(res.sendToBackend).toHaveBeenCalledWith('0', jasmine.any(Function));
-
+    var eventData = {
+      "bubbles": true,
+      "button": -1,
+      "clientX": 1241,
+      "clientY": 360,
+      "currentTarget": actor,
+      "pageX": 1241,
+      "pageY": 360,
+      "returnValue": true,
+      "screenX": 1241,
+      "screenY": 490,
+      "detail": 0,
+      "view": window,
+      "type": "pointerdown",
+      "x": 1241,
+      "y": 360,
+      "pointerId": 1,
+      "width": 1,
+      "height": 1,
+      "pressure": 0,
+      "tiltX": 0,
+      "tiltY": 0,
+      "pointerType": "mouse",
+      "isPrimary": true
+    };
     // down
-    Reg.fireEvent(actor, "pointerdown", qx.event.type.Event, []);
+    var nativeEvent = new window.PointerEvent("pointerdown", Object.assign(eventData, {
+      type: "pointerup"
+    }));
+    Reg.fireEvent(actor, "pointerdown", qx.event.type.Pointer, [nativeEvent, actor, actor, true, true]);
     expect(actor).toHaveClass("switchPressed");
     expect(actor).not.toHaveClass("switchUnpressed");
-    // up
-    Reg.fireEvent(actor, "pointerup", qx.event.type.Event, [true, true]);
-    expect(actor).not.toHaveClass("switchPressed");
-    expect(actor).toHaveClass("switchUnpressed");
+
+    setTimeout(function () {
+      // up
+      nativeEvent = new window.PointerEvent("pointerup", Object.assign(eventData, {
+        type: "pointerup"
+      }));
+      Reg.fireEvent(actor, "pointerup", qx.event.type.Pointer, [nativeEvent, actor, actor, true, true]);
+      qx.event.Registration.fireEvent(actor, "tap", qx.event.type.Event, []);
+      expect(actor).not.toHaveClass("switchPressed");
+      expect(actor).toHaveClass("switchUnpressed");
+
+      expect(spy).toHaveBeenCalledWith('1/0/1', '82');
+      expect(spy.calls.count()).toEqual(1);
+      done();
+    }, 10);
+
+  });
+
+  it('should test the longpress', function(done) {
+    var res = this.createTestElement("trigger", {
+      value: "1",
+      shortvalue: "2",
+      shorttime: "100",
+      flavour: "potassium"
+    }, '<label>Test</label>', ['1/0/0', '1/0/1'], [
+      {'transform': 'DPT:1.001', 'mode': 'write', 'variant': 'button'},
+      {'transform': 'DPT:1.001', 'mode': 'write', 'variant': 'short'}
+    ]);
+
+    this.initWidget(res);
+    var spy = spyOn(cv.TemplateEngine.getInstance().visu, "write");
+    var actor = res.getInteractionElement();
+    expect(actor).not.toBe(null);
+
+    var Reg = qx.event.Registration;
+
+    var eventData = {
+      "bubbles": true,
+      "button": -1,
+      "clientX": 1241,
+      "clientY": 360,
+      "currentTarget": actor,
+      "pageX": 1241,
+      "pageY": 360,
+      "returnValue": true,
+      "screenX": 1241,
+      "screenY": 490,
+      "detail": 0,
+      "view": window,
+      "type": "pointerdown",
+      "x": 1241,
+      "y": 360,
+      "pointerId": 1,
+      "width": 1,
+      "height": 1,
+      "pressure": 0,
+      "tiltX": 0,
+      "tiltY": 0,
+      "pointerType": "mouse",
+      "isPrimary": true
+    };
+    // down
+    var nativeEvent = new window.PointerEvent("pointerdown", Object.assign(eventData, {
+      type: "pointerup"
+    }));
+    Reg.fireEvent(actor, "pointerdown", qx.event.type.Pointer, [nativeEvent, actor, actor, true, true]);
+    expect(actor).toHaveClass("switchPressed");
+    expect(actor).not.toHaveClass("switchUnpressed");
+
+    setTimeout(function () {
+      // up
+      nativeEvent = new window.PointerEvent("pointerup", Object.assign(eventData, {
+        type: "pointerup"
+      }));
+      Reg.fireEvent(actor, "pointerup", qx.event.type.Pointer, [nativeEvent, actor, actor, true, true]);
+      qx.event.Registration.fireEvent(actor, "tap", qx.event.type.Event, []);
+      expect(actor).not.toHaveClass("switchPressed");
+      expect(actor).toHaveClass("switchUnpressed");
+
+      expect(spy).toHaveBeenCalledWith('1/0/0', '81');
+      expect(spy.calls.count()).toEqual(1);
+      done();
+    }, 150);
+
   });
 });


### PR DESCRIPTION
- parser error on shortValue
- do not fire shortpress event on pointerup after longpress event
- add tests for this use case

set default browser in debug testrun to headless chrome

fixes error reported here: https://knx-user-forum.de/forum/supportforen/cometvisu/1323678-cv-trigger-widget-long-button-und-short-jalousie-raffstore-0-11-0-dev