### PR TITLE
- parse address in reload element

### DIFF
--- a/source/class/cv/parser/widgets/Reload.js
+++ b/source/class/cv/parser/widgets/Reload.js
@@ -40,7 +40,9 @@ qx.Class.define('cv.parser.widgets.Reload', {
      * @param pageType {String} Page type (2d, 3d, ...)
      */
     parse: function (xml, path, flavour, pageType) {
-      return cv.parser.WidgetParser.parseElement(this, xml, path, flavour, pageType);
+      var data = cv.parser.WidgetParser.parseElement(this, xml, path, flavour, pageType);
+      cv.parser.WidgetParser.parseAddress(xml, path);
+      return data;
     }
   },
 

--- a/source/class/cv/ui/structure/pure/Reload.js
+++ b/source/class/cv/ui/structure/pure/Reload.js
@@ -46,7 +46,8 @@ qx.Class.define('cv.ui.structure.pure.Reload', {
       return;
     },
 
-    handleUpdate: function (value) {
+    _update: function (address, data) {
+      var value = this.defaultValueHandling(address, data);
       if (value > 0) {
         cv.util.Location.reload(true);
       }

--- a/source/test/karma/ui/structure/pure/Reload-spec.js
+++ b/source/test/karma/ui/structure/pure/Reload-spec.js
@@ -30,11 +30,11 @@ describe("testing a reload widget", function() {
   });
 
   it("should test the reload action", function() {
-    var widgetInstance = this.createTestElement("reload");
+    var widgetInstance = this.createTestElement("reload", null, null, '1/0/0');
     spyOn(cv.util.Location, "reload");
-    widgetInstance.handleUpdate(0);
+    widgetInstance._update('1/0/0', 0);
     expect(cv.util.Location.reload).not.toHaveBeenCalled();
-    widgetInstance.handleUpdate(1);
+    widgetInstance._update('1/0/0', 1);
     expect(cv.util.Location.reload).toHaveBeenCalledWith(true);
   });
 });

--- a/source/test/karma/ui/structure/pure/Trigger-spec.js
+++ b/source/test/karma/ui/structure/pure/Trigger-spec.js
@@ -213,7 +213,6 @@ describe("testing a trigger", function() {
         type: "pointerup"
       }));
       Reg.fireEvent(actor, "pointerup", qx.event.type.Pointer, [nativeEvent, actor, actor, true, true]);
-      qx.event.Registration.fireEvent(actor, "tap", qx.event.type.Event, []);
       expect(actor).not.toHaveClass("switchPressed");
       expect(actor).toHaveClass("switchUnpressed");
 


### PR DESCRIPTION
- fix update handling

fixes error reported here: https://knx-user-forum.de/forum/supportforen/cometvisu/1349460-reload-widget-funktioniert-nicht