### PR TITLE
do not use group widgets align setting as global class because its on…

### DIFF
--- a/source/class/cv/parser/WidgetParser.js
+++ b/source/class/cv/parser/WidgetParser.js
@@ -186,7 +186,8 @@ qx.Class.define('cv.parser.WidgetParser', {
       var layout = this.parseLayout( qx.bom.Selector.matches('layout', qx.dom.Hierarchy.getChildElements(element))[0] );
       var style = qx.lang.Object.isEmpty(layout) ? '' : 'style="' + this.extractLayout( layout, pageType ) + '"';
       var classes = handler.getDefaultClasses ? handler.getDefaultClasses(widgetType) : this.getDefaultClasses(widgetType);
-      if ( qx.bom.element.Attribute.get(element, 'align') ) {
+      // the group widgets align attribute is just targeting the group header and is handled by the widget itself, so we skip it here
+      if ( qx.bom.element.Attribute.get(element, 'align') && widgetType !== "group" ) {
         classes+=" "+qx.bom.element.Attribute.get(element, 'align') ;
       }
       classes += ' ' + this.setWidgetLayout(element, path);


### PR DESCRIPTION
…ly aligning the group header

fixes error reported here:
https://knx-user-forum.de/forum/supportforen/cometvisu/1385023-cv11-0-text-widget-zeigt-label-zentriert-an