### PR TITLE
fix template example to correctly bracket the actual template

### DIFF
--- a/doc/manual/de/config/xml-format.rst
+++ b/doc/manual/de/config/xml-format.rst
@@ -225,34 +225,36 @@ die entsprechenden Werte ersetzt werden. Das folgende Beispiel zeigt, wie man ei
 
     <pages>
         <meta>
-            <template name="Heizung">
-                <group name="Heizung">
-                  {{{ additional_content }}}
-                  <slide min="0" max="100" format="%d%%">
-                    <label>
-                      <icon name="sani_heating" />
-                      Heizung
-                    </label>
-                    <address transform="OH:dimmer" variant="">{{ control_address }}</address>
-                  </slide>
-                  <info format="%.1f °C">
-                    <label>
-                      <icon name="temp_temperature" />
-                      Ist
-                    </label>
-                    <address transform="OH:number" variant="">{{ currenttemp_address }}</address>
-                  </info>
-                  <infotrigger uplabel="+" upvalue="0.5" downlabel="-"
-                               downvalue="-0.5" styling="BluePurpleRedTemp"
-                               infoposition="middle" format="%.1f °C" change="absolute" min="15" max="25">
-                    <label>
-                      <icon name="temp_control" />
-                      Soll
-                    </label>
-                    <address transform="OH:number" variant="">{{ targettemp_address }}</address>
-                  </infotrigger>
-                </group>
-            </template>
+            <templates>
+                <template name="Heizung">
+                    <group name="Heizung">
+                      {{{ additional_content }}}
+                      <slide min="0" max="100" format="%d%%">
+                        <label>
+                          <icon name="sani_heating" />
+                          Heizung
+                        </label>
+                        <address transform="OH:dimmer" variant="">{{ control_address }}</address>
+                      </slide>
+                      <info format="%.1f °C">
+                        <label>
+                          <icon name="temp_temperature" />
+                          Ist
+                        </label>
+                        <address transform="OH:number" variant="">{{ currenttemp_address }}</address>
+                      </info>
+                      <infotrigger uplabel="+" upvalue="0.5" downlabel="-"
+                                   downvalue="-0.5" styling="BluePurpleRedTemp"
+                                   infoposition="middle" format="%.1f °C" change="absolute" min="15" max="25">
+                        <label>
+                          <icon name="temp_control" />
+                          Soll
+                        </label>
+                        <address transform="OH:number" variant="">{{ targettemp_address }}</address>
+                      </infotrigger>
+                    </group>
+                </template>
+            </templates>
         </meta>
         <page>
             <page name="Wohnzimmer">

--- a/doc/manual/en/config/xml-format.rst
+++ b/doc/manual/en/config/xml-format.rst
@@ -222,34 +222,36 @@ shows how to define and use a template.
 
     <pages>
         <meta>
-            <template name="Heating">
-                <group name="Heating">
-                  {{{ additional_content }}}
-                  <slide min="0" max="100" format="%d%%">
-                    <label>
-                      <icon name="sani_heating" />
-                      Heating
-                    </label>
-                    <address transform="OH:dimmer" variant="">{{ control_address }}</address>
-                  </slide>
-                  <info format="%.1f °C">
-                    <label>
-                      <icon name="temp_temperature" />
-                      actual value
-                    </label>
-                    <address transform="OH:number" variant="">{{ currenttemp_address }}</address>
-                  </info>
-                  <infotrigger uplabel="+" upvalue="0.5" downlabel="-"
-                               downvalue="-0.5" styling="BluePurpleRedTemp"
-                               infoposition="middle" format="%.1f °C" change="absolute" min="15" max="25">
-                    <label>
-                      <icon name="temp_control" />
-                      setpoint
-                    </label>
-                    <address transform="OH:number" variant="">{{ targettemp_address }}</address>
-                  </infotrigger>
-                </group>
-            </template>
+            <templates>
+                <template name="Heating">
+                    <group name="Heating">
+                      {{{ additional_content }}}
+                      <slide min="0" max="100" format="%d%%">
+                        <label>
+                          <icon name="sani_heating" />
+                          Heating
+                        </label>
+                        <address transform="OH:dimmer" variant="">{{ control_address }}</address>
+                      </slide>
+                      <info format="%.1f °C">
+                        <label>
+                          <icon name="temp_temperature" />
+                          actual value
+                        </label>
+                        <address transform="OH:number" variant="">{{ currenttemp_address }}</address>
+                      </info>
+                      <infotrigger uplabel="+" upvalue="0.5" downlabel="-"
+                                   downvalue="-0.5" styling="BluePurpleRedTemp"
+                                   infoposition="middle" format="%.1f °C" change="absolute" min="15" max="25">
+                        <label>
+                          <icon name="temp_control" />
+                          setpoint
+                        </label>
+                        <address transform="OH:number" variant="">{{ targettemp_address }}</address>
+                      </infotrigger>
+                    </group>
+                </template>
+            </templates>
         </meta>
         <page>
             <page name="Living room">


### PR DESCRIPTION
Hi,

in the manual, the template definition is not bracketed in a <templates>/</templates> construct. This pull request fixes the issue and allows the example to be actually used in CometVisu.

Greetings
Marc
