### PR TITLE
Fix iPad scroll during turning

### DIFF
--- a/source/class/cv/report/Record.js
+++ b/source/class/cv/report/Record.js
@@ -312,7 +312,7 @@ qx.Class.define('cv.report.Record', {
 
     recordScroll: function(ev) {
       var page = ev.getTarget();
-      var path = qx.bom.element.Attribute.get(page, "id");
+      var path = (undefined !== page && 'getAttribute' in page) ? qx.bom.element.Attribute.get(page, "id") : undefined;
       var data = {
         type: ev.getType(),
         page: path,


### PR DESCRIPTION
 When scrolling during rotation of the iPad `recordScroll` was throwing as `page` was not the page element but instead Window.
=> Make maximum robust

closes #889 