### PR TITLE
fix lost formulas when using cache.

### DIFF
--- a/source/class/cv/ConfigCache.js
+++ b/source/class/cv/ConfigCache.js
@@ -59,6 +59,15 @@ qx.Class.define('cv.ConfigCache', {
       var model = cv.data.Model.getInstance();
       var cache = this.getData();
       cv.Config.configSettings = cache.configSettings;
+      // restore formulas
+      if (cv.Config.configSettings.mappings) {
+        Object.keys(cv.Config.configSettings.mappings).forEach(function (name) {
+          var mapping = cv.Config.configSettings.mappings[name];
+          if (mapping && mapping.formulaSource) {
+            mapping.formula = new Function('x', 'var y;' + mapping.formulaSource + '; return y;'); // jshint ignore:line
+          }
+        }, this);
+      }
       model.setWidgetDataModel(cache.data);
       model.setAddressList(cache.addresses);
       qx.bom.element.Attribute.set(body, "html", cv.ConfigCache.getBody());

--- a/source/class/cv/parser/MetaParser.js
+++ b/source/class/cv/parser/MetaParser.js
@@ -93,8 +93,8 @@ qx.Class.define("cv.parser.MetaParser", {
       var mapping = {};
       var formula = qx.bom.Selector.query('formula', elem);
       if (formula.length > 0) {
-        var func = qx.lang.Function.globalEval('var func = function(x){var y;' + qx.dom.Node.getText(formula[0]) + '; return y;}; func');
-        mapping.formula = func;
+        mapping.formulaSource = qx.dom.Node.getText(formula[0]);
+        mapping.formula = new Function('x', 'var y;' + mapping.formulaSource + '; return y;'); // jshint ignore:line
       }
       var subElements = qx.bom.Selector.query('entry', elem);
       subElements.forEach(function (subElem) {


### PR DESCRIPTION
fixes error reported here: https://knx-user-forum.de/forum/supportforen/cometvisu/1343891-cv-0-11-0-mapping-formula-wird-nicht-ausgef%C3%BChrt

This fix also needs to be cherry-picked to 0.11.1. This Bug also exists in the latest release.