### PR TITLE
improve refresh stop/start handling when widget changes its visibilit…

### DIFF
--- a/source/class/cv/plugins/diagram/Diagram.js
+++ b/source/class/cv/plugins/diagram/Diagram.js
@@ -90,10 +90,8 @@ qx.Class.define('cv.plugins.diagram.Diagram', {
         var pageId = this.getParentPage().getPath();
         var broker = qx.event.message.Bus;
 
-        // stop refreshing when page is left
-        broker.subscribe("path." + pageId + ".exitingPageChange", function () {
-          this._stopRefresh(this._timer);
-        }, this);
+        // let the refresh only be active when this widget is visible
+        this.setRestartOnVisible(true);
 
         broker.subscribe("path." + pageId + ".beforePageChange", function () {
           if (!this._init) {
@@ -106,8 +104,6 @@ qx.Class.define('cv.plugins.diagram.Diagram', {
           if (this._init) {
             this.initDiagram(false);
           }
-          // start refreshing when page is entered
-          this._startRefresh(this._timer, true);
         }, this);
 
         // initialize the diagram but don't make the initialization process wait for it

--- a/source/test/karma/helper-spec.js
+++ b/source/test/karma/helper-spec.js
@@ -49,7 +49,7 @@ var createTestWidgetString = function (name, attributes, content) {
     qx.dom.Element.insertEnd(elem, page);
     data = cv.parser.WidgetParser.parse(page, 'id', null, "text");
     cv.ui.structure.WidgetFactory.createInstance(data.$$type, data);
-    data = cv.data.Model.getInstance().getWidgetData(data['children'][0]);
+    data = cv.data.Model.getInstance().getWidgetData(data.children[0]);
   } else {
     data = cv.parser.WidgetParser.parse(elem, 'id_0', null, "text");
   }
@@ -316,6 +316,12 @@ beforeEach(function () {
   this.createTestWidgetString = createTestWidgetString;
   this.findChild = findChild;
   this.initWidget = function(widget) {
+    if (widget.getVisibilityParent) {
+      var parent = widget.getVisibilityParent();
+      if (parent) {
+        parent.setVisible(true);
+      }
+    }
     widget.setVisible && widget.setVisible(true);
     qx.event.message.Bus.dispatchByName("setup.dom.finished.before");
     qx.event.message.Bus.dispatchByName("setup.dom.finished");

--- a/source/test/karma/ui/structure/pure/Image-spec.js
+++ b/source/test/karma/ui/structure/pure/Image-spec.js
@@ -36,6 +36,8 @@ describe("testing a image widget", function() {
       spyOn(spiedTimer, "start");
       return spiedTimer;
     });
+
+    qx.event.Timer.once = Con.once;
   });
 
   afterEach(function () {
@@ -95,7 +97,7 @@ describe("testing the refresh caching of the image widget", function() {
       refresh: 1,
       cachecontrol: 'full'
     });
-    qx.event.message.Bus.dispatchByName("setup.dom.finished");
+    this.initWidget(widget);
     var domElement = widget.getDomElement();
     expect(qx.bom.element.Attribute.get(qx.bom.Selector.query("img", domElement)[0], "src")).toBe('/source/resource/icon/comet_64_ff8000.png');
 
@@ -116,9 +118,10 @@ describe("testing the refresh caching of the image widget", function() {
       refresh: 1,
       cachecontrol: 'weak'
     });
-    qx.event.message.Bus.dispatchByName("setup.dom.finished");
+    this.initWidget(widget);
     var domElement = widget.getDomElement();
     expect(qx.bom.element.Attribute.get(qx.bom.Selector.query("img", domElement)[0], "src")).toBe('/source/resource/icon/comet_64_ff8000.png');
+    widget.setVisible(true);
 
     qx.event.Timer.once(function() {
       expect(qx.bom.element.Attribute.get(qx.bom.Selector.query("img", domElement)[0], "src")).toMatch(/^\/source\/resource\/icon\/comet_64_ff8000.png#/);


### PR DESCRIPTION
…y state. Start timer immediately if the widget gets visible and the last runtime is older then the refresh interval, otherwise start when the next interval step is reached.

Removes the custom refresh start/stop handling if the diagram widget to avoid duplication behaviours.

refs #894