### PR TITLE
Fix refresh behaviour

### DIFF
--- a/source/class/cv/plugins/diagram/AbstractDiagram.js
+++ b/source/class/cv/plugins/diagram/AbstractDiagram.js
@@ -505,7 +505,7 @@ qx.Class.define('cv.plugins.diagram.AbstractDiagram', {
 
       this.initDiagram( true );
 
-      this._startRefresh(this._timerPopup);
+      this._startRefresh(this._timerPopup, true);
     },
 
     initDiagram: function( isPopup ) {

--- a/source/class/cv/plugins/diagram/AbstractDiagram.js
+++ b/source/class/cv/plugins/diagram/AbstractDiagram.js
@@ -460,11 +460,17 @@ qx.Class.define('cv.plugins.diagram.AbstractDiagram', {
      * Start the refresh timer
      *
      * @param timer {qx.event.Timer} start this timer
+     * @param runImmediately {Boolean} fire the timers 'interval' event immediately to trigger an refresh right now
      * @protected
      */
-    _startRefresh: function(timer) {
-      if (timer && !timer.isEnabled()) {
-        timer.start();
+    _startRefresh: function(timer, runImmediately) {
+      if (timer) {
+        if (!timer.isEnabled()) {
+          timer.start();
+        }
+        if (runImmediately === true) {
+          timer.fireEvent('interval');
+        }
       }
     },
 

--- a/source/class/cv/plugins/diagram/Diagram.js
+++ b/source/class/cv/plugins/diagram/Diagram.js
@@ -101,7 +101,7 @@ qx.Class.define('cv.plugins.diagram.Diagram', {
           }
         }, this);
 
-        broker.subscribe("path." + pageId + ".appear", function () {
+        broker.subscribe("page." + pageId + ".appear", function () {
           // create diagram when it's not already existing
           if (this._init) {
             this.initDiagram(false);

--- a/source/class/cv/plugins/diagram/Diagram.js
+++ b/source/class/cv/plugins/diagram/Diagram.js
@@ -107,7 +107,7 @@ qx.Class.define('cv.plugins.diagram.Diagram', {
             this.initDiagram(false);
           }
           // start refreshing when page is entered
-          this._startRefresh(this._timer);
+          this._startRefresh(this._timer, true);
         }, this);
 
         // initialize the diagram but don't make the initialization process wait for it

--- a/source/class/cv/ui/common/Refresh.js
+++ b/source/class/cv/ui/common/Refresh.js
@@ -37,7 +37,6 @@ qx.Mixin.define("cv.ui.common.Refresh", {
     // Stop the while invisible
     this.addListener("changeVisible", function(ev) {
       if (this._timer && ev.getData() !== ev.getOldData() && this.__ownTimerId === this._timer.toHashCode()) {
-        console.log('timer', this.getPath());
         if (ev.getData()) {
           this._timer.start();
         } else {

--- a/source/class/cv/ui/common/Refresh.js
+++ b/source/class/cv/ui/common/Refresh.js
@@ -36,7 +36,8 @@ qx.Mixin.define("cv.ui.common.Refresh", {
 
     // Stop the while invisible
     this.addListener("changeVisible", function(ev) {
-      if (this._timer && ev.getData() !== ev.getOldData()) {
+      if (this._timer && ev.getData() !== ev.getOldData() && this.__ownTimerId === this._timer.toHashCode()) {
+        console.log('timer', this.getPath());
         if (ev.getData()) {
           this._timer.start();
         } else {
@@ -70,6 +71,7 @@ qx.Mixin.define("cv.ui.common.Refresh", {
   members: {
     _timer: null,
     __setup: false,
+    __ownTimerId: null,
 
     setupRefreshAction: function () {
       if (this.getRefresh() && this.getRefresh() > 0) {
@@ -92,6 +94,7 @@ qx.Mixin.define("cv.ui.common.Refresh", {
             this.refreshAction(target, src);
           }, this);
           this._timer.start();
+          this.__ownTimerId = this._timer.toHashCode();
         }
       }
     },


### PR DESCRIPTION
- Diagram refresh has been fixed: the topic was wrong, so the AbstractDiagram._startRefresh method has never been called
- do not let the Refresh-Mixin start/stop timers that have been created somewhere else. This should prevent the refresh function from stopping in tr064 (and other) plugin.

Edit:
- just changed the behaviour to refresh immediately, after the diagram page appears