### PR TITLE
influxfetch could not handle series generated by smarthomeNG containi…

### DIFF
--- a/source/resource/plugins/diagram/influxfetch.php
+++ b/source/resource/plugins/diagram/influxfetch.php
@@ -85,7 +85,7 @@ function getTs( $tsParameter, $field, $start, $end, $ds, $res, $fill, $filter )
   if( '' == $ts[0] || '' == $ts[1] )
     return 'Error: wrong ts parameter [' . $tsParameter . ']';
 
-  if( !preg_match('/^[A-Za-z0-9_\-]*$/', $ts[1]) )
+  if( !preg_match('/^[A-Za-z0-9_\-\.]*$/', $ts[1]) )
     return 'Error: invalid series [' . $ts[1] . ']';
 
   if( '' == $field || !preg_match('/^[A-Za-z0-9_\-]*$/', $field) )


### PR DESCRIPTION
…ng  a dot in series name

influxdb plugin in smarthomeNG generates series names which could contain a dot in the name, e.g. 'eg.wohnzimmer.temperatur'.
Added the dot as a valid char in the preg_match.