### PR TITLE
do not override grid settings when tooltip is enabled

### DIFF
--- a/source/class/cv/plugins/diagram/AbstractDiagram.js
+++ b/source/class/cv/plugins/diagram/AbstractDiagram.js
@@ -582,7 +582,8 @@ qx.Class.define('cv.plugins.diagram.AbstractDiagram', {
         });
       }
       if (this.getTooltip()) {
-        qx.lang.Object.mergeWith(options, {grid: {hoverable: true, clickable: true}});
+        options.grid.hoverable = true;
+        options.grid.clickable = true;
       }
 
       if (!isPopup && !this.getPreviewlabels()) {


### PR DESCRIPTION
fixes error reported here: https://knx-user-forum.de/forum/supportforen/cometvisu/1331665-bug-mit-diagrammhintergrund-tooltip