### PR TITLE
Reduce some Qx and switch to native

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,10 @@ jobs:
     - source temp-python/bin/activate
     - "./generate.py source -sI"
     - deactivate
-    - "node ./node_modules/protractor/bin/webdriver-manager update --gecko=false"
+    - export CHROME_VERSION=$($CHROME_BIN --version | awk '{ print $3 }' | cut -d'.' -f 1,2,3)
+    - export DRIVER_VERSION=$(curl -s "https://chromedriver.storage.googleapis.com/LATEST_RELEASE_${CHROME_VERSION}")
+    - echo "using chrome driver version $DRIVER_VERSION"
+    - "node ./node_modules/protractor/bin/webdriver-manager update --gecko=false --versions.chrome=${DRIVER_VERSION}"
     - grunt e2e-chrome
   - name: 'End-to-end Tests: Chrome beta'
     env: CV_BUILD=test CV_BROWSER=Chrome_travis CV_VERSION=beta

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -586,7 +586,7 @@ module.exports = function(grunt) {
           var now = new Date();
           newName += "-" + now.toISOString().split(".")[0].replace(/[\D]/g, "");
         }
-        fs.rename(path + file, path + newName + "." + parts.join('.'));
+        fs.renameSync(path + file, path + newName + "." + parts.join('.'));
       }
     });
   });

--- a/client/source/class/cv/io/Client.js
+++ b/client/source/class/cv/io/Client.js
@@ -248,13 +248,13 @@ qx.Class.define('cv.io.Client', {
 
     setBackend: function(newBackend) {
       // override default settings
-      var backend = qx.lang.Object.mergeWith(qx.lang.Object.clone(cv.io.Client.backends['default']), newBackend);
+      var backend = Object.assign({}, cv.io.Client.backends['default'], newBackend);
       this.backend = backend;
       if (backend.transport === 'sse' && backend.transportFallback) {
         if (window.EventSource === undefined) {
           // browser does not support EventSource object => use fallback
           // transport + settings
-          qx.lang.Object.mergeWith(backend, backend.transportFallback);
+          Object.assign(backend, backend.transportFallback);
         }
       }
       // add trailing slash to baseURL if not set
@@ -496,7 +496,7 @@ qx.Class.define('cv.io.Client', {
             delete options.listeners;
           }
         }
-        ajaxRequest.set(qx.lang.Object.mergeWith({
+        ajaxRequest.set(Object.assign({
           accept: "application/json"
         }, options || {}));
         if (callback) {
@@ -553,7 +553,7 @@ qx.Class.define('cv.io.Client', {
       var json = this.getResponse(args);
       // read backend configuration if send by backend
       if (json.c) {
-        this.setBackend(qx.lang.Object.mergeWith(this.getBackend(), json.c));
+        this.setBackend(Object.assign(this.getBackend(), json.c));
       }
       this.session = json.s || "SESSION";
       this.setServer(this.getResponseHeader(args, "Server"));

--- a/client/source/class/cv/io/Client.js
+++ b/client/source/class/cv/io/Client.js
@@ -60,7 +60,7 @@ qx.Class.define('cv.io.Client', {
     }
 
     if (backendName && backendName !== 'default') {
-      if (qx.lang.Type.isObject(backendName)) {
+      if (typeof backendName === 'object') {
         // override default settings
         this.setBackend(backendName);
       } else if (cv.io.Client.backends[backendName]) {
@@ -402,7 +402,7 @@ qx.Class.define('cv.io.Client', {
         if (!ev) { return null; }
         var json = ev.getTarget().getResponse();
         if (!json) { return null; }
-        if (qx.lang.Type.isString(json)) {
+        if (typeof json === 'string') {
           json = cv.io.parser.Json.parse(json);
         }
         return json;
@@ -428,7 +428,7 @@ qx.Class.define('cv.io.Client', {
         Object.getOwnPropertyNames(data).forEach(function (key) {
           if (key === "i" || key === "t") {
             prefix += key + "=" + data[key] + "&";
-          } else if (qx.lang.Type.isArray(data[key])) {
+          } else if (Array.isArray(data[key])) {
             suffix += key + "=" + data[key].join("&" + key + "=") + "&";
           } else {
             suffix += key + "=" + data[key] + "&";

--- a/client/source/class/cv/io/parser/Json.js
+++ b/client/source/class/cv/io/parser/Json.js
@@ -31,12 +31,12 @@ qx.Class.define('cv.io.parser.Json', {
       "qx": function(data) {
         var result = {};
         try {
-          result = qx.lang.Json.parse(data);
+          result = JSON.parse(data);
         } catch (e) {
           data.split("}{").forEach(function(subData, i) {
             try {
               var jsonString = i === 0 ? subData + "}" : "{" + subData;
-              result = Object.assign(result, qx.lang.Json.parse(jsonString));
+              result = Object.assign(result, JSON.parse(jsonString));
             } catch (se) {
               qx.log.Logger.error(se);
             }

--- a/client/source/class/cv/io/parser/Json.js
+++ b/client/source/class/cv/io/parser/Json.js
@@ -36,7 +36,7 @@ qx.Class.define('cv.io.parser.Json', {
           data.split("}{").forEach(function(subData, i) {
             try {
               var jsonString = i === 0 ? subData + "}" : "{" + subData;
-              result = qx.lang.Object.mergeWith(result, qx.lang.Json.parse(jsonString));
+              result = Object.assign(result, qx.lang.Json.parse(jsonString));
             } catch (se) {
               qx.log.Logger.error(se);
             }

--- a/client/source/class/cv/io/transport/LongPolling.js
+++ b/client/source/class/cv/io/transport/LongPolling.js
@@ -184,7 +184,7 @@ qx.Class.define('cv.io.transport.LongPolling', {
         // addresses-startPageAddresses
         var diffAddresses = [];
         for (var i = 0; i < this.client.addresses.length; i++) {
-          if (!qx.lang.Array.contains(this.client.initialAddresses, this.client.addresses[i])) {
+          if (!this.client.initialAddresses.includes(this.client.addresses[i])) {
             diffAddresses.push(this.client.addresses[i]);
           }
         }

--- a/doc/manual/de/colab/dev/test.rst
+++ b/doc/manual/de/colab/dev/test.rst
@@ -86,7 +86,7 @@ Der Test für diese Datei sollte nun folgendermaßen aussehen:
         // die Hilfsfunktion gibt ein Array mit 2 Elementen zurück, das erste ist die Instanz den Widget-Objekts, das zweite der HTML-Code als String
         var res = this.createTestWidgetString("new-widget", {}, "<label>Test</label>");
         // macht aus dem String ein DOM Element
-        var widget = qx.bom.Html.clean([res[1]])[0];
+        var widget = (function(){var div=document.createElement('div');div.innerHTML=res[1];return div.childNodes[0];})();
         // das Widget Object (Instanz der Klasse cv.ui.structure.pure.NewWidget)
         var obj = res[0];
 

--- a/doc/manual/en/colab/dev/test.rst
+++ b/doc/manual/en/colab/dev/test.rst
@@ -95,7 +95,7 @@ The test for this file should now look like this:
         // the helper returns an array of 2 elements, the first is the widget object, the second the HTML code as a string
         var res = this.createTestWidgetString("new-widget", {}, "<label>Test</label>");
         // turns the string into a DOM element
-        var widget = qx.bom.Html.clean([res[1]])[0];
+        var widget = (function(){var div=document.createElement('div');div.innerHTML=res[1];return div.childNodes[0];})();
         // Widget Object (instance of class cv.ui.structure.pure.NewWidget)
         var obj = res[0];
 

--- a/skeletons/widget-test.js
+++ b/skeletons/widget-test.js
@@ -6,7 +6,7 @@ describe("testing a %WIDGET_NAME% widget", function() {
 
   it("should test the %WIDGET_NAME% creator", function() {
     var res = this.createTestWidgetString("%WIDGET_NAME%", {}, "<label>Test</label>");
-    var widget = qx.bom.Html.clean([res[1]])[0];
+    var widget = (function(){var div=document.createElement('div');div.innerHTML=res[1];return div.childNodes[0];})();
     var obj = res[0];
 
     expect(widget).toHaveClass('%WIDGET_NAME%');

--- a/skeletons/widget-test.js
+++ b/skeletons/widget-test.js
@@ -6,7 +6,7 @@ describe("testing a %WIDGET_NAME% widget", function() {
 
   it("should test the %WIDGET_NAME% creator", function() {
     var res = this.createTestWidgetString("%WIDGET_NAME%", {}, "<label>Test</label>");
-    var widget = (function(){var div=document.createElement('div');div.innerHTML=res[1];return div.childNodes[0];})();
+    var widget = cv.util.String.htmlStringToDomElement(res[1]);
     var obj = res[0];
 
     expect(widget).toHaveClass('%WIDGET_NAME%');

--- a/source/class/cv/Application.js
+++ b/source/class/cv/Application.js
@@ -255,7 +255,7 @@ qx.Class.define("cv.Application",
           }
         }
       }
-      body += "```\n"+exString+"\n```\n\n**Client-Data:**\n```\n"+qx.lang.Json.stringify(bugData, null, 2)+"\n```";
+      body += "```\n"+exString+"\n```\n\n**Client-Data:**\n```\n"+JSON.stringify(bugData, null, 2)+"\n```";
 
       var notification = {
         topic: "cv.error",

--- a/source/class/cv/Application.js
+++ b/source/class/cv/Application.js
@@ -374,7 +374,7 @@ qx.Class.define("cv.Application",
           cv.ui.ToastManager.getInstance();
         } else {
           // load empty HTML structure
-          qx.bom.element.Attribute.set(body, "html", cv.Application.HTML_STRUCT);
+          body.innerHTML = cv.Application.HTML_STRUCT;
           // initialize NotificationCenter
           cv.ui.NotificationCenter.getInstance();
           cv.ui.ToastManager.getInstance();
@@ -408,7 +408,7 @@ qx.Class.define("cv.Application",
 
           // load empty HTML structure
           var body = qx.bom.Selector.query("body")[0];
-          qx.bom.element.Attribute.set(body, "html", cv.Application.HTML_STRUCT);
+          body.innerHTML = cv.Application.HTML_STRUCT;
 
           //empty model
           cv.data.Model.getInstance().resetWidgetDataModel();

--- a/source/class/cv/Application.js
+++ b/source/class/cv/Application.js
@@ -280,13 +280,13 @@ qx.Class.define("cv.Application",
                   }
                   parent = parent.parentNode;
                 }
-                var box = qx.bom.Selector.query("#enableReporting", parent)[0];
+                var box = parent.querySelector("#enableReporting");
                 var url = window.location.href.split("#").shift();
                 if (box && box.checked) {
                   // reload with reporting enabled
                   url = qx.util.Uri.appendParamsToUrl(url, "reporting=true");
                 }
-                box = qx.bom.Selector.query("#reportErrors", parent)[0];
+                box = parent.querySelector("#reportErrors");
                 if (box && box.checked) {
                   // reload with automatic error reporting enabled
                   url = qx.util.Uri.appendParamsToUrl(url, "reportErrors=true");
@@ -363,7 +363,7 @@ qx.Class.define("cv.Application",
       qx.bom.Lifecycle.onReady(function () {
         // init notification router
         cv.core.notifications.Router.getInstance();
-        var body = qx.bom.Selector.query("body")[0];
+        var body = document.querySelector("body");
 
         if (cv.Config.enableCache && cv.ConfigCache.isCached()) {
           // load settings
@@ -407,7 +407,7 @@ qx.Class.define("cv.Application",
           cv.ConfigCache.clear();
 
           // load empty HTML structure
-          var body = qx.bom.Selector.query("body")[0];
+          var body = document.querySelector("body");
           body.innerHTML = cv.Application.HTML_STRUCT;
 
           //empty model

--- a/source/class/cv/Application.js
+++ b/source/class/cv/Application.js
@@ -275,7 +275,7 @@ qx.Class.define("cv.Application",
               action: function(ev) {
                 var parent = ev.getTarget().parentNode;
                 while (parent) {
-                  if (parent.id === "notification-center" || qx.bom.element.Class.has(parent, "popup")) {
+                  if (parent.id === "notification-center" || parent.classList.contains("popup")) {
                     break;
                   }
                   parent = parent.parentNode;

--- a/source/class/cv/ConfigCache.js
+++ b/source/class/cv/ConfigCache.js
@@ -51,7 +51,7 @@ qx.Class.define('cv.ConfigCache', {
         addresses: model.getAddressList(),
         configSettings: config
       });
-      localStorage.setItem(cv.Config.configSuffix+".body", qx.bom.element.Attribute.get(qx.bom.Selector.query('body')[0], 'html'));
+      localStorage.setItem(cv.Config.configSuffix+".body", qx.bom.Selector.query('body')[0].getAttribute('html'));
     },
 
     restore: function() {

--- a/source/class/cv/ConfigCache.js
+++ b/source/class/cv/ConfigCache.js
@@ -41,7 +41,7 @@ qx.Class.define('cv.ConfigCache', {
       if (qx.core.Environment.get("html.storage.local") === false) {
         return;
       }
-      var config = qx.lang.Object.clone(cv.Config.configSettings, true);
+      var config = JSON.parse(JSON.stringify(cv.Config.configSettings)); // deep copy
       var model = cv.data.Model.getInstance();
       this.save(this._cacheKey, {
         hash: this.toHash(xml),

--- a/source/class/cv/ConfigCache.js
+++ b/source/class/cv/ConfigCache.js
@@ -51,11 +51,11 @@ qx.Class.define('cv.ConfigCache', {
         addresses: model.getAddressList(),
         configSettings: config
       });
-      localStorage.setItem(cv.Config.configSuffix+".body", qx.bom.Selector.query('body')[0].innerHTML);
+      localStorage.setItem(cv.Config.configSuffix+".body", document.querySelector('body').innerHTML);
     },
 
     restore: function() {
-      var body = qx.bom.Selector.query("body")[0];
+      var body = document.querySelector("body");
       var model = cv.data.Model.getInstance();
       var cache = this.getData();
       cv.Config.configSettings = cache.configSettings;

--- a/source/class/cv/ConfigCache.js
+++ b/source/class/cv/ConfigCache.js
@@ -75,7 +75,7 @@ qx.Class.define('cv.ConfigCache', {
     
     save: function(key, data) {
       if (qx.core.Environment.get("html.storage.local") === true) {
-        localStorage.setItem(cv.Config.configSuffix + "." + key, qx.lang.Json.stringify(data));
+        localStorage.setItem(cv.Config.configSuffix + "." + key, JSON.stringify(data));
       }
     },
     
@@ -91,7 +91,7 @@ qx.Class.define('cv.ConfigCache', {
         return null;
       }
       if (!this._parseCacheData) {
-        this._parseCacheData = qx.lang.Json.parse(localStorage.getItem(cv.Config.configSuffix + "." + this._cacheKey));
+        this._parseCacheData = JSON.parse(localStorage.getItem(cv.Config.configSuffix + "." + this._cacheKey));
       }
       if (!this._parseCacheData) {
         return null;

--- a/source/class/cv/ConfigCache.js
+++ b/source/class/cv/ConfigCache.js
@@ -70,7 +70,7 @@ qx.Class.define('cv.ConfigCache', {
       }
       model.setWidgetDataModel(cache.data);
       model.setAddressList(cache.addresses);
-      body.setAttribute("html", cv.ConfigCache.getBody());
+      body.innerHTML = cv.ConfigCache.getBody();
     },
     
     save: function(key, data) {

--- a/source/class/cv/ConfigCache.js
+++ b/source/class/cv/ConfigCache.js
@@ -51,7 +51,7 @@ qx.Class.define('cv.ConfigCache', {
         addresses: model.getAddressList(),
         configSettings: config
       });
-      localStorage.setItem(cv.Config.configSuffix+".body", qx.bom.Selector.query('body')[0].getAttribute('html'));
+      localStorage.setItem(cv.Config.configSuffix+".body", qx.bom.Selector.query('body')[0].innerHTML);
     },
 
     restore: function() {

--- a/source/class/cv/ConfigCache.js
+++ b/source/class/cv/ConfigCache.js
@@ -70,7 +70,7 @@ qx.Class.define('cv.ConfigCache', {
       }
       model.setWidgetDataModel(cache.data);
       model.setAddressList(cache.addresses);
-      qx.bom.element.Attribute.set(body, "html", cv.ConfigCache.getBody());
+      body.setAttribute("html", cv.ConfigCache.getBody());
     },
     
     save: function(key, data) {

--- a/source/class/cv/TemplateEngine.js
+++ b/source/class/cv/TemplateEngine.js
@@ -623,8 +623,9 @@ qx.Class.define('cv.TemplateEngine', {
         page_name = decodeURI(page_name.replace("\\\/", "/"));
 
         //      console.log("Page: "+page_name+", Scope: "+scope);
-        var selector = (scope !== undefined && scope !== null) ? '.page[id^="' + scope + '"] h1:contains(' + page_name + ')' : '.page h1:contains(' + page_name + ')';
+        var selector = (scope !== undefined && scope !== null) ? '.page[id^="' + scope + '"] h1' : '.page h1';
         var pages = document.querySelectorAll(selector);
+        pages = Array.from( pages ).filter(function(h){return h.textContent === page_name;});
         if (pages.length > 1 && this.getCurrentPage() !== null) {
           var currentPageId = this.getCurrentPage().getPath();
           // More than one Page found -> search in the current pages descendants first

--- a/source/class/cv/TemplateEngine.js
+++ b/source/class/cv/TemplateEngine.js
@@ -431,7 +431,7 @@ qx.Class.define('cv.TemplateEngine', {
         this.debug("logged in");
 
         // as we are sure that the default CSS were loaded now:
-        qx.bom.Selector.query('link[href*="mobile.css"]').forEach(function (elem) {
+        document.querySelectorAll('link[href*="mobile.css"]').forEach(function (elem) {
           elem.setAttribute('media', 'only screen and (max-width: ' + cv.Config.maxMobileScreenWidth + 'px)');
         });
         if (!cv.Config.cacheUsed) {
@@ -472,7 +472,7 @@ qx.Class.define('cv.TemplateEngine', {
         }, this);
 
         // run the Trick-O-Matic scripts for great SVG backdrops
-        qx.bom.Selector.query('embed').forEach(function(elem) {
+        document.querySelectorAll('embed').forEach(function(elem) {
           elem.onload = cv.ui.TrickOMatic.run;
         });
 
@@ -480,8 +480,8 @@ qx.Class.define('cv.TemplateEngine', {
 
         this.xml = null; // not needed anymore - free the space
 
-        qx.bom.Selector.query('.icon').forEach(cv.util.IconTools.fillRecoloredIcon, cv.util.IconTools);
-        qx.bom.Selector.query('.loading').forEach(function(elem) {
+        document.querySelectorAll('.icon').forEach(cv.util.IconTools.fillRecoloredIcon, cv.util.IconTools);
+        document.querySelectorAll('.loading').forEach(function(elem) {
           qx.bom.element.Class.remove(elem, 'loading');
         }, this);
 
@@ -624,7 +624,7 @@ qx.Class.define('cv.TemplateEngine', {
 
         //      console.log("Page: "+page_name+", Scope: "+scope);
         var selector = (scope !== undefined && scope !== null) ? '.page[id^="' + scope + '"] h1:contains(' + page_name + ')' : '.page h1:contains(' + page_name + ')';
-        var pages = qx.bom.Selector.query(selector);
+        var pages = document.querySelectorAll(selector);
         if (pages.length > 1 && this.getCurrentPage() !== null) {
           var currentPageId = this.getCurrentPage().getPath();
           // More than one Page found -> search in the current pages descendants first
@@ -705,7 +705,7 @@ qx.Class.define('cv.TemplateEngine', {
 
       // push new state to history
       if (skipHistory === undefined) {
-        var headline = qx.bom.Selector.query("#"+page_id+" h1");
+        var headline = document.querySelectorAll("#"+page_id+" h1");
         var pageTitle = "CometVisu";
         if (headline.length) {
           pageTitle = headline[0].textContent+ " - "+pageTitle;
@@ -721,7 +721,7 @@ qx.Class.define('cv.TemplateEngine', {
     selectDesign: function () {
       var body = document.querySelector("body");
 
-      qx.bom.Selector.query('body > *').forEach(function(elem) {
+      document.querySelectorAll('body > *').forEach(function(elem) {
         qx.bom.element.Style.set(elem, 'display', 'none');
       }, this);
       qx.bom.element.Style.set(body, 'backgroundColor', "black");

--- a/source/class/cv/TemplateEngine.js
+++ b/source/class/cv/TemplateEngine.js
@@ -432,7 +432,7 @@ qx.Class.define('cv.TemplateEngine', {
 
         // as we are sure that the default CSS were loaded now:
         qx.bom.Selector.query('link[href*="mobile.css"]').forEach(function (elem) {
-          qx.bom.element.Attribute.set(elem, 'media', 'only screen and (max-width: ' + cv.Config.maxMobileScreenWidth + 'px)');
+          elem.setAttribute('media', 'only screen and (max-width: ' + cv.Config.maxMobileScreenWidth + 'px)');
         });
         if (!cv.Config.cacheUsed) {
           this.debug("creating pages");

--- a/source/class/cv/TemplateEngine.js
+++ b/source/class/cv/TemplateEngine.js
@@ -333,7 +333,7 @@ qx.Class.define('cv.TemplateEngine', {
       var settings = cv.Config.configSettings;
       var pagesNode = qx.bom.Selector.query("pages", loaded_xml)[0];
 
-      var predefinedDesign = qx.bom.element.Attribute.get(pagesNode, "design");
+      var predefinedDesign = pagesNode.getAttribute("design");
       // design by url
       // design by config file
       if (!cv.Config.clientDesign && !settings.clientDesign) {
@@ -349,37 +349,37 @@ qx.Class.define('cv.TemplateEngine', {
       // load structure-part
       this.loadParts([cv.Config.getStructure()]);
 
-      if (qx.bom.element.Attribute.get(pagesNode, "backend") !== null) {
-        settings.backend = qx.bom.element.Attribute.get(pagesNode, "backend");
+      if (pagesNode.getAttribute("backend") !== null) {
+        settings.backend = pagesNode.getAttribute("backend");
       }
       this.initBackendClient();
 
-      if (qx.bom.element.Attribute.get(pagesNode, 'scroll_speed') === null) {
+      if (pagesNode.getAttribute('scroll_speed') === null) {
         settings.scrollSpeed = 400;
       } else {
-        settings.scrollSpeed = parseInt(qx.bom.element.Attribute.get(pagesNode, 'scroll_speed'));
+        settings.scrollSpeed = parseInt(pagesNode.getAttribute('scroll_speed'));
       }
 
-      if (qx.bom.element.Attribute.get(pagesNode, 'bind_click_to_widget') !== null) {
-        settings.bindClickToWidget = qx.bom.element.Attribute.get(pagesNode, 'bind_click_to_widget') === "true";
+      if (pagesNode.getAttribute('bind_click_to_widget') !== null) {
+        settings.bindClickToWidget = pagesNode.getAttribute('bind_click_to_widget') === "true";
       }
-      if (qx.bom.element.Attribute.get(pagesNode, 'default_columns') !== null) {
-        settings.defaultColumns = qx.bom.element.Attribute.get(pagesNode, 'default_columns');
+      if (pagesNode.getAttribute('default_columns') !== null) {
+        settings.defaultColumns = pagesNode.getAttribute('default_columns');
       }
-      if (qx.bom.element.Attribute.get(pagesNode, 'min_column_width') !== null) {
-        settings.minColumnWidth = qx.bom.element.Attribute.get(pagesNode, 'min_column_width');
+      if (pagesNode.getAttribute('min_column_width') !== null) {
+        settings.minColumnWidth = pagesNode.getAttribute('min_column_width');
       }
-      settings.screensave_time = qx.bom.element.Attribute.get(pagesNode, 'screensave_time');
+      settings.screensave_time = pagesNode.getAttribute('screensave_time');
       if (settings.screensave_time) {
         settings.screensave_time = parseInt(settings.screensave_time, 10);
       }
-      settings.screensave_page = qx.bom.element.Attribute.get(pagesNode, 'screensave_page');
+      settings.screensave_page = pagesNode.getAttribute('screensave_page');
 
-      if (qx.bom.element.Attribute.get(pagesNode, 'max_mobile_screen_width') !== null) {
-        settings.maxMobileScreenWidth = qx.bom.element.Attribute.get(pagesNode, 'max_mobile_screen_width');
+      if (pagesNode.getAttribute('max_mobile_screen_width') !== null) {
+        settings.maxMobileScreenWidth = pagesNode.getAttribute('max_mobile_screen_width');
       }
 
-      var globalClass = qx.bom.element.Attribute.get(pagesNode, 'class');
+      var globalClass = pagesNode.getAttribute('class');
       if (globalClass !== null) {
         qx.bom.element.Class.add(qx.bom.Selector.query('body')[0], globalClass);
       }
@@ -632,7 +632,7 @@ qx.Class.define('cv.TemplateEngine', {
           pages.forEach(function (page) {
             var p = cv.util.Tree.getClosest(page, ".page");
             if (qx.dom.Node.getText(page) === page_name) {
-              var pid = qx.bom.element.Attribute.get(p, 'id');
+              var pid = p.getAttribute('id');
               if (pid.length < currentPageId.length) {
                 // found pages path is shorter the the current pages -> must be an ancestor
                 if (currentPageId.indexOf(pid) === 0) {
@@ -657,7 +657,7 @@ qx.Class.define('cv.TemplateEngine', {
             // take the first page that fits (old behaviour)
             pages.forEach(function (page) {
               if (qx.dom.Node.getText(page)  === page_name) {
-                page_id = qx.bom.element.Attribute.get(cv.util.Tree.getClosest(page, ".page"), "id");
+                page_id = cv.util.Tree.getClosest(page, ".page").getAttribute("id");
                 // break loop
                 return false;
               }
@@ -666,7 +666,7 @@ qx.Class.define('cv.TemplateEngine', {
         } else {
           pages.forEach(function (page) {
             if (qx.dom.Node.getText(page) === page_name) {
-              page_id = qx.bom.element.Attribute.get(cv.util.Tree.getClosest(page, ".page"), "id");
+              page_id = cv.util.Tree.getClosest(page, ".page").getAttribute("id");
               // break loop
               return false;
             }

--- a/source/class/cv/TemplateEngine.js
+++ b/source/class/cv/TemplateEngine.js
@@ -723,9 +723,9 @@ qx.Class.define('cv.TemplateEngine', {
       var body = document.querySelector("body");
 
       document.querySelectorAll('body > *').forEach(function(elem) {
-        elem.style['display'] = 'none';
+        elem.style.display = 'none';
       }, this);
-      body.style['backgroundColor'] = "black";
+      body.style['background-color'] = "black";
 
 
       var div = qx.dom.Element.create("div", {id: "designSelector"});
@@ -781,11 +781,11 @@ qx.Class.define('cv.TemplateEngine', {
           qx.dom.Element.insertEnd(tDiv, myDiv);
 
           qx.event.Registration.addListener(myDiv, 'pointerover', function() {
-            myDiv.style['background'] = "#bbbbbb";
+            myDiv.style.background = "#bbbbbb";
           }, this);
 
           qx.event.Registration.addListener(myDiv, 'pointerout', function() {
-            myDiv.style['background'] = "transparent";
+            myDiv.style.background = "transparent";
           }, this);
 
           qx.event.Registration.addListener(myDiv, 'tap', function() {

--- a/source/class/cv/TemplateEngine.js
+++ b/source/class/cv/TemplateEngine.js
@@ -728,13 +728,13 @@ qx.Class.define('cv.TemplateEngine', {
 
 
       var div = qx.dom.Element.create("div", {id: "designSelector"});
-      qx.bom.element.Style.setStyles(body, {
+      Object.entries({
         background: "#808080",
         width: "400px",
         color: "white",
         margin: "auto",
         padding: "0.5em"
-      });
+      }).forEach(function(key,value){body.style[key]=value;});
       div.innerHTML = "Loading ...";
 
       body.appendChild(div);
@@ -773,10 +773,10 @@ qx.Class.define('cv.TemplateEngine', {
             zIndex: 2
           });
           var pos = document.querySelector("iframe").getBoundingClientRect();
-          qx.bom.element.Style.setStyles(tDiv, {
+          Object.entries({
             left: pos.left + "px",
             top: pos.top + "px"
-          });
+          }).forEach(function(key,value){tDiv.style[key]=value;});
           qx.dom.Element.insertEnd(tDiv, myDiv);
 
           qx.event.Registration.addListener(myDiv, 'pointerover', function() {

--- a/source/class/cv/TemplateEngine.js
+++ b/source/class/cv/TemplateEngine.js
@@ -331,7 +331,7 @@ qx.Class.define('cv.TemplateEngine', {
        */
       // read predefined design in config
       var settings = cv.Config.configSettings;
-      var pagesNode = qx.bom.Selector.query("pages", loaded_xml)[0];
+      var pagesNode = loaded_xml.querySelector("pages");
 
       var predefinedDesign = pagesNode.getAttribute("design");
       // design by url
@@ -381,7 +381,7 @@ qx.Class.define('cv.TemplateEngine', {
 
       var globalClass = pagesNode.getAttribute('class');
       if (globalClass !== null) {
-        qx.bom.element.Class.add(qx.bom.Selector.query('body')[0], globalClass);
+        qx.bom.element.Class.add(document.querySelector('body'), globalClass);
       }
 
       settings.scriptsToLoad = [];
@@ -436,7 +436,7 @@ qx.Class.define('cv.TemplateEngine', {
         });
         if (!cv.Config.cacheUsed) {
           this.debug("creating pages");
-          var page = qx.bom.Selector.query('pages > page', this.xml)[0]; // only one page element allowed...
+          var page = this.xml.querySelector('pages > page'); // only one page element allowed...
 
           this.createPages(page, 'id');
           this.debug("finalizing");
@@ -719,7 +719,7 @@ qx.Class.define('cv.TemplateEngine', {
     },
 
     selectDesign: function () {
-      var body = qx.bom.Selector.query("body")[0];
+      var body = document.querySelector("body");
 
       qx.bom.Selector.query('body > *').forEach(function(elem) {
         qx.bom.element.Style.set(elem, 'display', 'none');
@@ -772,7 +772,7 @@ qx.Class.define('cv.TemplateEngine', {
             width: "160px",
             zIndex: 2
           });
-          var pos = qx.bom.Selector.query("iframe")[0].getBoundingClientRect();
+          var pos = document.querySelector("iframe").getBoundingClientRect();
           qx.bom.element.Style.setStyles(tDiv, {
             left: pos.left + "px",
             top: pos.top + "px"

--- a/source/class/cv/TemplateEngine.js
+++ b/source/class/cv/TemplateEngine.js
@@ -722,9 +722,9 @@ qx.Class.define('cv.TemplateEngine', {
       var body = document.querySelector("body");
 
       document.querySelectorAll('body > *').forEach(function(elem) {
-        qx.bom.element.Style.set(elem, 'display', 'none');
+        elem.style['display'] = 'none';
       }, this);
-      qx.bom.element.Style.set(body, 'backgroundColor', "black");
+      body.style['backgroundColor'] = "black";
 
 
       var div = qx.dom.Element.create("div", {id: "designSelector"});
@@ -780,11 +780,11 @@ qx.Class.define('cv.TemplateEngine', {
           qx.dom.Element.insertEnd(tDiv, myDiv);
 
           qx.event.Registration.addListener(myDiv, 'pointerover', function() {
-            qx.bom.element.Style.set(myDiv, 'background', "#bbbbbb");
+            myDiv.style['background'] = "#bbbbbb";
           }, this);
 
           qx.event.Registration.addListener(myDiv, 'pointerout', function() {
-            qx.bom.element.Style.set(myDiv, 'background', "transparent");
+            myDiv.style['background'] = "transparent";
           }, this);
 
           qx.event.Registration.addListener(myDiv, 'tap', function() {

--- a/source/class/cv/TemplateEngine.js
+++ b/source/class/cv/TemplateEngine.js
@@ -129,7 +129,7 @@ qx.Class.define('cv.TemplateEngine', {
      * @param parts {String[]|String} parts to load
      */
     loadParts: function(parts) {
-      if (!qx.lang.Type.isArray(parts)) {
+      if (!Array.isArray(parts)) {
         parts = [parts];
       }
       var loadLazyParts = this.lazyPlugins.filter(function(part) {
@@ -497,7 +497,7 @@ qx.Class.define('cv.TemplateEngine', {
      * Start the screensaver if a screensave time is set
      */
     startScreensaver: function() {
-      if (qx.lang.Type.isNumber(cv.Config.configSettings.screensave_time)) {
+      if (typeof cv.Config.configSettings.screensave_time === 'number') {
         this.screensave = new qx.event.Timer(cv.Config.configSettings.screensave_time * 1000);
         this.screensave.addListener("interval", function () {
           this.scrollToPage();

--- a/source/class/cv/TemplateEngine.js
+++ b/source/class/cv/TemplateEngine.js
@@ -381,7 +381,7 @@ qx.Class.define('cv.TemplateEngine', {
 
       var globalClass = pagesNode.getAttribute('class');
       if (globalClass !== null) {
-        qx.bom.element.Class.add(document.querySelector('body'), globalClass);
+        document.querySelector('body').classList.add(globalClass);
       }
 
       settings.scriptsToLoad = [];
@@ -482,7 +482,7 @@ qx.Class.define('cv.TemplateEngine', {
 
         document.querySelectorAll('.icon').forEach(cv.util.IconTools.fillRecoloredIcon, cv.util.IconTools);
         document.querySelectorAll('.loading').forEach(function(elem) {
-          qx.bom.element.Class.remove(elem, 'loading');
+          elem.classList.remove('loading');
         }, this);
 
         this.startScreensaver();

--- a/source/class/cv/TemplateEngine.js
+++ b/source/class/cv/TemplateEngine.js
@@ -632,7 +632,7 @@ qx.Class.define('cv.TemplateEngine', {
           var fallback = true;
           pages.forEach(function (page) {
             var p = cv.util.Tree.getClosest(page, ".page");
-            if (qx.dom.Node.getText(page) === page_name) {
+            if (page.innerText === page_name) {
               var pid = p.getAttribute('id');
               if (pid.length < currentPageId.length) {
                 // found pages path is shorter the the current pages -> must be an ancestor
@@ -657,7 +657,7 @@ qx.Class.define('cv.TemplateEngine', {
           if (fallback) {
             // take the first page that fits (old behaviour)
             pages.forEach(function (page) {
-              if (qx.dom.Node.getText(page)  === page_name) {
+              if (page.innerText  === page_name) {
                 page_id = cv.util.Tree.getClosest(page, ".page").getAttribute("id");
                 // break loop
                 return false;
@@ -666,7 +666,7 @@ qx.Class.define('cv.TemplateEngine', {
           }
         } else {
           pages.forEach(function (page) {
-            if (qx.dom.Node.getText(page) === page_name) {
+            if (page.innerText === page_name) {
               page_id = cv.util.Tree.getClosest(page, ".page").getAttribute("id");
               // break loop
               return false;
@@ -763,7 +763,7 @@ qx.Class.define('cv.TemplateEngine', {
           myDiv.innerHTML += "<iframe src=\""+qx.util.ResourceManager.getInstance().toUri("designs/design_preview.html")+"?design=" + element + "\" width=\"160\" height=\"90\" border=\"0\" scrolling=\"auto\" frameborder=\"0\" style=\"z-index: 1;\"></iframe>";
           myDiv.innerHTML += "<img width=\"60\" height=\"30\" src=\""+qx.util.ResourceManager.getInstance().toUri("demo/media/arrow.png")+"\" alt=\"select\" border=\"0\" style=\"margin: 60px 10px 10px 30px;\"/>";
 
-          qx.dom.Element.insertEnd(myDiv, div);
+          div.appendChild(myDiv);
 
 
           var tDiv = qx.dom.Element.create("div", {
@@ -778,7 +778,7 @@ qx.Class.define('cv.TemplateEngine', {
             left: pos.left + "px",
             top: pos.top + "px"
           }).forEach(function(key_value){tDiv.style[key_value[0]]=key_value[1];});
-          qx.dom.Element.insertEnd(tDiv, myDiv);
+          myDiv.appendChild(tDiv);
 
           qx.event.Registration.addListener(myDiv, 'pointerover', function() {
             myDiv.style.background = "#bbbbbb";

--- a/source/class/cv/TemplateEngine.js
+++ b/source/class/cv/TemplateEngine.js
@@ -735,7 +735,7 @@ qx.Class.define('cv.TemplateEngine', {
         color: "white",
         margin: "auto",
         padding: "0.5em"
-      }).forEach(function([key,value]){body.style[key]=value;});
+      }).forEach(function(key_value){body.style[key_value[0]]=key_value[1];});
       div.innerHTML = "Loading ...";
 
       body.appendChild(div);
@@ -777,7 +777,7 @@ qx.Class.define('cv.TemplateEngine', {
           Object.entries({
             left: pos.left + "px",
             top: pos.top + "px"
-          }).forEach(function([key,value]){tDiv.style[key]=value;});
+          }).forEach(function(key_value){tDiv.style[key_value[0]]=key_value[1];});
           qx.dom.Element.insertEnd(tDiv, myDiv);
 
           qx.event.Registration.addListener(myDiv, 'pointerover', function() {

--- a/source/class/cv/TemplateEngine.js
+++ b/source/class/cv/TemplateEngine.js
@@ -735,7 +735,7 @@ qx.Class.define('cv.TemplateEngine', {
         color: "white",
         margin: "auto",
         padding: "0.5em"
-      }).forEach(function(key,value){body.style[key]=value;});
+      }).forEach(function([key,value]){body.style[key]=value;});
       div.innerHTML = "Loading ...";
 
       body.appendChild(div);
@@ -777,7 +777,7 @@ qx.Class.define('cv.TemplateEngine', {
           Object.entries({
             left: pos.left + "px",
             top: pos.top + "px"
-          }).forEach(function(key,value){tDiv.style[key]=value;});
+          }).forEach(function([key,value]){tDiv.style[key]=value;});
           qx.dom.Element.insertEnd(tDiv, myDiv);
 
           qx.event.Registration.addListener(myDiv, 'pointerover', function() {

--- a/source/class/cv/TemplateEngine.js
+++ b/source/class/cv/TemplateEngine.js
@@ -136,7 +136,7 @@ qx.Class.define('cv.TemplateEngine', {
         return parts.indexOf(part) >= 0;
       });
       if (loadLazyParts.length) {
-        qx.lang.Array.exclude(parts, loadLazyParts);
+        parts = parts.filter(function(p){return !loadLazyParts.includes(p);});
       }
       this.__partQueue.append(parts);
       qx.io.PartLoader.require(parts, function(states) {
@@ -243,7 +243,8 @@ qx.Class.define('cv.TemplateEngine', {
       var model = cv.data.Model.getInstance();
       this.visu.update = model.update.bind(model); // override clients update function
       if (cv.Config.reporting) {
-        this.visu.record = qx.lang.Function.curry(cv.report.Record.getInstance().record, cv.report.Record.BACKEND).bind(cv.report.Record.getInstance());
+        var recordInstance = cv.report.Record.getInstance();
+        this.visu.record = function(p,d){recordInstance.record.apply(recordInstance,[cv.report.Record.BACKEND,p,d]);};
       }
       this.visu.showError = this._handleClientError.bind(this);
       this.visu.user = 'demo_user'; // example for setting a user
@@ -271,7 +272,7 @@ qx.Class.define('cv.TemplateEngine', {
     },
 
     _handleClientError: function (errorCode, varargs) {
-      varargs = qx.lang.Array.fromArguments(arguments, 1);
+      varargs = Array.prototype.slice.call(arguments, 1);
       var notification;
       var message = '';
       switch (errorCode) {
@@ -413,7 +414,7 @@ qx.Class.define('cv.TemplateEngine', {
       var metaParser = new cv.parser.MetaParser();
 
       // start with the plugins
-      settings.pluginsToLoad = qx.lang.Array.append(settings.pluginsToLoad, metaParser.parsePlugins(loaded_xml));
+      settings.pluginsToLoad = settings.pluginsToLoad.concat(metaParser.parsePlugins(loaded_xml));
       // and then the rest
       metaParser.parse(loaded_xml, done);
       this.debug("parsed");

--- a/source/class/cv/Transform.js
+++ b/source/class/cv/Transform.js
@@ -94,7 +94,7 @@ qx.Class.define('cv.Transform', {
     addTransform: function (prefix, transforms) {
       for (var trans in transforms) {
         if (transforms[trans].link) {
-          this.registry[prefix + ':' + trans] = qx.lang.Object.mergeWith(qx.lang.Object.clone(transforms[transforms[trans].link]), transforms[trans]);
+          this.registry[prefix + ':' + trans] = Object.assign({}, transforms[transforms[trans].link], transforms[trans]);
         } else {
           this.registry[prefix + ':' + trans] = transforms[trans];
         }

--- a/source/class/cv/core/notifications/Router.js
+++ b/source/class/cv/core/notifications/Router.js
@@ -58,9 +58,9 @@ qx.Class.define("cv.core.notifications.Router", {
       if (!message.hasOwnProperty("condition")) {
         // nothing to evaluate
         return true;
-      } else if (qx.lang.Type.isBoolean(message.condition)) {
+      } else if (typeof message.condition === 'boolean') {
         return message.condition;
-      } else if (qx.lang.Type.isFunction(message.condition)) {
+      } else if (typeof message.condition === 'function') {
         return message.condition();
       } else {
         qx.log.Logger.error(this, "unhandled message condition type: "+message.condition);

--- a/source/class/cv/core/notifications/actions/Link.js
+++ b/source/class/cv/core/notifications/actions/Link.js
@@ -71,7 +71,7 @@ qx.Class.define("cv.core.notifications.actions.Link", {
   members: {
 
     _transformAction: function(value) {
-      if (qx.lang.Type.isFunction(value)) {
+      if (typeof value === 'function') {
         return value;
       }
       switch(value) {

--- a/source/class/cv/data/Model.js
+++ b/source/class/cv/data/Model.js
@@ -215,11 +215,11 @@ qx.Class.define('cv.data.Model', {
      */
     getWidgetDataByElement: function (element) {
       var
-        parent = qx.dom.Element.getParentElement(element),
+        parent = element.parentNode,
         path = parent.getAttribute('id');
 
       if (path === undefined) {
-        path = qx.dom.Element.getParentElement(parent).getAttribute('id');
+        path = parent.parentNode.getAttribute('id');
       }
       return this.getWidgetData(path);
     },

--- a/source/class/cv/data/Model.js
+++ b/source/class/cv/data/Model.js
@@ -216,10 +216,10 @@ qx.Class.define('cv.data.Model', {
     getWidgetDataByElement: function (element) {
       var
         parent = qx.dom.Element.getParentElement(element),
-        path = qx.bom.element.Attribute.get(parent, 'id');
+        path = parent.getAttribute('id');
 
       if (path === undefined) {
-        path = qx.bom.element.Attribute.get(qx.dom.Element.getParentElement(parent), 'id');
+        path = qx.dom.Element.getParentElement(parent).getAttribute('id');
       }
       return this.getWidgetData(path);
     },

--- a/source/class/cv/data/Model.js
+++ b/source/class/cv/data/Model.js
@@ -143,7 +143,7 @@ qx.Class.define('cv.data.Model', {
           }
         });
         if (removeIndex >= 0) {
-          qx.lang.Array.removeAt(this.__stateListeners[address], removeIndex);
+          this.__stateListeners[address].splice(removeIndex, 1);
           if (this.__stateListeners[address].length === 0) {
             delete this.__stateListeners[address];
           }

--- a/source/class/cv/io/Mockup.js
+++ b/source/class/cv/io/Mockup.js
@@ -72,7 +72,7 @@ qx.Class.define('cv.io.Mockup', {
             // the respond would fail if we do not override it here
             request.readyState = 1;
           }
-          request.respond(response.status, response.headers, qx.lang.Json.stringify(response.body));
+          request.respond(response.status, response.headers, JSON.stringify(response.body));
         }
       }.bind(this));
     }

--- a/source/class/cv/io/Reflection.js
+++ b/source/class/cv/io/Reflection.js
@@ -93,7 +93,8 @@ qx.Class.define('cv.io.Reflection', {
      * Set all attributes of a widget.
      */
     write: function (path, attributes) {
-      qx.bom.element.Dataset.setData(qx.dom.Hierarchy.getChildElements(this.lookupWidget(path))[0], attributes);
+      // TODO: Implement - it was the non existing function
+      //  qx .bom.element.Dataset.setData(qx.dom.Hierarchy.getChildElements(this.lookupWidget(path))[0], attributes);
     },
 
     /**

--- a/source/class/cv/io/Reflection.js
+++ b/source/class/cv/io/Reflection.js
@@ -82,10 +82,10 @@ qx.Class.define('cv.io.Reflection', {
     select: function (path, state) {
       var container = this.lookupWidget(path);
       if (state) {
-        qx.bom.element.Class.set(container, 'selected');
+        container.classList.add('selected');
       }
       else {
-        qx.bom.element.Class.remove(container, 'selected');
+        container.classList.remove('selected');
       }
     },
 
@@ -188,7 +188,7 @@ qx.Class.define('cv.io.Reflection', {
           pathParts.pop();
           path = pathParts.join('_') + '_';
           var page = document.querySelector('#' + path);
-          if (qx.bom.element.Class.has(page, "page")) {
+          if (page.classList.contains("page")) {
             return page;
           }
         }
@@ -217,8 +217,8 @@ qx.Class.define('cv.io.Reflection', {
      * Focus a widget.
      */
     focus: function (path) {
-      qx.bom.element.Class.remove(document.querySelector('.focused'), 'focused');
-      qx.bom.element.Class.add(this.lookupWidget(path), 'focused');
+      document.querySelector('.focused').classList.remove('focused');
+      this.lookupWidget(path).classList.add('focused');
     }
   },
 

--- a/source/class/cv/io/Reflection.js
+++ b/source/class/cv/io/Reflection.js
@@ -53,7 +53,7 @@ qx.Class.define('cv.io.Reflection', {
             }
             thisEntry = thisEntry[thisNumber];
           }
-          qx.bom.Selector.matches('div.widget_container', qx.dom.Hierarchy.getDescendants(elem)).forEach(function(widget, i) {
+          Array.prototype.filter.call(qx.dom.Hierarchy.getDescendants(elem),function(m){return m.matches('div.widget_container');}).forEach(function(widget, i) {
             if (undefined === thisEntry[i]) {
               thisEntry[i] = {};
             }

--- a/source/class/cv/io/Reflection.js
+++ b/source/class/cv/io/Reflection.js
@@ -171,7 +171,7 @@ qx.Class.define('cv.io.Reflection', {
      * Return a widget (to be precise: the widget_container) for the given path
      */
     lookupWidget: function (path) {
-      return qx.bom.Selector.query('.page#' + path)[0];
+      return document.querySelector('.page#' + path);
     },
 
     getParentPage: function (page) {
@@ -187,7 +187,7 @@ qx.Class.define('cv.io.Reflection', {
         while (pathParts.length > 1) {
           pathParts.pop();
           path = pathParts.join('_') + '_';
-          var page = qx.bom.Selector.query('#' + path)[0];
+          var page = document.querySelector('#' + path);
           if (qx.bom.element.Class.has(page, "page")) {
             return page;
           }
@@ -208,7 +208,7 @@ qx.Class.define('cv.io.Reflection', {
      * child elements.
      */
     deleteCommand: function (path) {
-      this.debug(this.lookupWidget(path), qx.bom.Selector.query('#' + path)[0]);
+      this.debug(this.lookupWidget(path), document.querySelector('#' + path));
       //this.lookupWidget( path ).remove();
       return "deleted widget '" + path + "'";
     },
@@ -217,7 +217,7 @@ qx.Class.define('cv.io.Reflection', {
      * Focus a widget.
      */
     focus: function (path) {
-      qx.bom.element.Class.remove(qx.bom.Selector.query('.focused')[0], 'focused');
+      qx.bom.element.Class.remove(document.querySelector('.focused'), 'focused');
       qx.bom.element.Class.add(this.lookupWidget(path), 'focused');
     }
   },

--- a/source/class/cv/io/Reflection.js
+++ b/source/class/cv/io/Reflection.js
@@ -42,7 +42,7 @@ qx.Class.define('cv.io.Reflection', {
      */
     list: function () {
       var widgetTree = {};
-      qx.bom.Selector.query('.page').forEach(function (elem) {
+      document.querySelectorAll('.page').forEach(function (elem) {
         var id = elem.getAttribute("id").split('_');
         var thisEntry = widgetTree;
         if ('id' === id.shift()) {

--- a/source/class/cv/io/Reflection.js
+++ b/source/class/cv/io/Reflection.js
@@ -53,7 +53,7 @@ qx.Class.define('cv.io.Reflection', {
             }
             thisEntry = thisEntry[thisNumber];
           }
-          Array.prototype.filter.call(qx.dom.Hierarchy.getDescendants(elem),function(m){return m.matches('div.widget_container');}).forEach(function(widget, i) {
+          Array.from(elem.getElementsByTagName("*")).filter(function(m){return m.matches('div.widget_container');}).forEach(function(widget, i) {
             if (undefined === thisEntry[i]) {
               thisEntry[i] = {};
             }

--- a/source/class/cv/io/Reflection.js
+++ b/source/class/cv/io/Reflection.js
@@ -70,7 +70,7 @@ qx.Class.define('cv.io.Reflection', {
      */
     read: function (path) {
       var widget = this.lookupWidget(path),
-        data = qx.lang.Object.mergeWith({}, cv.data.Model.getInstance().getWidgetDataByElement(widget)); // copy
+        data = Object.assign({}, cv.data.Model.getInstance().getWidgetDataByElement(widget)); // copy
       delete data.basicvalue;
       delete data.value;
       return data;

--- a/source/class/cv/io/Reflection.js
+++ b/source/class/cv/io/Reflection.js
@@ -43,7 +43,7 @@ qx.Class.define('cv.io.Reflection', {
     list: function () {
       var widgetTree = {};
       qx.bom.Selector.query('.page').forEach(function (elem) {
-        var id = qx.bom.element.Attribute.get(elem, "id").split('_');
+        var id = elem.getAttribute("id").split('_');
         var thisEntry = widgetTree;
         if ('id' === id.shift()) {
           var thisNumber;
@@ -177,7 +177,7 @@ qx.Class.define('cv.io.Reflection', {
     getParentPage: function (page) {
       if (0 === page.length) { return null; }
 
-      return this.getParentPageById(qx.bom.element.Attribute.get(page, 'id'), true);
+      return this.getParentPageById(page.getAttribute('id'), true);
     },
 
     getParentPageById: function (path, isPageId) {

--- a/source/class/cv/parser/MetaParser.js
+++ b/source/class/cv/parser/MetaParser.js
@@ -59,14 +59,14 @@ qx.Class.define("cv.parser.MetaParser", {
         var content = elem.getAttribute('content');
         switch (type) {
           case 'css':
-            files.css.push(elem.getAttribute('text'));
+            files.css.push(elem.innerText);
             break;
 
           case 'js':
             if (content === 'plugin') {
-              cv.Config.configSettings.pluginsToLoad.push(elem.getAttribute('text'));
+              cv.Config.configSettings.pluginsToLoad.push(elem.innerText);
             } else {
-              files.js.push(elem.getAttribute('text'));
+              files.js.push(elem.innerText);
             }
             break;
 
@@ -287,16 +287,16 @@ qx.Class.define("cv.parser.MetaParser", {
         // templates
         var titleElem = qx.bom.Selector.query('title-template', elem)[0];
         if (titleElem) {
-          config.titleTemplate = titleElem.getAttribute("html");
+          config.titleTemplate = titleElem.innerHTML;
         }
         var messageElem = qx.bom.Selector.query('message-template', elem)[0];
         if (messageElem) {
-          config.messageTemplate = messageElem.getAttribute("html");
+          config.messageTemplate = messageElem.innerHTML;
         }
 
         // condition
         var conditionElem = qx.bom.Selector.query('condition', elem)[0];
-        var condition = conditionElem.getAttribute("text");
+        var condition = conditionElem.innerText;
         if (condition === "true") {
           condition = true;
         } else if (condition === "false") {
@@ -371,7 +371,7 @@ qx.Class.define("cv.parser.MetaParser", {
             }, this);
             areq.send();
           } else {
-            var cleaned = elem.getAttribute('html').replace(/\n\s*/g, '').trim();
+            var cleaned = elem.innerHTML.replace(/\n\s*/g, '').trim();
             cv.parser.WidgetParser.addTemplate(
               templateName,
               // templates can only have one single root element, so we wrap it here

--- a/source/class/cv/parser/MetaParser.js
+++ b/source/class/cv/parser/MetaParser.js
@@ -226,7 +226,7 @@ qx.Class.define("cv.parser.MetaParser", {
         }
         code += text;
       }, this);
-      var footerElement = qx.bom.Selector.query(".footer")[0];
+      var footerElement = document.querySelector(".footer");
       footerElement.innerHTML += code;
     },
 
@@ -259,7 +259,7 @@ qx.Class.define("cv.parser.MetaParser", {
       qx.bom.Selector.query('meta > notifications state-notification', xml).forEach(function (elem) {
         var target = cv.core.notifications.Router.getTarget(elem.getAttribute('target')) || cv.ui.NotificationCenter.getInstance();
 
-        var addressContainer = qx.bom.Selector.query('addresses', elem)[0];
+        var addressContainer = elem.querySelector('addresses');
 
         var config = {
           target: target,
@@ -285,17 +285,17 @@ qx.Class.define("cv.parser.MetaParser", {
         }
 
         // templates
-        var titleElem = qx.bom.Selector.query('title-template', elem)[0];
+        var titleElem = elem.querySelector('title-template');
         if (titleElem) {
           config.titleTemplate = titleElem.innerHTML;
         }
-        var messageElem = qx.bom.Selector.query('message-template', elem)[0];
+        var messageElem = elem.querySelector('message-template');
         if (messageElem) {
           config.messageTemplate = messageElem.innerHTML;
         }
 
         // condition
-        var conditionElem = qx.bom.Selector.query('condition', elem)[0];
+        var conditionElem = elem.querySelector('condition');
         var condition = conditionElem.innerText;
         if (condition === "true") {
           condition = true;

--- a/source/class/cv/parser/MetaParser.js
+++ b/source/class/cv/parser/MetaParser.js
@@ -33,13 +33,13 @@ qx.Class.define("cv.parser.MetaParser", {
       this.parseFiles(xml);
 
       // parse the icons
-      qx.bom.Selector.query('meta > icons icon-definition', xml).forEach(this.parseIcons, this);
+      xml.querySelectorAll('meta > icons icon-definition').forEach(this.parseIcons, this);
 
       // then the mappings
-      qx.bom.Selector.query('meta > mappings mapping', xml).forEach(this.parseMappings, this);
+      xml.querySelectorAll('meta > mappings mapping').forEach(this.parseMappings, this);
 
       // then the stylings
-      qx.bom.Selector.query('meta > stylings styling', xml).forEach(this.parseStylings, this);
+      xml.querySelectorAll('meta > stylings styling').forEach(this.parseStylings, this);
 
       // then the status bar
       this.parseStatusBar(xml);
@@ -54,7 +54,7 @@ qx.Class.define("cv.parser.MetaParser", {
         css: [],
         js: []
       };
-      qx.bom.Selector.query('meta > files file', xml).forEach(function (elem) {
+      xml.querySelectorAll('meta > files file').forEach(function (elem) {
         var type = elem.getAttribute('type');
         var content = elem.getAttribute('content');
         switch (type) {
@@ -91,12 +91,12 @@ qx.Class.define("cv.parser.MetaParser", {
     parseMappings: function(elem) {
       var name = elem.getAttribute('name');
       var mapping = {};
-      var formula = qx.bom.Selector.query('formula', elem);
+      var formula = elem.querySelectorAll('formula');
       if (formula.length > 0) {
         mapping.formulaSource = qx.dom.Node.getText(formula[0]);
         mapping.formula = new Function('x', 'var y;' + mapping.formulaSource + '; return y;'); // jshint ignore:line
       }
-      var subElements = qx.bom.Selector.query('entry', elem);
+      var subElements = elem.querySelectorAll('entry');
       subElements.forEach(function (subElem) {
         var origin = subElem.childNodes;
         var value = [];
@@ -145,7 +145,7 @@ qx.Class.define("cv.parser.MetaParser", {
       var name = elem.getAttribute('name');
       var classnames = '';
       var styling = {};
-      qx.bom.Selector.query('entry', elem).forEach(function (subElem) {
+      elem.querySelectorAll('entry').forEach(function (subElem) {
         classnames += qx.dom.Node.getText(subElem) + ' ';
         // check for default entry
         var isDefaultValue = subElem.getAttribute('default');
@@ -176,7 +176,7 @@ qx.Class.define("cv.parser.MetaParser", {
 
     parseStatusBar: function(xml) {
       var code = '';
-      qx.bom.Selector.query('meta > statusbar status', xml).forEach(function (elem) {
+      xml.querySelectorAll('meta > statusbar status').forEach(function (elem) {
         var condition = elem.getAttribute('condition');
         var extend = elem.getAttribute('hrefextend');
         var sPath = window.location.pathname;
@@ -232,7 +232,7 @@ qx.Class.define("cv.parser.MetaParser", {
 
     parsePlugins: function(xml) {
       var pluginsToLoad = [];
-      qx.bom.Selector.query('meta > plugins plugin', xml).forEach(function (elem) {
+      xml.querySelectorAll('meta > plugins plugin').forEach(function (elem) {
         var name = elem.getAttribute('name');
         if (name) {
           pluginsToLoad.push("plugin-"+name);
@@ -256,7 +256,7 @@ qx.Class.define("cv.parser.MetaParser", {
 
     parseStateNotifications: function(xml) {
       var stateConfig = {};
-      qx.bom.Selector.query('meta > notifications state-notification', xml).forEach(function (elem) {
+      xml.querySelectorAll('meta > notifications state-notification').forEach(function (elem) {
         var target = cv.core.notifications.Router.getTarget(elem.getAttribute('target')) || cv.ui.NotificationCenter.getInstance();
 
         var addressContainer = elem.querySelector('addresses');
@@ -330,7 +330,7 @@ qx.Class.define("cv.parser.MetaParser", {
           done();
         }
       };
-      var templates = qx.bom.Selector.query('meta > templates template', xml);
+      var templates = xml.querySelectorAll('meta > templates template');
       if (templates.length === 0) {
         done();
       } else {

--- a/source/class/cv/parser/MetaParser.js
+++ b/source/class/cv/parser/MetaParser.js
@@ -310,7 +310,7 @@ qx.Class.define("cv.parser.MetaParser", {
           if (!stateConfig.hasOwnProperty(address)) {
             stateConfig[address] = [];
           }
-          var addressConfig = qx.lang.Object.clone(config);
+          var addressConfig = Object.assign({}, config);
           addressConfig.addressConfig = addresses[address];
           stateConfig[address].push(addressConfig);
         });

--- a/source/class/cv/parser/MetaParser.js
+++ b/source/class/cv/parser/MetaParser.js
@@ -76,7 +76,7 @@ qx.Class.define("cv.parser.MetaParser", {
         }
       }, this);
       if (files.css.length > 0) {
-        qx.lang.Array.append(cv.Config.configSettings.stylesToLoad, files.css);
+        cv.Config.configSettings.stylesToLoad = cv.Config.configSettings.stylesToLoad.concat(files.css);
       }
       if (files.js.length > 0) {
         cv.util.ScriptLoader.getInstance().addScripts(files.js);

--- a/source/class/cv/parser/MetaParser.js
+++ b/source/class/cv/parser/MetaParser.js
@@ -55,18 +55,18 @@ qx.Class.define("cv.parser.MetaParser", {
         js: []
       };
       qx.bom.Selector.query('meta > files file', xml).forEach(function (elem) {
-        var type = qx.bom.element.Attribute.get(elem, 'type');
-        var content = qx.bom.element.Attribute.get(elem, 'content');
+        var type = elem.getAttribute('type');
+        var content = elem.getAttribute('content');
         switch (type) {
           case 'css':
-            files.css.push(qx.bom.element.Attribute.get(elem, 'text'));
+            files.css.push(elem.getAttribute('text'));
             break;
 
           case 'js':
             if (content === 'plugin') {
-              cv.Config.configSettings.pluginsToLoad.push(qx.bom.element.Attribute.get(elem, 'text'));
+              cv.Config.configSettings.pluginsToLoad.push(elem.getAttribute('text'));
             } else {
-              files.js.push(qx.bom.element.Attribute.get(elem, 'text'));
+              files.js.push(elem.getAttribute('text'));
             }
             break;
 
@@ -89,7 +89,7 @@ qx.Class.define("cv.parser.MetaParser", {
     },
 
     parseMappings: function(elem) {
-      var name = qx.bom.element.Attribute.get(elem, 'name');
+      var name = elem.getAttribute('name');
       var mapping = {};
       var formula = qx.bom.Selector.query('formula', elem);
       if (formula.length > 0) {
@@ -111,7 +111,7 @@ qx.Class.define("cv.parser.MetaParser", {
           }
         }
         // check for default entry
-        var isDefaultValue = qx.bom.element.Attribute.get(subElem, 'default');
+        var isDefaultValue = subElem.getAttribute('default');
         if (isDefaultValue !== undefined) {
           isDefaultValue = isDefaultValue === "true";
         }
@@ -129,9 +129,9 @@ qx.Class.define("cv.parser.MetaParser", {
           if (!mapping.range) {
             mapping.range = {};
           }
-          mapping.range[parseFloat(qx.bom.element.Attribute.get(subElem, 'range_min'))] = [parseFloat(qx.bom.element.Attribute.get(subElem, 'range_max')), value];
+          mapping.range[parseFloat(subElem.getAttribute('range_min'))] = [parseFloat(subElem.getAttribute('range_max')), value];
           if (isDefaultValue) {
-            mapping.defaultValue = parseFloat(qx.bom.element.Attribute.get(subElem, 'range_min'));
+            mapping.defaultValue = parseFloat(subElem.getAttribute('range_min'));
           }
         } else if (subElements.length === 1) {
           // use as catchall mapping
@@ -142,13 +142,13 @@ qx.Class.define("cv.parser.MetaParser", {
     },
 
     parseStylings: function(elem) {
-      var name = qx.bom.element.Attribute.get(elem, 'name');
+      var name = elem.getAttribute('name');
       var classnames = '';
       var styling = {};
       qx.bom.Selector.query('entry', elem).forEach(function (subElem) {
         classnames += qx.dom.Node.getText(subElem) + ' ';
         // check for default entry
-        var isDefaultValue = qx.bom.element.Attribute.get(subElem, 'default');
+        var isDefaultValue = subElem.getAttribute('default');
         if (isDefaultValue !== undefined) {
           isDefaultValue = isDefaultValue === "true";
         } else {
@@ -164,9 +164,9 @@ qx.Class.define("cv.parser.MetaParser", {
           if (!styling.range) {
             styling.range = {};
           }
-          styling.range[parseFloat(qx.bom.element.Attribute.get(subElem, 'range_min'))] = [parseFloat(qx.bom.element.Attribute.get(subElem, 'range_max')), qx.dom.Node.getText(subElem)];
+          styling.range[parseFloat(subElem.getAttribute('range_min'))] = [parseFloat(subElem.getAttribute('range_max')), qx.dom.Node.getText(subElem)];
           if (isDefaultValue) {
-            styling.defaultValue = parseFloat(qx.bom.element.Attribute.get(subElem, 'range_min'));
+            styling.defaultValue = parseFloat(subElem.getAttribute('range_min'));
           }
         }
       }, this);
@@ -177,8 +177,8 @@ qx.Class.define("cv.parser.MetaParser", {
     parseStatusBar: function(xml) {
       var code = '';
       qx.bom.Selector.query('meta > statusbar status', xml).forEach(function (elem) {
-        var condition = qx.bom.element.Attribute.get(elem,'condition');
-        var extend = qx.bom.element.Attribute.get(elem,'hrefextend');
+        var condition = elem.getAttribute('condition');
+        var extend = elem.getAttribute('hrefextend');
         var sPath = window.location.pathname;
         var sPage = sPath.substring(sPath.lastIndexOf('/') + 1);
 
@@ -233,7 +233,7 @@ qx.Class.define("cv.parser.MetaParser", {
     parsePlugins: function(xml) {
       var pluginsToLoad = [];
       qx.bom.Selector.query('meta > plugins plugin', xml).forEach(function (elem) {
-        var name = qx.bom.element.Attribute.get(elem, 'name');
+        var name = elem.getAttribute('name');
         if (name) {
           pluginsToLoad.push("plugin-"+name);
         }
@@ -243,42 +243,42 @@ qx.Class.define("cv.parser.MetaParser", {
 
     __parseIconDefinition: function(elem) {
       return {
-        name : qx.bom.element.Attribute.get(elem, 'name'),
-        uri : qx.bom.element.Attribute.get(elem, 'uri'),
-        type : qx.bom.element.Attribute.get(elem, 'type'),
-        flavour : qx.bom.element.Attribute.get(elem, 'flavour'),
-        color : qx.bom.element.Attribute.get(elem, 'color'),
-        styling : qx.bom.element.Attribute.get(elem, 'styling'),
-        dynamic : qx.bom.element.Attribute.get(elem, 'dynamic'),
-        'class' : qx.bom.element.Attribute.get(elem, 'class')
+        name : elem.getAttribute('name'),
+        uri : elem.getAttribute('uri'),
+        type : elem.getAttribute('type'),
+        flavour : elem.getAttribute('flavour'),
+        color : elem.getAttribute('color'),
+        styling : elem.getAttribute('styling'),
+        dynamic : elem.getAttribute('dynamic'),
+        'class' : elem.getAttribute('class')
       };
     },
 
     parseStateNotifications: function(xml) {
       var stateConfig = {};
       qx.bom.Selector.query('meta > notifications state-notification', xml).forEach(function (elem) {
-        var target = cv.core.notifications.Router.getTarget(qx.bom.element.Attribute.get(elem, 'target')) || cv.ui.NotificationCenter.getInstance();
+        var target = cv.core.notifications.Router.getTarget(elem.getAttribute('target')) || cv.ui.NotificationCenter.getInstance();
 
         var addressContainer = qx.bom.Selector.query('addresses', elem)[0];
 
         var config = {
           target: target,
-          severity: qx.bom.element.Attribute.get(elem, 'severity'),
-          skipInitial: qx.bom.element.Attribute.get(elem, 'skip-initial') !== "false",
-          deletable: qx.bom.element.Attribute.get(elem, 'deletable') !== "false",
-          unique: qx.bom.element.Attribute.get(elem, 'unique') === "true",
-          valueMapping: qx.bom.element.Attribute.get(addressContainer, 'value-mapping'),
-          addressMapping: qx.bom.element.Attribute.get(addressContainer, 'address-mapping')
+          severity: elem.getAttribute('severity'),
+          skipInitial: elem.getAttribute('skip-initial') !== "false",
+          deletable: elem.getAttribute('deletable') !== "false",
+          unique: elem.getAttribute('unique') === "true",
+          valueMapping: addressContainer.getAttribute('value-mapping'),
+          addressMapping: addressContainer.getAttribute('address-mapping')
         };
 
-        var name = qx.bom.element.Attribute.get(elem, 'name');
+        var name = elem.getAttribute('name');
         if (name) {
           config.topic = "cv.state."+name;
         }
-        var icon = qx.bom.element.Attribute.get(elem, 'icon');
+        var icon = elem.getAttribute('icon');
         if (icon) {
           config.icon = icon;
-          var iconClasses = qx.bom.element.Attribute.get(elem, 'icon-classes');
+          var iconClasses = elem.getAttribute('icon-classes');
           if (iconClasses) {
             config.iconClasses = iconClasses;
           }
@@ -287,16 +287,16 @@ qx.Class.define("cv.parser.MetaParser", {
         // templates
         var titleElem = qx.bom.Selector.query('title-template', elem)[0];
         if (titleElem) {
-          config.titleTemplate = qx.bom.element.Attribute.get(titleElem, "html");
+          config.titleTemplate = titleElem.getAttribute("html");
         }
         var messageElem = qx.bom.Selector.query('message-template', elem)[0];
         if (messageElem) {
-          config.messageTemplate = qx.bom.element.Attribute.get(messageElem, "html");
+          config.messageTemplate = messageElem.getAttribute("html");
         }
 
         // condition
         var conditionElem = qx.bom.Selector.query('condition', elem)[0];
-        var condition = qx.bom.element.Attribute.get(conditionElem, "text");
+        var condition = conditionElem.getAttribute("text");
         if (condition === "true") {
           condition = true;
         } else if (condition === "false") {
@@ -335,9 +335,9 @@ qx.Class.define("cv.parser.MetaParser", {
         done();
       } else {
         templates.forEach(function (elem) {
-          var templateName = qx.bom.element.Attribute.get(elem, 'name');
+          var templateName = elem.getAttribute('name');
           qx.log.Logger.debug(this, 'loading template:', templateName);
-          var ref = qx.bom.element.Attribute.get(elem, 'ref');
+          var ref = elem.getAttribute('ref');
           if (ref) {
             // load template fom external file
             var areq = new qx.io.request.Xhr(ref);
@@ -371,7 +371,7 @@ qx.Class.define("cv.parser.MetaParser", {
             }, this);
             areq.send();
           } else {
-            var cleaned = qx.bom.element.Attribute.get(elem, 'html').replace(/\n\s*/g, '').trim();
+            var cleaned = elem.getAttribute('html').replace(/\n\s*/g, '').trim();
             cv.parser.WidgetParser.addTemplate(
               templateName,
               // templates can only have one single root element, so we wrap it here

--- a/source/class/cv/parser/MetaParser.js
+++ b/source/class/cv/parser/MetaParser.js
@@ -102,7 +102,7 @@ qx.Class.define("cv.parser.MetaParser", {
         var value = [];
         for (var i = 0; i < origin.length; i++) {
           var v = origin[i];
-          if (qx.dom.Node.isElement(v) && v.nodeName.toLowerCase() === 'icon') {
+          if (v && v.nodeType === 1 && v.nodeName.toLowerCase() === 'icon') {
             var icon = this.__parseIconDefinition(v);
             value.push(cv.IconHandler.getInstance().getIconElement(icon.name, icon.type, icon.flavour, icon.color, icon.styling, icon["class"]));
           }

--- a/source/class/cv/parser/MetaParser.js
+++ b/source/class/cv/parser/MetaParser.js
@@ -93,7 +93,7 @@ qx.Class.define("cv.parser.MetaParser", {
       var mapping = {};
       var formula = elem.querySelectorAll('formula');
       if (formula.length > 0) {
-        mapping.formulaSource = qx.dom.Node.getText(formula[0]);
+        mapping.formulaSource = formula[0].textContent;
         mapping.formula = new Function('x', 'var y;' + mapping.formulaSource + '; return y;'); // jshint ignore:line
       }
       var subElements = elem.querySelectorAll('entry');
@@ -102,12 +102,12 @@ qx.Class.define("cv.parser.MetaParser", {
         var value = [];
         for (var i = 0; i < origin.length; i++) {
           var v = origin[i];
-          if (qx.dom.Node.isElement(v) && qx.dom.Node.getName(v).toLowerCase() === 'icon') {
+          if (qx.dom.Node.isElement(v) && v.nodeName.toLowerCase() === 'icon') {
             var icon = this.__parseIconDefinition(v);
             value.push(cv.IconHandler.getInstance().getIconElement(icon.name, icon.type, icon.flavour, icon.color, icon.styling, icon["class"]));
           }
-          else if (qx.dom.Node.getText(v).trim().length) {
-            value.push(qx.dom.Node.getText(v).trim());
+          else if (v.textContent.trim().length) {
+            value.push(v.textContent.trim());
           }
         }
         // check for default entry
@@ -146,7 +146,7 @@ qx.Class.define("cv.parser.MetaParser", {
       var classnames = '';
       var styling = {};
       elem.querySelectorAll('entry').forEach(function (subElem) {
-        classnames += qx.dom.Node.getText(subElem) + ' ';
+        classnames += subElem.textContent + ' ';
         // check for default entry
         var isDefaultValue = subElem.getAttribute('default');
         if (isDefaultValue !== undefined) {
@@ -156,7 +156,7 @@ qx.Class.define("cv.parser.MetaParser", {
         }
         // now set the styling values
         if (subElem.getAttribute('value')) {
-          styling[subElem.getAttribute('value')] = qx.dom.Node.getText(subElem);
+          styling[subElem.getAttribute('value')] = subElem.textContent;
           if (isDefaultValue) {
             styling.defaultValue = subElem.getAttribute('value');
           }
@@ -164,7 +164,7 @@ qx.Class.define("cv.parser.MetaParser", {
           if (!styling.range) {
             styling.range = {};
           }
-          styling.range[parseFloat(subElem.getAttribute('range_min'))] = [parseFloat(subElem.getAttribute('range_max')), qx.dom.Node.getText(subElem)];
+          styling.range[parseFloat(subElem.getAttribute('range_min'))] = [parseFloat(subElem.getAttribute('range_max')), subElem.textContent];
           if (isDefaultValue) {
             styling.defaultValue = parseFloat(subElem.getAttribute('range_min'));
           }
@@ -202,7 +202,7 @@ qx.Class.define("cv.parser.MetaParser", {
           return;
         }
 
-        var text = qx.dom.Node.getText(elem);
+        var text = elem.textContent;
         var search;
         switch (extend) {
           case 'all': // append all parameters

--- a/source/class/cv/parser/WidgetParser.js
+++ b/source/class/cv/parser/WidgetParser.js
@@ -52,10 +52,10 @@ qx.Class.define('cv.parser.WidgetParser', {
      */
     renderTemplates: function (rootPage) {
       qx.bom.Selector.query('template', rootPage).forEach(function (elem) {
-        var templateName = qx.bom.element.Attribute.get(elem, 'name');
+        var templateName = elem.getAttribute('name');
         var variables = {};
         qx.dom.Hierarchy.getChildElements(elem).forEach(function (variable) {
-          variables[qx.bom.element.Attribute.get(variable, 'name')] = qx.bom.element.Attribute.get(variable, 'html');
+          variables[variable.getAttribute('name')] = variable.getAttribute('html');
         }, this);
 
         if (this.__templates.hasOwnProperty(templateName)) {
@@ -187,24 +187,24 @@ qx.Class.define('cv.parser.WidgetParser', {
       var style = qx.lang.Object.isEmpty(layout) ? '' : 'style="' + this.extractLayout( layout, pageType ) + '"';
       var classes = handler.getDefaultClasses ? handler.getDefaultClasses(widgetType) : this.getDefaultClasses(widgetType);
       // the group widgets align attribute is just targeting the group header and is handled by the widget itself, so we skip it here
-      if ( qx.bom.element.Attribute.get(element, 'align') && widgetType !== "group" ) {
-        classes+=" "+qx.bom.element.Attribute.get(element, 'align') ;
+      if ( element.getAttribute('align') && widgetType !== "group" ) {
+        classes+=" "+element.getAttribute('align') ;
       }
       classes += ' ' + this.setWidgetLayout(element, path);
-      if( qx.bom.element.Attribute.get(element, 'flavour') ) {
-        flavour = qx.bom.element.Attribute.get(element, 'flavour');
+      if( element.getAttribute('flavour') ) {
+        flavour = element.getAttribute('flavour');
       }// sub design choice
       if( flavour ) {
         classes += ' flavour_' + flavour;
       }
-      if (qx.bom.element.Attribute.get(element, 'class')) {
-        classes += ' custom_' + qx.bom.element.Attribute.get(element, 'class');
+      if (element.getAttribute('class')) {
+        classes += ' custom_' + element.getAttribute('class');
       }
       var label = (widgetType==='text') ? this.parseLabel( qx.bom.Selector.query("label", element)[0], flavour, '' ) : this.parseLabel( qx.bom.Selector.query("label", element)[0], flavour );
 
       var bindClickToWidget = cv.TemplateEngine.getInstance().bindClickToWidget;
-      if (qx.bom.element.Attribute.get(element, "bind_click_to_widget")) {
-        bindClickToWidget = qx.bom.element.Attribute.get(element, "bind_click_to_widget") === "true";
+      if (element.getAttribute("bind_click_to_widget")) {
+        bindClickToWidget = element.getAttribute("bind_click_to_widget") === "true";
       }
 
       var data = {
@@ -214,7 +214,7 @@ qx.Class.define('cv.parser.WidgetParser', {
       };
       data.bindClickToWidget = bindClickToWidget;
       ['mapping', 'align', 'align'].forEach(function(prop) {
-        data[prop] = qx.bom.element.Attribute.get(element, prop) || null;
+        data[prop] = element.getAttribute(prop) || null;
       }, this);
 
       data.layout = layout || null;
@@ -318,11 +318,11 @@ qx.Class.define('cv.parser.WidgetParser', {
       Array.prototype.forEach.call(label.childNodes, function(elem) {
         if( qx.dom.Node.isNodeName(elem, 'icon') ) {
           ret_val += cv.IconHandler.getInstance().getIconText(
-            qx.bom.element.Attribute.get(elem, 'name'),
-            qx.bom.element.Attribute.get(elem, 'type'),
-            qx.bom.element.Attribute.get(elem, 'flavour') || flavour,
-            qx.bom.element.Attribute.get(elem, 'color'),
-            qx.bom.element.Attribute.get(elem, 'styling') );
+            elem.getAttribute('name'),
+            elem.getAttribute('type'),
+            elem.getAttribute('flavour') || flavour,
+            elem.getAttribute('color'),
+            elem.getAttribute('styling') );
         } else {
           ret_val += elem.textContent;
         }
@@ -369,7 +369,7 @@ qx.Class.define('cv.parser.WidgetParser', {
      */
     parseFormat: function (xml, path) {
       var data = this.model.getWidgetData(path);
-      var value = qx.bom.element.Attribute.get(xml, 'format');
+      var value = xml.getAttribute('format');
       if (value) {
         data.format = value;
       }
@@ -405,15 +405,15 @@ qx.Class.define('cv.parser.WidgetParser', {
       qx.bom.Selector.query('address', element).forEach(function (elem) {
         var
           src = elem.textContent,
-          transform = qx.bom.element.Attribute.get(elem, 'transform'),
-          formatPos = +(qx.bom.element.Attribute.get(elem, 'format-pos') || 1) | 0, // force integer
+          transform = elem.getAttribute('transform'),
+          formatPos = +(elem.getAttribute('format-pos') || 1) | 0, // force integer
           mode = 1 | 2; // Bit 0 = read, Bit 1 = write  => 1|2 = 3 = readwrite
 
         if ((!src) || (!transform)) {// fix broken address-entries in config
           qx.log.Logger.error(this, "Either address or transform is missing in address element %1", element.outerHTML);
           return;
         }
-        switch (qx.bom.element.Attribute.get(elem, 'mode')) {
+        switch (elem.getAttribute('mode')) {
           case 'disable':
             mode = 0;
             break;
@@ -427,7 +427,7 @@ qx.Class.define('cv.parser.WidgetParser', {
             mode = 1 | 2;
             break;
         }
-        var variantInfo = makeAddressListFn ? makeAddressListFn(src, transform, mode, qx.bom.element.Attribute.get(elem, 'variant')) : [true, undefined];
+        var variantInfo = makeAddressListFn ? makeAddressListFn(src, transform, mode, elem.getAttribute('variant')) : [true, undefined];
         if (!skipAdding && (mode & 1) && variantInfo[0]) {// add only addresses when reading from them
           this.model.addAddress(src, id);
         }
@@ -470,7 +470,7 @@ qx.Class.define('cv.parser.WidgetParser', {
 
     parseStyling: function (xml, path) {
       var data = this.model.getWidgetData(path);
-      data.styling = qx.bom.element.Attribute.get(xml, 'styling');
+      data.styling = xml.getAttribute('styling');
     },
 
     // this might have been called from the cv.parser.WidgetParser with the including class as context

--- a/source/class/cv/parser/WidgetParser.js
+++ b/source/class/cv/parser/WidgetParser.js
@@ -61,7 +61,7 @@ qx.Class.define('cv.parser.WidgetParser', {
         if (this.__templates.hasOwnProperty(templateName)) {
           var renderedString = qx.bom.Template.render(this.__templates[templateName], variables).replace('\n', '').trim();
           var helperNode = elem.ownerDocument.createElement('template');
-          helperNode.setAttribute('html', renderedString.substring(6, renderedString.length - 7).trim());
+          helperNode.innerHTML = renderedString.substring(6, renderedString.length - 7).trim();
           // replace existing element with the rendered templates child
           var replacement = helperNode.firstElementChild;
           var next = elem.nextElementSibling;

--- a/source/class/cv/parser/WidgetParser.js
+++ b/source/class/cv/parser/WidgetParser.js
@@ -55,7 +55,7 @@ qx.Class.define('cv.parser.WidgetParser', {
         var templateName = elem.getAttribute('name');
         var variables = {};
         qx.dom.Hierarchy.getChildElements(elem).forEach(function (variable) {
-          variables[variable.getAttribute('name')] = variable.getAttribute('html');
+          variables[variable.getAttribute('name')] = variable.innerHTML;
         }, this);
 
         if (this.__templates.hasOwnProperty(templateName)) {

--- a/source/class/cv/parser/WidgetParser.js
+++ b/source/class/cv/parser/WidgetParser.js
@@ -51,7 +51,7 @@ qx.Class.define('cv.parser.WidgetParser', {
      * @param rootPage
      */
     renderTemplates: function (rootPage) {
-      qx.bom.Selector.query('template', rootPage).forEach(function (elem) {
+      rootPage.querySelectorAll('template').forEach(function (elem) {
         var templateName = elem.getAttribute('name');
         var variables = {};
         qx.dom.Hierarchy.getChildElements(elem).forEach(function (variable) {
@@ -402,7 +402,7 @@ qx.Class.define('cv.parser.WidgetParser', {
      */
     makeAddressList: function (element, id, makeAddressListFn, skipAdding) {
       var address = {};
-      qx.bom.Selector.query('address', element).forEach(function (elem) {
+      element.querySelectorAll('address').forEach(function (elem) {
         var
           src = elem.textContent,
           transform = elem.getAttribute('transform'),

--- a/source/class/cv/parser/WidgetParser.js
+++ b/source/class/cv/parser/WidgetParser.js
@@ -481,7 +481,7 @@ qx.Class.define('cv.parser.WidgetParser', {
         data.children = [];
       }
       var childs = qx.dom.Hierarchy.getChildElements(xml).filter(function(child) {
-        return ['layout', 'label', 'address'].indexOf(qx.dom.Node.getName(child)) === -1;
+        return ['layout', 'label', 'address'].indexOf(child.nodeName.toLowerCase()) === -1;
       }, this);
       childs.forEach(function (child, idx) {
         var childData = cv.parser.WidgetParser.parse(child, path + '_' + idx, flavour, pageType);

--- a/source/class/cv/parser/WidgetParser.js
+++ b/source/class/cv/parser/WidgetParser.js
@@ -200,7 +200,7 @@ qx.Class.define('cv.parser.WidgetParser', {
       if (element.getAttribute('class')) {
         classes += ' custom_' + element.getAttribute('class');
       }
-      var label = (widgetType==='text') ? this.parseLabel( qx.bom.Selector.query("label", element)[0], flavour, '' ) : this.parseLabel( qx.bom.Selector.query("label", element)[0], flavour );
+      var label = (widgetType==='text') ? this.parseLabel( element.querySelector("label"), flavour, '' ) : this.parseLabel( element.querySelector("label"), flavour );
 
       var bindClickToWidget = cv.TemplateEngine.getInstance().bindClickToWidget;
       if (element.getAttribute("bind_click_to_widget")) {
@@ -351,7 +351,7 @@ qx.Class.define('cv.parser.WidgetParser', {
         elementData.colspanS = qx.xml.Element.getAttributeNS(layout, '', 'colspan-s');
         rowspan = qx.xml.Element.getAttributeNS(layout, '', 'rowspan');
       }
-      elementData.colspan = parseFloat(elementData.colspan || qx.bom.element.Dataset.get(qx.bom.Selector.query('head')[0], 'colspanDefault') || 6);
+      elementData.colspan = parseFloat(elementData.colspan || qx.bom.element.Dataset.get(document.querySelector('head'), 'colspanDefault') || 6);
       elementData.colspanM = parseFloat(elementData.colspanM || cv.parser.WidgetParser.lookupM[Math.floor(elementData.colspan)] || elementData.colspan);
       elementData.colspanS = parseFloat(elementData.colspanS || cv.parser.WidgetParser.lookupS[Math.floor(elementData.colspan)] || elementData.colspan);
 

--- a/source/class/cv/parser/WidgetParser.js
+++ b/source/class/cv/parser/WidgetParser.js
@@ -351,7 +351,7 @@ qx.Class.define('cv.parser.WidgetParser', {
         elementData.colspanS = qx.xml.Element.getAttributeNS(layout, '', 'colspan-s');
         rowspan = qx.xml.Element.getAttributeNS(layout, '', 'rowspan');
       }
-      elementData.colspan = parseFloat(elementData.colspan || qx.bom.element.Dataset.get(document.querySelector('head'), 'colspanDefault') || 6);
+      elementData.colspan = parseFloat(elementData.colspan || document.querySelector('head').dataset['colspanDefault'] || 6);
       elementData.colspanM = parseFloat(elementData.colspanM || cv.parser.WidgetParser.lookupM[Math.floor(elementData.colspan)] || elementData.colspan);
       elementData.colspanS = parseFloat(elementData.colspanS || cv.parser.WidgetParser.lookupS[Math.floor(elementData.colspan)] || elementData.colspan);
 

--- a/source/class/cv/parser/WidgetParser.js
+++ b/source/class/cv/parser/WidgetParser.js
@@ -61,7 +61,7 @@ qx.Class.define('cv.parser.WidgetParser', {
         if (this.__templates.hasOwnProperty(templateName)) {
           var renderedString = qx.bom.Template.render(this.__templates[templateName], variables).replace('\n', '').trim();
           var helperNode = elem.ownerDocument.createElement('template');
-          qx.bom.element.Attribute.set(helperNode, 'html', renderedString.substring(6, renderedString.length - 7).trim());
+          helperNode.setAttribute('html', renderedString.substring(6, renderedString.length - 7).trim());
           // replace existing element with the rendered templates child
           var replacement = helperNode.firstElementChild;
           var next = elem.nextElementSibling;

--- a/source/class/cv/parser/WidgetParser.js
+++ b/source/class/cv/parser/WidgetParser.js
@@ -54,7 +54,7 @@ qx.Class.define('cv.parser.WidgetParser', {
       rootPage.querySelectorAll('template').forEach(function (elem) {
         var templateName = elem.getAttribute('name');
         var variables = {};
-        qx.dom.Hierarchy.getChildElements(elem).forEach(function (variable) {
+        elem.children.forEach(function (variable) {
           variables[variable.getAttribute('name')] = variable.innerHTML;
         }, this);
 
@@ -183,7 +183,7 @@ qx.Class.define('cv.parser.WidgetParser', {
         return handler.createDefaultWidget(widgetType, element, path, flavour, pageType);
       }
 
-      var layout = this.parseLayout( Array.prototype.filter.call(qx.dom.Hierarchy.getChildElements(element),function(m){return m.matches('layout');})[0] );
+      var layout = this.parseLayout( Array.from(element.children).filter(function(m){return m.matches('layout');})[0] );
       var style = qx.lang.Object.isEmpty(layout) ? '' : 'style="' + this.extractLayout( layout, pageType ) + '"';
       var classes = handler.getDefaultClasses ? handler.getDefaultClasses(widgetType) : this.getDefaultClasses(widgetType);
       // the group widgets align attribute is just targeting the group header and is handled by the widget itself, so we skip it here
@@ -316,7 +316,7 @@ qx.Class.define('cv.parser.WidgetParser', {
         ( style ? (' style="' + style + '"') : '' ) + '>';
 
       Array.prototype.forEach.call(label.childNodes, function(elem) {
-        if( qx.dom.Node.isNodeName(elem, 'icon') ) {
+        if( elem.nodeName.toLowerCase() ==='icon' ) {
           ret_val += cv.IconHandler.getInstance().getIconText(
             elem.getAttribute('name'),
             elem.getAttribute('type'),
@@ -341,7 +341,7 @@ qx.Class.define('cv.parser.WidgetParser', {
     setWidgetLayout: function( element, path ) {
       var
         elementData = this.model.getWidgetData( path ),
-        layout      = Array.prototype.filter.call(qx.dom.Hierarchy.getChildElements(element),function(m){return m.matches('layout');})[0],
+        layout      = Array.from(element.children).filter(function(m){return m.matches('layout');})[0],
         ret_val = '',
         rowspan = null;
 
@@ -480,7 +480,7 @@ qx.Class.define('cv.parser.WidgetParser', {
       if (!data.children) {
         data.children = [];
       }
-      var childs = qx.dom.Hierarchy.getChildElements(xml).filter(function(child) {
+      var childs = Array.from(xml.children).filter(function(child) {
         return ['layout', 'label', 'address'].indexOf(child.nodeName.toLowerCase()) === -1;
       }, this);
       childs.forEach(function (child, idx) {

--- a/source/class/cv/parser/WidgetParser.js
+++ b/source/class/cv/parser/WidgetParser.js
@@ -184,7 +184,7 @@ qx.Class.define('cv.parser.WidgetParser', {
       }
 
       var layout = this.parseLayout( Array.from(element.children).filter(function(m){return m.matches('layout');})[0] );
-      var style = qx.lang.Object.isEmpty(layout) ? '' : 'style="' + this.extractLayout( layout, pageType ) + '"';
+      var style = Object.keys(layout).length === 0 ? '' : 'style="' + this.extractLayout( layout, pageType ) + '"';
       var classes = handler.getDefaultClasses ? handler.getDefaultClasses(widgetType) : this.getDefaultClasses(widgetType);
       // the group widgets align attribute is just targeting the group header and is handled by the widget itself, so we skip it here
       if ( element.getAttribute('align') && widgetType !== "group" ) {

--- a/source/class/cv/parser/WidgetParser.js
+++ b/source/class/cv/parser/WidgetParser.js
@@ -183,7 +183,7 @@ qx.Class.define('cv.parser.WidgetParser', {
         return handler.createDefaultWidget(widgetType, element, path, flavour, pageType);
       }
 
-      var layout = this.parseLayout( qx.bom.Selector.matches('layout', qx.dom.Hierarchy.getChildElements(element))[0] );
+      var layout = this.parseLayout( Array.prototype.filter.call(qx.dom.Hierarchy.getChildElements(element),function(m){return m.matches('layout');})[0] );
       var style = qx.lang.Object.isEmpty(layout) ? '' : 'style="' + this.extractLayout( layout, pageType ) + '"';
       var classes = handler.getDefaultClasses ? handler.getDefaultClasses(widgetType) : this.getDefaultClasses(widgetType);
       // the group widgets align attribute is just targeting the group header and is handled by the widget itself, so we skip it here
@@ -341,7 +341,7 @@ qx.Class.define('cv.parser.WidgetParser', {
     setWidgetLayout: function( element, path ) {
       var
         elementData = this.model.getWidgetData( path ),
-        layout      = qx.bom.Selector.matches('layout', qx.dom.Hierarchy.getChildElements(element))[0],
+        layout      = Array.prototype.filter.call(qx.dom.Hierarchy.getChildElements(element),function(m){return m.matches('layout');})[0],
         ret_val = '',
         rowspan = null;
 

--- a/source/class/cv/parser/widgets/NavBar.js
+++ b/source/class/cv/parser/widgets/NavBar.js
@@ -48,16 +48,16 @@ qx.Class.define('cv.parser.widgets.NavBar', {
     createDefaultWidget: function (widgetType, n, path) {
 
       var classes = "navbar clearfix";
-      if (qx.bom.element.Attribute.get(n, 'flavour')) {
-        classes += " flavour_" + qx.bom.element.Attribute.get(n, 'flavour');
+      if (n.getAttribute('flavour')) {
+        classes += " flavour_" + n.getAttribute('flavour');
       }// sub design choice
 
       // store scope globally
       var id = path.split("_");
       id.pop();
-      var pos = qx.bom.element.Attribute.get(n, 'position') || 'left';
+      var pos = n.getAttribute('position') || 'left';
       cv.data.Model.getInstance().setWidgetData(id.join('_') + '_' + pos + '_navbar', {
-        'scope': cv.parser.widgets.NavBar._transformScope(qx.bom.element.Attribute.get(n, 'scope'))
+        'scope': cv.parser.widgets.NavBar._transformScope(n.getAttribute('scope'))
       });
 
       return cv.data.Model.getInstance().setWidgetData(cv.parser.WidgetParser.getStoragePath(n, path), {

--- a/source/class/cv/parser/widgets/Page.js
+++ b/source/class/cv/parser/widgets/Page.js
@@ -35,17 +35,17 @@ qx.Class.define('cv.parser.widgets.Page', {
 
       var storagePath = cv.parser.WidgetParser.getStoragePath(page, path);
       var addresses = {};
-      if (qx.bom.element.Attribute.get(page, 'ga')) {
-        var src = qx.bom.element.Attribute.get(page, 'ga');
+      if (page.getAttribute('ga')) {
+        var src = page.getAttribute('ga');
         cv.data.Model.getInstance().addAddress(src, storagePath);
         addresses[ src ] = [ 'DPT:1.001', cv.data.Model.READ ];
       }
 
-      var name    = qx.bom.element.Attribute.get(page, 'name');
-      pageType = qx.bom.element.Attribute.get(page, 'type') || 'text';              //text, 2d or 3d
-      var backdrop = qx.bom.element.Attribute.get(page, 'backdrop');
-      var showtopnavigation = qx.bom.element.Attribute.get(page, 'showtopnavigation') ? qx.bom.element.Attribute.get(page, 'showtopnavigation') === "true" : null;
-      var showfooter = qx.bom.element.Attribute.get(page, 'showfooter') ? qx.bom.element.Attribute.get(page, 'showfooter') === "true": true;
+      var name    = page.getAttribute('name');
+      pageType = page.getAttribute('type') || 'text';              //text, 2d or 3d
+      var backdrop = page.getAttribute('backdrop');
+      var showtopnavigation = page.getAttribute('showtopnavigation') ? page.getAttribute('showtopnavigation') === "true" : null;
+      var showfooter = page.getAttribute('showfooter') ? page.getAttribute('showfooter') === "true": true;
       // make sure the type has the correct value as we need to use it ass CSS class
       switch (pageType) {
         case '2d':
@@ -65,7 +65,7 @@ qx.Class.define('cv.parser.widgets.Page', {
         right  : path === "id" ? false : null
       };
       qx.bom.Selector.matches("navbar", qx.dom.Hierarchy.getChildElements(page)).forEach( function(elem) {
-        shownavbar[ qx.bom.element.Attribute.get(elem, 'position') || 'left' ] = true;
+        shownavbar[ elem.getAttribute('position') || 'left' ] = true;
       });
       // overwrite default when set manually in the config
       ['top', 'left', 'right', 'bottom'].forEach(function(pos) {
@@ -73,21 +73,21 @@ qx.Class.define('cv.parser.widgets.Page', {
           // do not override current values
           return;
         }
-        var value = qx.bom.element.Attribute.get(page, 'shownavbar-'+pos);
+        var value = page.getAttribute('shownavbar-'+pos);
         if (qx.lang.Type.isString(value)) {
           shownavbar[pos] = value === "true";
         }
       }, this);
       var bindClickToWidget = cv.TemplateEngine.getInstance().bindClickToWidget;
-      if (qx.bom.element.Attribute.get(page, "bind_click_to_widget")) {
-        bindClickToWidget = qx.bom.element.Attribute.get(page, "bind_click_to_widget")==="true";
+      if (page.getAttribute("bind_click_to_widget")) {
+        bindClickToWidget = page.getAttribute("bind_click_to_widget")==="true";
       }
-      if( qx.bom.element.Attribute.get(page, 'flavour') ) {
-        flavour = qx.bom.element.Attribute.get(page, 'flavour');// sub design choice
+      if( page.getAttribute('flavour') ) {
+        flavour = page.getAttribute('flavour');// sub design choice
       }
       var wstyle  = '';                                     // widget style
-      if( qx.bom.element.Attribute.get(page, 'align') ) {
-        wstyle += 'text-align:' + qx.bom.element.Attribute.get(page, 'align') + ';';
+      if( page.getAttribute('align') ) {
+        wstyle += 'text-align:' + page.getAttribute('align') + ';';
       }
       if( wstyle !== '' ) {
         wstyle = 'style="' + wstyle + '"';
@@ -109,10 +109,10 @@ qx.Class.define('cv.parser.widgets.Page', {
         showNavbarBottom  : shownavbar.bottom,
         showNavbarLeft    : shownavbar.left,
         showNavbarRight   : shownavbar.right,
-        backdropAlign     : '2d' === pageType ? (qx.bom.element.Attribute.get(page, 'backdropalign' ) || '50% 50%') : null,
-        size              : qx.bom.element.Attribute.get(page, 'size') || null,
+        backdropAlign     : '2d' === pageType ? (page.getAttribute('backdropalign') || '50% 50%') : null,
+        size              : page.getAttribute('size') || null,
         address           : addresses,
-        linkVisible       : qx.bom.element.Attribute.get(page, 'visible') ? qx.bom.element.Attribute.get(page, 'visible') === "true" : true,
+        linkVisible       : page.getAttribute('visible') ? page.getAttribute('visible') === "true" : true,
         flavour           : flavour || null,
         $$type            : "page",
         backdrop          : backdrop || null,

--- a/source/class/cv/parser/widgets/Page.js
+++ b/source/class/cv/parser/widgets/Page.js
@@ -74,7 +74,7 @@ qx.Class.define('cv.parser.widgets.Page', {
           return;
         }
         var value = page.getAttribute('shownavbar-'+pos);
-        if (qx.lang.Type.isString(value)) {
+        if (typeof value === 'string') {
           shownavbar[pos] = value === "true";
         }
       }, this);

--- a/source/class/cv/parser/widgets/Page.js
+++ b/source/class/cv/parser/widgets/Page.js
@@ -64,7 +64,7 @@ qx.Class.define('cv.parser.widgets.Page', {
         left   : path === "id" ? false : null,
         right  : path === "id" ? false : null
       };
-      Array.prototype.filter.call(qx.dom.Hierarchy.getChildElements(page),function(m){return m.matches("navbar");}).forEach( function(elem) {
+      Array.from(page.children).filter(function(m){return m.matches("navbar");}).forEach( function(elem) {
         shownavbar[ elem.getAttribute('position') || 'left' ] = true;
       });
       // overwrite default when set manually in the config
@@ -93,7 +93,7 @@ qx.Class.define('cv.parser.widgets.Page', {
         wstyle = 'style="' + wstyle + '"';
       }
 
-      var layout = cv.parser.WidgetParser.parseLayout( Array.prototype.filter.call(qx.dom.Hierarchy.getChildElements(page),function(m){return m.matches("layout");})[0] );
+      var layout = cv.parser.WidgetParser.parseLayout( Array.from(page.children).filter(function(m){return m.matches("layout");})[0] );
       var backdropType = null;
       if (backdrop) {
         backdropType = '.svg' === backdrop.substring( backdrop.length - 4 ) ? 'embed' : 'img';

--- a/source/class/cv/parser/widgets/Page.js
+++ b/source/class/cv/parser/widgets/Page.js
@@ -64,7 +64,7 @@ qx.Class.define('cv.parser.widgets.Page', {
         left   : path === "id" ? false : null,
         right  : path === "id" ? false : null
       };
-      qx.bom.Selector.matches("navbar", qx.dom.Hierarchy.getChildElements(page)).forEach( function(elem) {
+      Array.prototype.filter.call(qx.dom.Hierarchy.getChildElements(page),function(m){return m.matches("navbar");}).forEach( function(elem) {
         shownavbar[ elem.getAttribute('position') || 'left' ] = true;
       });
       // overwrite default when set manually in the config
@@ -93,7 +93,7 @@ qx.Class.define('cv.parser.widgets.Page', {
         wstyle = 'style="' + wstyle + '"';
       }
 
-      var layout = cv.parser.WidgetParser.parseLayout( qx.bom.Selector.matches("layout", qx.dom.Hierarchy.getChildElements(page))[0] );
+      var layout = cv.parser.WidgetParser.parseLayout( Array.prototype.filter.call(qx.dom.Hierarchy.getChildElements(page),function(m){return m.matches("layout");})[0] );
       var backdropType = null;
       if (backdrop) {
         backdropType = '.svg' === backdrop.substring( backdrop.length - 4 ) ? 'embed' : 'img';

--- a/source/class/cv/parser/widgets/PageJump.js
+++ b/source/class/cv/parser/widgets/PageJump.js
@@ -42,7 +42,7 @@ qx.Class.define('cv.parser.widgets.PageJump', {
     parse: function (xml, path, flavour, pageType) {
       var data = cv.parser.WidgetParser.parseElement(this, xml, path, flavour, pageType, this.getAttributeToPropertyMappings());
 
-      var widgetInfo = qx.bom.Selector.query('widgetinfo > *', xml)[0];
+      var widgetInfo = xml.querySelector('widgetinfo > *');
       if (widgetInfo!==undefined) {
         data.classes += " infoaction";
       }

--- a/source/class/cv/parser/widgets/Slide.js
+++ b/source/class/cv/parser/widgets/Slide.js
@@ -45,7 +45,7 @@ qx.Class.define('cv.parser.widgets.Slide', {
       cv.parser.WidgetParser.parseAddress(xml, path);
 
       var datatype_min, datatype_max;
-      Array.prototype.filter.call(qx.dom.Hierarchy.getChildElements(xml),function(m){return m.matches("address");}).forEach(function(elem) {
+      Array.from(xml.children).filter(function(m){return m.matches("address");}).forEach(function(elem) {
         var transform = elem.getAttribute('transform');
         if (cv.Transform.registry[transform] && cv.Transform.registry[transform].range) {
           if (!( datatype_min > cv.Transform.registry[transform].range.min )) {// jshint ignore:line

--- a/source/class/cv/parser/widgets/Slide.js
+++ b/source/class/cv/parser/widgets/Slide.js
@@ -45,7 +45,7 @@ qx.Class.define('cv.parser.widgets.Slide', {
       cv.parser.WidgetParser.parseAddress(xml, path);
 
       var datatype_min, datatype_max;
-      qx.bom.Selector.matches("address", qx.dom.Hierarchy.getChildElements(xml)).forEach(function(elem) {
+      Array.prototype.filter.call(qx.dom.Hierarchy.getChildElements(xml),function(m){return m.matches("address");}).forEach(function(elem) {
         var transform = elem.getAttribute('transform');
         if (cv.Transform.registry[transform] && cv.Transform.registry[transform].range) {
           if (!( datatype_min > cv.Transform.registry[transform].range.min )) {// jshint ignore:line

--- a/source/class/cv/parser/widgets/Unknown.js
+++ b/source/class/cv/parser/widgets/Unknown.js
@@ -37,7 +37,7 @@ qx.Class.define('cv.parser.widgets.Unknown', {
     parse: function (xml, path, flavour, pageType) {
       return cv.data.Model.getInstance().setWidgetData(path, {
         'path': path,
-        'unknownType': qx.dom.Node.getName(xml).toLowerCase(),
+        'unknownType': xml.nodeName.toLowerCase(),
         '$$type': "unknown",
         'pageType': pageType
       });

--- a/source/class/cv/plugins/CalendarList.js
+++ b/source/class/cv/plugins/CalendarList.js
@@ -79,7 +79,7 @@ qx.Class.define('cv.plugins.CalendarList', {
       var data = cv.parser.WidgetParser.parseElement(this, xml, path, flavour, pageType, this.getAttributeToPropertyMappings());
       cv.parser.WidgetParser.parseRefresh(xml, path);
       this.calendars[path] = [];
-      qx.bom.Selector.query('calendar', xml).forEach(function (cal) {
+      xml.querySelectorAll('calendar').forEach(function (cal) {
         var calData = {
           type: cal.getAttribute('type'),
           userid: cal.getAttribute('userid'),

--- a/source/class/cv/plugins/Clock.js
+++ b/source/class/cv/plugins/Clock.js
@@ -111,8 +111,8 @@ qx.Class.define('cv.plugins.Clock', {
       var hourElem = qx.bom.Selector.query('#Hour', svg)[0];
       var minuteElem = qx.bom.Selector.query('#Minute', svg)[0];
       if( hourElem !== undefined && minuteElem !== undefined ) {
-        qx.bom.element.Attribute.set(hourElem, "transform", 'rotate(' + ((time[0] % 12) * 360 / 12 + time[1] * 30 / 60) + ',50,50)');
-        qx.bom.element.Attribute.set(minuteElem, "transform", 'rotate(' + (time[1] * 6) + ',50,50)');
+        hourElem.setAttribute("transform", 'rotate(' + ((time[0] % 12) * 360 / 12 + time[1] * 30 / 60) + ',50,50)');
+        minuteElem.setAttribute("transform", 'rotate(' + (time[1] * 6) + ',50,50)');
       } else {
         console.error('Error: trying to update unknown clock SVG elements #Hour and/or #Minute');
       }

--- a/source/class/cv/plugins/Clock.js
+++ b/source/class/cv/plugins/Clock.js
@@ -106,10 +106,10 @@ qx.Class.define('cv.plugins.Clock', {
     _update: function (address, data, isDataAlreadyHandled) {
       var element = this.getDomElement();
       var value = isDataAlreadyHandled ? data : this.defaultValueHandling(address, data);
-      var svg = qx.bom.Selector.query('svg', element)[0];
+      var svg = element.querySelector('svg');
       var time = value.split(':');
-      var hourElem = qx.bom.Selector.query('#Hour', svg)[0];
-      var minuteElem = qx.bom.Selector.query('#Minute', svg)[0];
+      var hourElem = svg.querySelector('#Hour');
+      var minuteElem = svg.querySelector('#Minute');
       if( hourElem !== undefined && minuteElem !== undefined ) {
         hourElem.setAttribute("transform", 'rotate(' + ((time[0] % 12) * 360 / 12 + time[1] * 30 / 60) + ',50,50)');
         minuteElem.setAttribute("transform", 'rotate(' + (time[1] * 6) + ',50,50)');

--- a/source/class/cv/plugins/Gauge.js
+++ b/source/class/cv/plugins/Gauge.js
@@ -191,7 +191,7 @@ qx.Class.define('cv.plugins.Gauge', {
 
     // overridden
     getValueElement: function() {
-      return qx.bom.Selector.query('#gauge_' + this.getPath(), this.getDomElement())[0];
+      return this.getDomElement().querySelector('#gauge_' + this.getPath());
     },
 
     // property apply

--- a/source/class/cv/plugins/Gauge.js
+++ b/source/class/cv/plugins/Gauge.js
@@ -181,10 +181,7 @@ qx.Class.define('cv.plugins.Gauge', {
         lcdColor: steelseries.LcdColor.STANDARD,
         ledColor: steelseries.LedColor.RED_LED
       };
-      var params = qx.lang.Object.mergeWith(
-        qx.lang.Object.clone(cv.data.Model.getInstance().getWidgetData(this.getPath())),
-        additional
-      );
+      var params = Object.assign({}, cv.data.Model.getInstance().getWidgetData(this.getPath()), additional );
       this.__gaugeElement = new steelseries[this.getGType()]("gauge_"+this.getPath(), params);
       this.base(arguments);
     },

--- a/source/class/cv/plugins/MobileMenu.js
+++ b/source/class/cv/plugins/MobileMenu.js
@@ -74,12 +74,12 @@ qx.Class.define('cv.plugins.MobileMenu', {
         if (!navLeft.classList.contains('mobilemenu')){
           navLeft.classList.add('mobilemenu');
         }
-        qx.bom.element.Style.set(navLeft, "display", "none");
+        navLeft.style["display"] = "none";
         qx.event.message.Bus.subscribe("path.pageChanged", function() {
           var navbar = navLeft.querySelector('.navbar');
           var animation = qx.bom.element.Animation.animate(navbar, qx.util.Animation.SLIDE_LEFT_OUT);
           animation.addListenerOnce("end", function() {
-            qx.bom.element.Style.set(navLeft, "display", "none");
+            navLeft.style["display"] = "none";
           }, this);
         });
 
@@ -98,7 +98,7 @@ qx.Class.define('cv.plugins.MobileMenu', {
     _action: function() {
       if (window.innerWidth <= cv.Config.maxMobileScreenWidth){
         if(this.isTouchDevice()){
-          qx.bom.element.Style.set(this.__navLeft, "display", "block");
+          this.__navLeft.style["display"] = "block";
           var navbar = this.__navLeft.querySelector('.navbar.navbarActive');
           qx.bom.element.Animation.animate(navbar, qx.util.Animation.SLIDE_LEFT_IN);
         }

--- a/source/class/cv/plugins/MobileMenu.js
+++ b/source/class/cv/plugins/MobileMenu.js
@@ -74,12 +74,12 @@ qx.Class.define('cv.plugins.MobileMenu', {
         if (!navLeft.classList.contains('mobilemenu')){
           navLeft.classList.add('mobilemenu');
         }
-        navLeft.style["display"] = "none";
+        navLeft.style.display = "none";
         qx.event.message.Bus.subscribe("path.pageChanged", function() {
           var navbar = navLeft.querySelector('.navbar');
           var animation = qx.bom.element.Animation.animate(navbar, qx.util.Animation.SLIDE_LEFT_OUT);
           animation.addListenerOnce("end", function() {
-            navLeft.style["display"] = "none";
+            navLeft.style.display = "none";
           }, this);
         });
 
@@ -98,7 +98,7 @@ qx.Class.define('cv.plugins.MobileMenu', {
     _action: function() {
       if (window.innerWidth <= cv.Config.maxMobileScreenWidth){
         if(this.isTouchDevice()){
-          this.__navLeft.style["display"] = "block";
+          this.__navLeft.style.display = "block";
           var navbar = this.__navLeft.querySelector('.navbar.navbarActive');
           qx.bom.element.Animation.animate(navbar, qx.util.Animation.SLIDE_LEFT_IN);
         }

--- a/source/class/cv/plugins/MobileMenu.js
+++ b/source/class/cv/plugins/MobileMenu.js
@@ -71,8 +71,8 @@ qx.Class.define('cv.plugins.MobileMenu', {
     getDomString: function() {
       if (window.innerWidth <= cv.Config.maxMobileScreenWidth){
         var navLeft = this.__navLeft = document.querySelector('#navbarLeft');
-        if (!qx.bom.element.Class.has(navLeft, 'mobilemenu')){
-          qx.bom.element.Class.add(navLeft, 'mobilemenu');
+        if (!navLeft.classList.contains('mobilemenu')){
+          navLeft.classList.add('mobilemenu');
         }
         qx.bom.element.Style.set(navLeft, "display", "none");
         qx.event.message.Bus.subscribe("path.pageChanged", function() {

--- a/source/class/cv/plugins/MobileMenu.js
+++ b/source/class/cv/plugins/MobileMenu.js
@@ -70,13 +70,13 @@ qx.Class.define('cv.plugins.MobileMenu', {
     // overridden
     getDomString: function() {
       if (window.innerWidth <= cv.Config.maxMobileScreenWidth){
-        var navLeft = this.__navLeft = qx.bom.Selector.query('#navbarLeft')[0];
+        var navLeft = this.__navLeft = document.querySelector('#navbarLeft');
         if (!qx.bom.element.Class.has(navLeft, 'mobilemenu')){
           qx.bom.element.Class.add(navLeft, 'mobilemenu');
         }
         qx.bom.element.Style.set(navLeft, "display", "none");
         qx.event.message.Bus.subscribe("path.pageChanged", function() {
-          var navbar = qx.bom.Selector.query('.navbar', navLeft)[0];
+          var navbar = navLeft.querySelector('.navbar');
           var animation = qx.bom.element.Animation.animate(navbar, qx.util.Animation.SLIDE_LEFT_OUT);
           animation.addListenerOnce("end", function() {
             qx.bom.element.Style.set(navLeft, "display", "none");
@@ -99,7 +99,7 @@ qx.Class.define('cv.plugins.MobileMenu', {
       if (window.innerWidth <= cv.Config.maxMobileScreenWidth){
         if(this.isTouchDevice()){
           qx.bom.element.Style.set(this.__navLeft, "display", "block");
-          var navbar = qx.bom.Selector.query('.navbar.navbarActive', this.__navLeft)[0];
+          var navbar = this.__navLeft.querySelector('.navbar.navbarActive');
           qx.bom.element.Animation.animate(navbar, qx.util.Animation.SLIDE_LEFT_IN);
         }
       }
@@ -108,7 +108,7 @@ qx.Class.define('cv.plugins.MobileMenu', {
     touchScroll: function(id){
       var scrollStartPos=0;
 
-      var elem = qx.bom.Selector.query('#'+id)[0];
+      var elem = document.querySelector('#'+id);
       qx.event.Registration.addListener(elem, "touchstart", function(event) {
         scrollStartPos=this.scrollTop+event.touches[0].pageY;
         event.preventDefault();

--- a/source/class/cv/plugins/RssLog.js
+++ b/source/class/cv/plugins/RssLog.js
@@ -342,7 +342,7 @@ qx.Class.define('cv.plugins.RssLog', {
 
       // get height of one entry, calc max num of display items in widget
       var displayrows = parseInt(c.dataset["last_rowcount"], 10) || 0;
-      qx.bom.Html.clean(['<li class="rsslogRow odd" id="dummydiv">.</li>'], null, c);
+      ul.innerHTML = '<li class="rsslogRow odd" id="dummydiv">.</li>';
       var dummyDiv = c.querySelector('#dummydiv'),
         rect = dummyDiv.getBoundingClientRect(),
         itemheight = Math.round(rect.bottom - rect.top);

--- a/source/class/cv/plugins/RssLog.js
+++ b/source/class/cv/plugins/RssLog.js
@@ -220,7 +220,7 @@ qx.Class.define('cv.plugins.RssLog', {
       var title = qx.dom.Node.getText(document.querySelector('#' + this.getPath() + ' .label')) || '';
       var popup = cv.ui.PopupHandler.showPopup("rsslog", {title: title, content: brss});
       var parent = cv.util.Tree.getParent(brss, "div", null, 1)[0];
-      Object.entries({height: "90%", width: "90%", margin: "auto"}).forEach(function(key,value){parent.style[key]=value;}); // define parent as 100%!
+      Object.entries({height: "90%", width: "90%", margin: "auto"}).forEach(function([key,value]){parent.style[key]=value;}); // define parent as 100%!
       if (this._timer) {
         this._timer.stop();
       }

--- a/source/class/cv/plugins/RssLog.js
+++ b/source/class/cv/plugins/RssLog.js
@@ -216,7 +216,7 @@ qx.Class.define('cv.plugins.RssLog', {
     },
 
     _action: function () {
-      var brss = (function(){var div=document.createElement('div');div.innerHTML='<div class="rsslog_popup" id="rss_' + this.getPath() + '_big"/>';return div.childNodes[0];})();
+      var brss = cv.util.String.htmlStringToDomElement('<div class="rsslog_popup" id="rss_' + this.getPath() + '_big"/>');
       var title = document.querySelector('#' + this.getPath() + ' .label').innerText || '';
       var popup = cv.ui.PopupHandler.showPopup("rsslog", {title: title, content: brss});
       var parent = cv.util.Tree.getParent(brss, "div", null, 1)[0];

--- a/source/class/cv/plugins/RssLog.js
+++ b/source/class/cv/plugins/RssLog.js
@@ -422,7 +422,7 @@ qx.Class.define('cv.plugins.RssLog', {
         var itemHtml = this.__getItemHtml(item, isBig);
 
         var rowElem = qx.dom.Element.create('li', { 'class' : 'rsslogRow ' + row });
-        rowElem.setAttribute("html", itemHtml);
+        rowElem.innerHTML = itemHtml;
 
         if (item.mapping && item.mapping !== '') {
           var mappedValue = this.applyMapping(itemack === 'disable' ? 0 : item.state, item.mapping);

--- a/source/class/cv/plugins/RssLog.js
+++ b/source/class/cv/plugins/RssLog.js
@@ -283,7 +283,7 @@ qx.Class.define('cv.plugins.RssLog', {
      */
     __refreshRss: function() {
       var src = this.getSrc();
-      var requestData = qx.lang.Object.clone(this.__fixedRequestData);
+      var requestData = Object.assign({}, this.__fixedRequestData);
       if (this.getFilter()) {
         requestData.f = this.getFilter();
       }
@@ -518,7 +518,7 @@ qx.Class.define('cv.plugins.RssLog', {
       var req = new qx.io.request.Xhr(this.__request.getUrl());
       req.set({
         method: "GET",
-        requestData: qx.lang.Object.mergeWith(qx.lang.Object.clone(this.__fixedRequestData), {
+        requestData: Object.assign({}, this.__fixedRequestData, {
           'u': id,
           'state': state
         }),

--- a/source/class/cv/plugins/RssLog.js
+++ b/source/class/cv/plugins/RssLog.js
@@ -430,7 +430,8 @@ qx.Class.define('cv.plugins.RssLog', {
         if (item.mapping && item.mapping !== '') {
           var mappedValue = this.applyMapping(itemack === 'disable' ? 0 : item.state, item.mapping);
           var span = rowElem.querySelector('.mappedValue');
-          this.defaultValue2DOM(mappedValue, qx.lang.Function.curry(this._applyValueToDom, span));
+          var self = this;
+          this.defaultValue2DOM(mappedValue, function(e){self._applyValueToDom(span,e);});
         }
         if (this.__separatoradd && idx !== 0) {
           rowElem.classList.add('rsslog_separator');
@@ -513,7 +514,8 @@ qx.Class.define('cv.plugins.RssLog', {
         var mappedValue = this.applyMapping(state, mapping);
         var span = item.querySelector('.mappedValue');
         span.innerHTML = '';
-        this.defaultValue2DOM(mappedValue, qx.lang.Function.curry(this._applyValueToDom, span));
+        var self = this;
+        this.defaultValue2DOM(mappedValue, function(e){self._applyValueToDom(span,e);});
       }
       var req = new qx.io.request.Xhr(this.__request.getUrl());
       req.set({

--- a/source/class/cv/plugins/RssLog.js
+++ b/source/class/cv/plugins/RssLog.js
@@ -234,7 +234,7 @@ qx.Class.define('cv.plugins.RssLog', {
         // But delay it so that any change done to the data has a chance to
         // arrive here.
 
-        if (popup.getCurrentDomElement() && qx.bom.element.Class.has(popup.getCurrentDomElement(), 'popup') && this.getItemack() === 'modify') {
+        if (popup.getCurrentDomElement() && popup.getCurrentDomElement().classList.contains('popup') && this.getItemack() === 'modify') {
           qx.event.Timer.once(function () {
             this.refreshRSSlog();
           }, this, 100);
@@ -430,7 +430,7 @@ qx.Class.define('cv.plugins.RssLog', {
           this.defaultValue2DOM(mappedValue, qx.lang.Function.curry(this._applyValueToDom, span));
         }
         if (this.__separatoradd && idx !== 0) {
-          qx.bom.element.Class.add(rowElem, 'rsslog_separator');
+          rowElem.classList.add('rsslog_separator');
           this.__separatorprevday = true;
         }
         else {
@@ -438,11 +438,11 @@ qx.Class.define('cv.plugins.RssLog', {
         }
 
         if (this.__separatorprevday === true) {
-          qx.bom.element.Class.add(rowElem, 'rsslog_prevday');
+          rowElem.classList.add('rsslog_prevday');
         }
 
         if (this.__isFuture) {
-          qx.bom.element.Class.add(rowElem, (row === 'rsslogodd') ? 'rsslog_futureeven' : 'rsslog_futureodd');
+          rowElem.classList.add((row === 'rsslogodd') ? 'rsslog_futureeven' : 'rsslog_futureodd');
         }
 
         qx.bom.element.Dataset.set(rowElem, 'id', item.id);
@@ -450,13 +450,13 @@ qx.Class.define('cv.plugins.RssLog', {
         if (item.tags) {
           var tmp = rowElem.querySelector('span');
           if (qx.lang.Type.isArray(item.tags)) {
-            item.tags.forEach(qx.lang.Function.curry(qx.bom.element.Class.add, tmp), this);
+            tmp.classList.add.apply( tmp.classList, item.tags );
           } else {
-            qx.bom.element.Class.add(tmp, item.tags);
+            tmp.classList.add(item.tags);
           }
         }
         if (item.state === "1" && itemack !== 'disable') {
-          qx.bom.element.Class.add(rowElem, "rsslog_ack");
+          rowElem.classList.add("rsslog_ack");
         }
 
         if (itemack === 'modify') {
@@ -504,8 +504,8 @@ qx.Class.define('cv.plugins.RssLog', {
 
       var id = qx.bom.element.Dataset.get(item, 'id');
       var mapping = qx.bom.element.Dataset.get(item, 'mapping');
-      qx.bom.element.Class.toggle(item, "rsslog_ack");
-      var state = +qx.bom.element.Class.has(item, "rsslog_ack"); // the new state is the same as hasClass
+      item.classList.toggle("rsslog_ack");
+      var state = +item.classList.contains("rsslog_ack"); // the new state is the same as hasClass
       if (mapping && mapping !== '') {
         var mappedValue = this.applyMapping(state, mapping);
         var span = item.querySelector('.mappedValue');

--- a/source/class/cv/plugins/RssLog.js
+++ b/source/class/cv/plugins/RssLog.js
@@ -244,7 +244,7 @@ qx.Class.define('cv.plugins.RssLog', {
           }
         }
       }, this);
-      qx.bom.element.Style.set(popup.getCurrentDomElement().querySelector('.main'), "overflow", "auto");
+      popup.getCurrentDomElement().querySelector('.main').style["overflow"] = "auto";
       this.refreshRSSlog(true);
     },
 

--- a/source/class/cv/plugins/RssLog.js
+++ b/source/class/cv/plugins/RssLog.js
@@ -422,7 +422,7 @@ qx.Class.define('cv.plugins.RssLog', {
         var itemHtml = this.__getItemHtml(item, isBig);
 
         var rowElem = qx.dom.Element.create('li', { 'class' : 'rsslogRow ' + row });
-        qx.bom.element.Attribute.set(rowElem, "html", itemHtml);
+        rowElem.setAttribute("html", itemHtml);
 
         if (item.mapping && item.mapping !== '') {
           var mappedValue = this.applyMapping(itemack === 'disable' ? 0 : item.state, item.mapping);

--- a/source/class/cv/plugins/RssLog.js
+++ b/source/class/cv/plugins/RssLog.js
@@ -220,7 +220,7 @@ qx.Class.define('cv.plugins.RssLog', {
       var title = qx.dom.Node.getText(document.querySelector('#' + this.getPath() + ' .label')) || '';
       var popup = cv.ui.PopupHandler.showPopup("rsslog", {title: title, content: brss});
       var parent = cv.util.Tree.getParent(brss, "div", null, 1)[0];
-      Object.entries({height: "90%", width: "90%", margin: "auto"}).forEach(function([key,value]){parent.style[key]=value;}); // define parent as 100%!
+      Object.entries({height: "90%", width: "90%", margin: "auto"}).forEach(function(key_value){parent.style[key_value[0]]=key_value[1];}); // define parent as 100%!
       if (this._timer) {
         this._timer.stop();
       }

--- a/source/class/cv/plugins/RssLog.js
+++ b/source/class/cv/plugins/RssLog.js
@@ -365,7 +365,7 @@ qx.Class.define('cv.plugins.RssLog', {
 
     __updateRssContent: function(ev) {
       var result = ev.getTarget().getResponse();
-      if (qx.lang.Type.isString(result)) {
+      if (typeof result === 'string') {
         // no json -> error
         this.error(result);
         return;
@@ -452,7 +452,7 @@ qx.Class.define('cv.plugins.RssLog', {
         rowElem.dataset['mapping'] = item.mapping;
         if (item.tags) {
           var tmp = rowElem.querySelector('span');
-          if (qx.lang.Type.isArray(item.tags)) {
+          if (Array.isArray(item.tags)) {
             tmp.classList.add.apply( tmp.classList, item.tags );
           } else {
             tmp.classList.add(item.tags);

--- a/source/class/cv/plugins/RssLog.js
+++ b/source/class/cv/plugins/RssLog.js
@@ -244,7 +244,7 @@ qx.Class.define('cv.plugins.RssLog', {
           }
         }
       }, this);
-      popup.getCurrentDomElement().querySelector('.main').style["overflow"] = "auto";
+      popup.getCurrentDomElement().querySelector('.main').style.overflow = "auto";
       this.refreshRSSlog(true);
     },
 

--- a/source/class/cv/plugins/RssLog.js
+++ b/source/class/cv/plugins/RssLog.js
@@ -381,7 +381,7 @@ qx.Class.define('cv.plugins.RssLog', {
       var c = qx.bom.Selector.query(selector)[0];
       var itemack = isBig === true ? this.getItemack() : ( 'modify' === this.getItemack() ? 'display' : this.getItemack());
 
-      this.debug("ID: "+qx.bom.element.Attribute.get(c, "id")+", Feed: "+this.getSrc());
+      this.debug("ID: "+c.getAttribute("id")+", Feed: "+this.getSrc());
 
       var ul = qx.dom.Element.create("ul");
       var displayrows = this.__prepareContentElement(ul, c);

--- a/source/class/cv/plugins/RssLog.js
+++ b/source/class/cv/plugins/RssLog.js
@@ -216,8 +216,8 @@ qx.Class.define('cv.plugins.RssLog', {
     },
 
     _action: function () {
-      var brss = qx.bom.Html.clean(['<div class="rsslog_popup" id="rss_' + this.getPath() + '_big"/>'])[0];
-      var title = qx.dom.Node.getText(document.querySelector('#' + this.getPath() + ' .label')) || '';
+      var brss = (function(){var div=document.createElement('div');div.innerHTML='<div class="rsslog_popup" id="rss_' + this.getPath() + '_big"/>';return div.childNodes[0];})();
+      var title = document.querySelector('#' + this.getPath() + ' .label').innerText || '';
       var popup = cv.ui.PopupHandler.showPopup("rsslog", {title: title, content: brss});
       var parent = cv.util.Tree.getParent(brss, "div", null, 1)[0];
       Object.entries({height: "90%", width: "90%", margin: "auto"}).forEach(function(key_value){parent.style[key_value[0]]=key_value[1];}); // define parent as 100%!
@@ -336,9 +336,9 @@ qx.Class.define('cv.plugins.RssLog', {
     },
 
     __prepareContentElement: function(ul, c) {
-      qx.dom.Element.empty(c);
+      c.innerHTML = '';
 
-      qx.dom.Element.insertEnd(ul, c);
+      c.appendChild(ul);
 
       // get height of one entry, calc max num of display items in widget
       var displayrows = parseInt(c.dataset["last_rowcount"], 10) || 0;
@@ -346,9 +346,9 @@ qx.Class.define('cv.plugins.RssLog', {
       var dummyDiv = c.querySelector('#dummydiv'),
         rect = dummyDiv.getBoundingClientRect(),
         itemheight = Math.round(rect.bottom - rect.top);
-      qx.dom.Element.remove(dummyDiv);
+      dummyDiv.parentNode.removeChild(dummyDiv);
       if (itemheight !== 0) {
-        var widget = qx.dom.Element.getParentElement(qx.dom.Element.getParentElement(c)), // get the parent widget
+        var widget = c.parentNode.parentNode, // get the parent widget
           widgetRect = widget.getBoundingClientRect(),
           displayheight = Math.round(widgetRect.bottom - widgetRect.top),
           labelElem = widget.querySelector('.label');
@@ -386,7 +386,7 @@ qx.Class.define('cv.plugins.RssLog', {
 
       this.debug("ID: "+c.getAttribute("id")+", Feed: "+this.getSrc());
 
-      var ul = qx.dom.Element.create("ul");
+      var ul = document.createElement("ul");
       var displayrows = this.__prepareContentElement(ul, c);
 
       var itemnum = items.length;
@@ -465,7 +465,7 @@ qx.Class.define('cv.plugins.RssLog', {
         if (itemack === 'modify') {
           qx.event.Registration.addListener(rowElem, "tap", this._onTap, this);
         }
-        qx.dom.Element.insertEnd(rowElem, ul);
+        ul.appendChild(rowElem);
 
         // Alternate row classes
         row = (row === 'rsslogodd') ? 'rsslogeven' : 'rsslogodd';
@@ -512,7 +512,7 @@ qx.Class.define('cv.plugins.RssLog', {
       if (mapping && mapping !== '') {
         var mappedValue = this.applyMapping(state, mapping);
         var span = item.querySelector('.mappedValue');
-        qx.dom.Element.empty(span);
+        span.innerHTML = '';
         this.defaultValue2DOM(mappedValue, qx.lang.Function.curry(this._applyValueToDom, span));
       }
       var req = new qx.io.request.Xhr(this.__request.getUrl());

--- a/source/class/cv/plugins/RssLog.js
+++ b/source/class/cv/plugins/RssLog.js
@@ -343,16 +343,19 @@ qx.Class.define('cv.plugins.RssLog', {
       // get height of one entry, calc max num of display items in widget
       var displayrows = parseInt(c.dataset["last_rowcount"], 10) || 0;
       qx.bom.Html.clean(['<li class="rsslogRow odd" id="dummydiv">.</li>'], null, c);
-      var dummyDiv = c.querySelector('#dummydiv');
-      var itemheight = qx.bom.element.Dimension.getHeight(dummyDiv);
+      var dummyDiv = c.querySelector('#dummydiv'),
+        rect = dummyDiv.getBoundingClientRect(),
+        itemheight = Math.round(rect.bottom - rect.top);
       qx.dom.Element.remove(dummyDiv);
       if (itemheight !== 0) {
-        var widget = qx.dom.Element.getParentElement(qx.dom.Element.getParentElement(c)); // get the parent widget
-        var displayheight = qx.bom.element.Dimension.getHeight(widget);
-        var labelElem = widget.querySelector('.label');
+        var widget = qx.dom.Element.getParentElement(qx.dom.Element.getParentElement(c)), // get the parent widget
+          widgetRect = widget.getBoundingClientRect(),
+          displayheight = Math.round(widgetRect.bottom - widgetRect.top),
+          labelElem = widget.querySelector('.label');
         if (labelElem) {
           // max. height of actor is widget-label(if exists)
-          displayheight -= qx.bom.element.Dimension.getHeight(labelElem);
+          var labelElemRect = labelElem.getBoundingClientRect();
+          displayheight -= Math.round(labelElemRect.bottom - labelElemRect.top);
         }
         displayrows = Math.floor(displayheight / itemheight);
       }

--- a/source/class/cv/plugins/RssLog.js
+++ b/source/class/cv/plugins/RssLog.js
@@ -217,7 +217,7 @@ qx.Class.define('cv.plugins.RssLog', {
 
     _action: function () {
       var brss = qx.bom.Html.clean(['<div class="rsslog_popup" id="rss_' + this.getPath() + '_big"/>'])[0];
-      var title = qx.dom.Node.getText(qx.bom.Selector.query('#' + this.getPath() + ' .label')[0]) || '';
+      var title = qx.dom.Node.getText(document.querySelector('#' + this.getPath() + ' .label')) || '';
       var popup = cv.ui.PopupHandler.showPopup("rsslog", {title: title, content: brss});
       var parent = cv.util.Tree.getParent(brss, "div", null, 1)[0];
       qx.bom.element.Style.setStyles(parent, {height: "90%", width: "90%", margin: "auto"}); // define parent as 100%!
@@ -244,7 +244,7 @@ qx.Class.define('cv.plugins.RssLog', {
           }
         }
       }, this);
-      qx.bom.element.Style.set(qx.bom.Selector.query('.main', popup.getCurrentDomElement())[0], "overflow", "auto");
+      qx.bom.element.Style.set(popup.getCurrentDomElement().querySelector('.main'), "overflow", "auto");
       this.refreshRSSlog(true);
     },
 
@@ -343,13 +343,13 @@ qx.Class.define('cv.plugins.RssLog', {
       // get height of one entry, calc max num of display items in widget
       var displayrows = parseInt(qx.bom.element.Dataset.get(c, "last_rowcount"), 10) || 0;
       qx.bom.Html.clean(['<li class="rsslogRow odd" id="dummydiv">.</li>'], null, c);
-      var dummyDiv = qx.bom.Selector.query('#dummydiv', c)[0];
+      var dummyDiv = c.querySelector('#dummydiv');
       var itemheight = qx.bom.element.Dimension.getHeight(dummyDiv);
       qx.dom.Element.remove(dummyDiv);
       if (itemheight !== 0) {
         var widget = qx.dom.Element.getParentElement(qx.dom.Element.getParentElement(c)); // get the parent widget
         var displayheight = qx.bom.element.Dimension.getHeight(widget);
-        var labelElem = qx.bom.Selector.query('.label', widget)[0];
+        var labelElem = widget.querySelector('.label');
         if (labelElem) {
           // max. height of actor is widget-label(if exists)
           displayheight -= qx.bom.element.Dimension.getHeight(labelElem);
@@ -378,7 +378,7 @@ qx.Class.define('cv.plugins.RssLog', {
 
       var isBig = this.__request.getUserData("big");
       var selector = '#rss_' + this.getPath() + (isBig === true ? '_big' : '');
-      var c = qx.bom.Selector.query(selector)[0];
+      var c = document.querySelector(selector);
       var itemack = isBig === true ? this.getItemack() : ( 'modify' === this.getItemack() ? 'display' : this.getItemack());
 
       this.debug("ID: "+c.getAttribute("id")+", Feed: "+this.getSrc());
@@ -426,7 +426,7 @@ qx.Class.define('cv.plugins.RssLog', {
 
         if (item.mapping && item.mapping !== '') {
           var mappedValue = this.applyMapping(itemack === 'disable' ? 0 : item.state, item.mapping);
-          var span = qx.bom.Selector.query('.mappedValue', rowElem)[0];
+          var span = rowElem.querySelector('.mappedValue');
           this.defaultValue2DOM(mappedValue, qx.lang.Function.curry(this._applyValueToDom, span));
         }
         if (this.__separatoradd && idx !== 0) {
@@ -448,7 +448,7 @@ qx.Class.define('cv.plugins.RssLog', {
         qx.bom.element.Dataset.set(rowElem, 'id', item.id);
         qx.bom.element.Dataset.set(rowElem, 'mapping', item.mapping);
         if (item.tags) {
-          var tmp = qx.bom.Selector.query('span', rowElem)[0];
+          var tmp = rowElem.querySelector('span');
           if (qx.lang.Type.isArray(item.tags)) {
             item.tags.forEach(qx.lang.Function.curry(qx.bom.element.Class.add, tmp), this);
           } else {
@@ -508,7 +508,7 @@ qx.Class.define('cv.plugins.RssLog', {
       var state = +qx.bom.element.Class.has(item, "rsslog_ack"); // the new state is the same as hasClass
       if (mapping && mapping !== '') {
         var mappedValue = this.applyMapping(state, mapping);
-        var span = qx.bom.Selector.query('.mappedValue', item)[0];
+        var span = item.querySelector('.mappedValue');
         qx.dom.Element.empty(span);
         this.defaultValue2DOM(mappedValue, qx.lang.Function.curry(this._applyValueToDom, span));
       }

--- a/source/class/cv/plugins/RssLog.js
+++ b/source/class/cv/plugins/RssLog.js
@@ -341,7 +341,7 @@ qx.Class.define('cv.plugins.RssLog', {
       qx.dom.Element.insertEnd(ul, c);
 
       // get height of one entry, calc max num of display items in widget
-      var displayrows = parseInt(qx.bom.element.Dataset.get(c, "last_rowcount"), 10) || 0;
+      var displayrows = parseInt(c.dataset["last_rowcount"], 10) || 0;
       qx.bom.Html.clean(['<li class="rsslogRow odd" id="dummydiv">.</li>'], null, c);
       var dummyDiv = c.querySelector('#dummydiv');
       var itemheight = qx.bom.element.Dimension.getHeight(dummyDiv);
@@ -356,7 +356,7 @@ qx.Class.define('cv.plugins.RssLog', {
         }
         displayrows = Math.floor(displayheight / itemheight);
       }
-      qx.bom.element.Dataset.set(c, "last_rowcount", displayrows);
+      c.dataset["last_rowcount"] = displayrows;
       return displayrows;
     },
 
@@ -396,11 +396,11 @@ qx.Class.define('cv.plugins.RssLog', {
           itemoffset = itemnum - displayrows;
         }
         if (this.getMode() === 'rollover') {
-          itemoffset = parseInt(qx.bom.element.Dataset.get(c, "itemoffset"), 10) || 0;
+          itemoffset = parseInt(c.dataset["itemoffset"], 10) || 0;
           if (itemoffset === itemnum) {
             itemoffset = 0;
           }
-          qx.bom.element.Dataset.set(c, "itemoffset", itemoffset + 1);
+          c.dataset["itemoffset"] = itemoffset + 1;
         }
       }
 
@@ -445,8 +445,8 @@ qx.Class.define('cv.plugins.RssLog', {
           rowElem.classList.add((row === 'rsslogodd') ? 'rsslog_futureeven' : 'rsslog_futureodd');
         }
 
-        qx.bom.element.Dataset.set(rowElem, 'id', item.id);
-        qx.bom.element.Dataset.set(rowElem, 'mapping', item.mapping);
+        rowElem.dataset['id'] = item.id;
+        rowElem.dataset['mapping'] = item.mapping;
         if (item.tags) {
           var tmp = rowElem.querySelector('span');
           if (qx.lang.Type.isArray(item.tags)) {
@@ -502,8 +502,8 @@ qx.Class.define('cv.plugins.RssLog', {
     _onTap: function(ev) {
       var item = ev.getCurrentTarget();
 
-      var id = qx.bom.element.Dataset.get(item, 'id');
-      var mapping = qx.bom.element.Dataset.get(item, 'mapping');
+      var id = item.dataset['id'];
+      var mapping = item.dataset['mapping'];
       item.classList.toggle("rsslog_ack");
       var state = +item.classList.contains("rsslog_ack"); // the new state is the same as hasClass
       if (mapping && mapping !== '') {

--- a/source/class/cv/plugins/RssLog.js
+++ b/source/class/cv/plugins/RssLog.js
@@ -220,7 +220,7 @@ qx.Class.define('cv.plugins.RssLog', {
       var title = qx.dom.Node.getText(document.querySelector('#' + this.getPath() + ' .label')) || '';
       var popup = cv.ui.PopupHandler.showPopup("rsslog", {title: title, content: brss});
       var parent = cv.util.Tree.getParent(brss, "div", null, 1)[0];
-      qx.bom.element.Style.setStyles(parent, {height: "90%", width: "90%", margin: "auto"}); // define parent as 100%!
+      Object.entries({height: "90%", width: "90%", margin: "auto"}).forEach(function(key,value){parent.style[key]=value;}); // define parent as 100%!
       if (this._timer) {
         this._timer.stop();
       }

--- a/source/class/cv/plugins/Speech.js
+++ b/source/class/cv/plugins/Speech.js
@@ -87,10 +87,10 @@ qx.Class.define('cv.plugins.Speech', {
 
       return cv.data.Model.getInstance().setWidgetData( path, {
         'path'    : path,
-        'language': qx.bom.element.Attribute.get(element, 'lang') ? qx.bom.element.Attribute.get(element, 'lang') .toLowerCase() : null,
+        'language': element.getAttribute('lang') ? element.getAttribute('lang') .toLowerCase() : null,
         'address' : address,
-        'mapping' : qx.bom.element.Attribute.get(element, 'mapping'),
-        'repeatTimeout': qx.bom.element.Attribute.get(element, 'repeat-timeout') ? parseInt(qx.bom.element.Attribute.get(element, 'repeat-timeout')) : -1,
+        'mapping' : element.getAttribute('mapping'),
+        'repeatTimeout': element.getAttribute('repeat-timeout') ? parseInt(element.getAttribute('repeat-timeout')) : -1,
         '$$type'  : 'speech'
       });
     }

--- a/source/class/cv/plugins/Strftime.js
+++ b/source/class/cv/plugins/Strftime.js
@@ -119,7 +119,7 @@ qx.Class.define('cv.plugins.Strftime', {
       var elem = this.getValueElement();
       var d = new Date();
       d.locale = this.getLocale();
-      qx.bom.element.Attribute.set(elem, "text", d.strftime(this.getFormat()));
+      elem.setAttribute("text", d.strftime(this.getFormat()));
     }
   },
 

--- a/source/class/cv/plugins/Strftime.js
+++ b/source/class/cv/plugins/Strftime.js
@@ -119,7 +119,7 @@ qx.Class.define('cv.plugins.Strftime', {
       var elem = this.getValueElement();
       var d = new Date();
       d.locale = this.getLocale();
-      elem.setAttribute("text", d.strftime(this.getFormat()));
+      elem.innerText = d.strftime(this.getFormat());
     }
   },
 

--- a/source/class/cv/plugins/Strftime.js
+++ b/source/class/cv/plugins/Strftime.js
@@ -104,7 +104,7 @@ qx.Class.define('cv.plugins.Strftime', {
     // overridden
     getValueElement: function() {
       if (!this.__valueElement) {
-        this.__valueElement = qx.bom.Selector.query(".strftime_value", this.getDomElement())[0];
+        this.__valueElement = this.getDomElement().querySelector(".strftime_value");
       }
       return this.__valueElement;
     },

--- a/source/class/cv/plugins/Svg.js
+++ b/source/class/cv/plugins/Svg.js
@@ -71,7 +71,7 @@ qx.Class.define('cv.plugins.Svg', {
       ajaxRequest.addListenerOnce("success", function (e) {
         var req = e.getTarget();
         var actor = this.getActor();
-        qx.bom.element.Attribute.set(actor, 'html', req.getResponseText());
+        actor.setAttribute('html', req.getResponseText());
       }, this);
       ajaxRequest.send();
     },
@@ -86,13 +86,13 @@ qx.Class.define('cv.plugins.Svg', {
       var line, i, l;
       for(i = 0, l = Math.floor(value/line_qty); i<=l;i++) {
         line = qx.bom.Selector.query('#line'+(i+1), element)[0];
-        qx.bom.element.Attribute.set(line, 'y1', 9+total*(i)+((value%line_qty)/line_qty)*total);
-        qx.bom.element.Attribute.set(line, 'y2', 9+total*(i)+((value%line_qty)/line_qty)*total);
+        line.setAttribute('y1', 9+total*(i)+((value%line_qty)/line_qty)*total);
+        line.setAttribute('y2', 9+total*(i)+((value%line_qty)/line_qty)*total);
       }
       for(i = Math.floor(value/line_qty)+1; i<=line_qty;i++) {
         line = qx.bom.Selector.query('#line'+(i+1), element)[0];
-        qx.bom.element.Attribute.set(line, 'y1', 9);
-        qx.bom.element.Attribute.set(line, 'y2', 9);
+        line.setAttribute('y1', 9);
+        line.setAttribute('y2', 9);
       }
     }
   },

--- a/source/class/cv/plugins/Svg.js
+++ b/source/class/cv/plugins/Svg.js
@@ -85,12 +85,12 @@ qx.Class.define('cv.plugins.Svg', {
       var line_qty = 48 / total;
       var line, i, l;
       for(i = 0, l = Math.floor(value/line_qty); i<=l;i++) {
-        line = qx.bom.Selector.query('#line'+(i+1), element)[0];
+        line = element.querySelector('#line'+(i+1));
         line.setAttribute('y1', 9+total*(i)+((value%line_qty)/line_qty)*total);
         line.setAttribute('y2', 9+total*(i)+((value%line_qty)/line_qty)*total);
       }
       for(i = Math.floor(value/line_qty)+1; i<=line_qty;i++) {
-        line = qx.bom.Selector.query('#line'+(i+1), element)[0];
+        line = element.querySelector('#line'+(i+1));
         line.setAttribute('y1', 9);
         line.setAttribute('y2', 9);
       }

--- a/source/class/cv/plugins/Svg.js
+++ b/source/class/cv/plugins/Svg.js
@@ -71,7 +71,7 @@ qx.Class.define('cv.plugins.Svg', {
       ajaxRequest.addListenerOnce("success", function (e) {
         var req = e.getTarget();
         var actor = this.getActor();
-        actor.setAttribute('html', req.getResponseText());
+        actor.innerHTML = req.getResponseText();
       }, this);
       ajaxRequest.send();
     },

--- a/source/class/cv/plugins/Timeout.js
+++ b/source/class/cv/plugins/Timeout.js
@@ -124,7 +124,7 @@ qx.Class.define('cv.plugins.Timeout', {
       qx.event.message.Bus.subscribe("path.pageChanged", function (ev) {
         var path = ev.getData();
         this.__timeoutCurrentPage = path;
-        this.__timeoutCurrentPageTitle = qx.dom.Node.getText(qx.bom.Selector.query("#" + path+ " div > h1")[0]);
+        this.__timeoutCurrentPageTitle = qx.dom.Node.getText(document.querySelector("#" + path+ " div > h1"));
         this.__timeoutIdleCount = 0;
         /* We could trun on and off the above binds if we are already on the right page
 

--- a/source/class/cv/plugins/Timeout.js
+++ b/source/class/cv/plugins/Timeout.js
@@ -124,7 +124,7 @@ qx.Class.define('cv.plugins.Timeout', {
       qx.event.message.Bus.subscribe("path.pageChanged", function (ev) {
         var path = ev.getData();
         this.__timeoutCurrentPage = path;
-        this.__timeoutCurrentPageTitle = qx.dom.Node.getText(document.querySelector("#" + path+ " div > h1"));
+        this.__timeoutCurrentPageTitle = document.querySelector("#" + path+ " div > h1").innerText;
         this.__timeoutIdleCount = 0;
         /* We could trun on and off the above binds if we are already on the right page
 

--- a/source/class/cv/plugins/UpnpController.js
+++ b/source/class/cv/plugins/UpnpController.js
@@ -188,15 +188,15 @@ qx.Class.define('cv.plugins.UpnpController', {
       var id = this.upnpcontroller_uid;
 
       if (mute === 0) {
-        qx.bom.element.Class.replace(document.querySelector('#' + id + '_muteButton'), 'switchPressed', 'switchUnpressed');
+        document.querySelector('#' + id + '_muteButton').classList.replace('switchPressed','switchUnpressed');
       } else {
-        qx.bom.element.Class.replace(document.querySelector('#' + id + '_muteButton'), 'switchUnpressed', 'switchPressed');
+        document.querySelector('#' + id + '_muteButton').classList.replace('switchUnpressed','switchPressed');
       }
 
       if (playMode === 'Play') {
-        qx.bom.element.Class.replace(document.querySelector('#' + id + '_playButton'), 'switchPressed', 'switchUnpressed');
+        document.querySelector('#' + id + '_playButton').classList.replace('switchPressed','switchUnpressed');
       } else {
-        qx.bom.element.Class.replace(document.querySelector('#' + id + '_playButton'), 'switchUnpressed', 'switchPressed');
+        document.querySelector('#' + id + '_playButton').classList.replace('switchUnpressed','switchPressed');
       }
 
       document.querySelector('#' + id + '_muteButton div.value').innerText = mute;
@@ -289,11 +289,11 @@ qx.Class.define('cv.plugins.UpnpController', {
         if (currentValue !== 'pressed') {
           document.querySelector('#' + this.upnpcontroller_uid + '_playlistsresult div.value').innerHTML = playlists;
           playlists.setAttribute('value', 'pressed');
-          qx.bom.element.Class.replace(playlists, 'switchUnpressed', 'switchPressed');
+          playlists.classList.replace('switchUnpressed','switchPressed');
         } else {
           document.querySelector('#' + this.upnpcontroller_uid + '_playlistsresult div.value').innerText = "";
           playlists.setAttribute('value', 'unpressed');
-          qx.bom.element.Class.replace(playlists, 'switchUnpressed', 'switchPressed');
+          playlists.classList.replace('switchUnpressed','switchPressed');
         }
       });
     },
@@ -345,10 +345,10 @@ qx.Class.define('cv.plugins.UpnpController', {
 
       if (muteValue === 0) {
         muteValue = 1;
-        qx.bom.element.Class.replace(muteButton, 'switchUnpressed', 'switchPressed');
+        muteButton.classList.replace('switchUnpressed','switchPressed');
       } else {
         muteValue = 0;
-        qx.bom.element.Class.replace(muteButton, 'switchPressed', 'switchUnpressed');
+        muteButton.classList.replace('switchPressed','switchUnpressed');
       }
 
       this.__callRemote('mute', {mute: muteValue}, function (data) {
@@ -368,10 +368,10 @@ qx.Class.define('cv.plugins.UpnpController', {
       var playButton = document.querySelector('#' + this.upnpcontroller_uid + '_playButton');
       if (playValue === 'Play') {
         cmd = 'pause';
-        qx.bom.element.Class.replace(playButton, 'switchUnpressed', 'switchPressed');
+        playButton.classList.replace('switchUnpressed','switchPressed');
       } else {
         cmd = 'play';
-        qx.bom.element.Class.replace(playButton, 'switchPressed', 'switchUnpressed');
+        playButton.classList.replace('switchPressed','switchUnpressed');
       }
 
       this.__callRemote(cmd, {}, function (ev) {

--- a/source/class/cv/plugins/UpnpController.js
+++ b/source/class/cv/plugins/UpnpController.js
@@ -199,17 +199,17 @@ qx.Class.define('cv.plugins.UpnpController', {
         qx.bom.element.Class.replace(qx.bom.Selector.query('#' + id + '_playButton')[0], 'switchUnpressed', 'switchPressed');
       }
 
-      qx.bom.element.Attribute.set(qx.bom.Selector.query('#' + id + '_muteButton div.value')[0], "text", mute);
-      qx.bom.element.Attribute.set(qx.bom.Selector.query('#' + id + '_playButton div.value')[0], "text", playMode);
-      qx.bom.element.Attribute.set(qx.bom.Selector.query('#' + id + '_volume div.value')[0], "text", volume);
-      qx.bom.element.Attribute.set(qx.bom.Selector.query('#' + id + '_title div.value')[0], "text", title);
-      qx.bom.element.Attribute.set(qx.bom.Selector.query('#' + id + '_artist div.value')[0], "text", artist);
-      qx.bom.element.Attribute.set(qx.bom.Selector.query('#' + id + '_album div.value')[0], "text", album);
-      qx.bom.element.Attribute.set(qx.bom.Selector.query('#' + id + '_time div.value')[0], "text", reltime + ' of ' + duration);
+      qx.bom.Selector.query('#' + id + '_muteButton div.value')[0].setAttribute("text", mute);
+      qx.bom.Selector.query('#' + id + '_playButton div.value')[0].setAttribute("text", playMode);
+      qx.bom.Selector.query('#' + id + '_volume div.value')[0].setAttribute("text", volume);
+      qx.bom.Selector.query('#' + id + '_title div.value')[0].setAttribute("text", title);
+      qx.bom.Selector.query('#' + id + '_artist div.value')[0].setAttribute("text", artist);
+      qx.bom.Selector.query('#' + id + '_album div.value')[0].setAttribute("text", album);
+      qx.bom.Selector.query('#' + id + '_time div.value')[0].setAttribute("text", reltime + ' of ' + duration);
 
       this.upnpcontroller_song_process_rel = this.calculateSongProcessed(reltime, duration);
       this.traceLog("song_process_rel: " + this.upnpcontroller_song_process_rel);
-      qx.bom.element.Attribute.set(qx.bom.Selector.query('#' + id + '_progress')[0], "value", this.upnpcontroller_song_process_rel);
+      qx.bom.Selector.query('#' + id + '_progress')[0].setAttribute("value", this.upnpcontroller_song_process_rel);
     },
 
     /**
@@ -287,12 +287,12 @@ qx.Class.define('cv.plugins.UpnpController', {
         }
 
         if (currentValue !== 'pressed') {
-          qx.bom.element.Attribute.set(qx.bom.Selector.query('#' + this.upnpcontroller_uid + '_playlistsresult div.value')[0], "html", playlists);
-          qx.bom.element.Attribute.set(playlists, 'value', 'pressed');
+          qx.bom.Selector.query('#' + this.upnpcontroller_uid + '_playlistsresult div.value')[0].setAttribute("html", playlists);
+          playlists.setAttribute('value', 'pressed');
           qx.bom.element.Class.replace(playlists, 'switchUnpressed', 'switchPressed');
         } else {
-          qx.bom.element.Attribute.set(qx.bom.Selector.query('#' + this.upnpcontroller_uid + '_playlistsresult div.value')[0], "text", "");
-          qx.bom.element.Attribute.set(playlists, 'value', 'unpressed');
+          qx.bom.Selector.query('#' + this.upnpcontroller_uid + '_playlistsresult div.value')[0].setAttribute("text", "");
+          playlists.setAttribute('value', 'unpressed');
           qx.bom.element.Class.replace(playlists, 'switchUnpressed', 'switchPressed');
         }
       });

--- a/source/class/cv/plugins/UpnpController.js
+++ b/source/class/cv/plugins/UpnpController.js
@@ -253,7 +253,7 @@ qx.Class.define('cv.plugins.UpnpController', {
     callgetplaylists: function () {
       this.traceLog("click callgetplaylists");
       var playlist = qx.bom.Selector.query('#' + this.upnpcontroller_uid + '_getplaylists')[0];
-      var currentValue = qx.bom.element.Attribute.get(playlist, 'value');
+      var currentValue = playlist.getAttribute('value');
       var playerIp = this.getPlayerIp();
       var playerPort = this.getPlayerPort();
 
@@ -300,7 +300,7 @@ qx.Class.define('cv.plugins.UpnpController', {
 
     callvolumedown: function () {
       this.traceLog("click callvolumedown");
-      var currentVolume = qx.bom.element.Attribute.get(qx.bom.Selector.query('#' + this.upnpcontroller_uid + '_volume div.value')[0], "text");
+      var currentVolume = qx.bom.Selector.query('#' + this.upnpcontroller_uid + '_volume div.value')[0].getAttribute("text");
 
       this.traceLog("currentVolume: " + currentVolume);
       var volume = Number(currentVolume) - 5;
@@ -312,7 +312,7 @@ qx.Class.define('cv.plugins.UpnpController', {
 
     callvolumeup: function () {
       this.traceLog("click callvolumeup");
-      var currentVolume = qx.bom.element.Attribute.get(qx.bom.Selector.query('#' + this.upnpcontroller_uid + '_volume div.value')[0], "text");
+      var currentVolume = qx.bom.Selector.query('#' + this.upnpcontroller_uid + '_volume div.value')[0].getAttribute("text");
       this.traceLog("currentVolume: " + currentVolume);
       var volume = Number(currentVolume) + 5;
 
@@ -338,7 +338,7 @@ qx.Class.define('cv.plugins.UpnpController', {
     toggleMute: function () {
       this.traceLog("click mute");
       var muteButton = qx.bom.Selector.query('#' + this.upnpcontroller_uid + '_muteButton')[0];
-      var muteValue = qx.bom.element.Attribute.get(qx.bom.Selector.query('div.value', muteButton)[0], "text");
+      var muteValue = qx.bom.Selector.query('div.value', muteButton)[0].getAttribute("text");
 
       this.traceLog("current muteValue: " + muteValue);
 
@@ -360,7 +360,7 @@ qx.Class.define('cv.plugins.UpnpController', {
 
     togglePlay: function () {
       this.traceLog("click play");
-      var playValue = qx.bom.element.Attribute.get(qx.bom.Selector.query('#' + this.upnpcontroller_uid + '_playButton div.value')[0], "text");
+      var playValue = qx.bom.Selector.query('#' + this.upnpcontroller_uid + '_playButton div.value')[0].getAttribute("text");
       var cmd;
 
       this.traceLog("current playValue: " + playValue);

--- a/source/class/cv/plugins/UpnpController.js
+++ b/source/class/cv/plugins/UpnpController.js
@@ -138,13 +138,13 @@ qx.Class.define('cv.plugins.UpnpController', {
      */
     initListeners: function () {
       var Reg = qx.event.Registration;
-      Reg.addListener(qx.bom.Selector.query('#' + this.upnpcontroller_uid + "_muteButton")[0], "tap", this.toggleMute, this);
-      Reg.addListener(qx.bom.Selector.query('#' + this.upnpcontroller_uid + "_playButton")[0], "tap", this.togglePlay, this);
-      Reg.addListener(qx.bom.Selector.query('#' + this.upnpcontroller_uid + "_next")[0], "tap", this.callNext, this);
-      Reg.addListener(qx.bom.Selector.query('#' + this.upnpcontroller_uid + "_prev")[0], "tap", this.callPrev, this);
-      Reg.addListener(qx.bom.Selector.query('#' + this.upnpcontroller_uid + "_volumedown")[0], "tap", this.callvolumedown, this);
-      Reg.addListener(qx.bom.Selector.query('#' + this.upnpcontroller_uid + "_volumeup")[0], "tap", this.callvolumeup, this);
-      Reg.addListener(qx.bom.Selector.query('#' + this.upnpcontroller_uid + "_getplaylists")[0], "tap", this.callgetplaylists, this);
+      Reg.addListener(document.querySelector('#' + this.upnpcontroller_uid + "_muteButton"), "tap", this.toggleMute, this);
+      Reg.addListener(document.querySelector('#' + this.upnpcontroller_uid + "_playButton"), "tap", this.togglePlay, this);
+      Reg.addListener(document.querySelector('#' + this.upnpcontroller_uid + "_next"), "tap", this.callNext, this);
+      Reg.addListener(document.querySelector('#' + this.upnpcontroller_uid + "_prev"), "tap", this.callPrev, this);
+      Reg.addListener(document.querySelector('#' + this.upnpcontroller_uid + "_volumedown"), "tap", this.callvolumedown, this);
+      Reg.addListener(document.querySelector('#' + this.upnpcontroller_uid + "_volumeup"), "tap", this.callvolumeup, this);
+      Reg.addListener(document.querySelector('#' + this.upnpcontroller_uid + "_getplaylists"), "tap", this.callgetplaylists, this);
     },
 
     _setupRefreshAction: function () {
@@ -188,28 +188,28 @@ qx.Class.define('cv.plugins.UpnpController', {
       var id = this.upnpcontroller_uid;
 
       if (mute === 0) {
-        qx.bom.element.Class.replace(qx.bom.Selector.query('#' + id + '_muteButton')[0], 'switchPressed', 'switchUnpressed');
+        qx.bom.element.Class.replace(document.querySelector('#' + id + '_muteButton'), 'switchPressed', 'switchUnpressed');
       } else {
-        qx.bom.element.Class.replace(qx.bom.Selector.query('#' + id + '_muteButton')[0], 'switchUnpressed', 'switchPressed');
+        qx.bom.element.Class.replace(document.querySelector('#' + id + '_muteButton'), 'switchUnpressed', 'switchPressed');
       }
 
       if (playMode === 'Play') {
-        qx.bom.element.Class.replace(qx.bom.Selector.query('#' + id + '_playButton')[0], 'switchPressed', 'switchUnpressed');
+        qx.bom.element.Class.replace(document.querySelector('#' + id + '_playButton'), 'switchPressed', 'switchUnpressed');
       } else {
-        qx.bom.element.Class.replace(qx.bom.Selector.query('#' + id + '_playButton')[0], 'switchUnpressed', 'switchPressed');
+        qx.bom.element.Class.replace(document.querySelector('#' + id + '_playButton'), 'switchUnpressed', 'switchPressed');
       }
 
-      qx.bom.Selector.query('#' + id + '_muteButton div.value')[0].innerText = mute;
-      qx.bom.Selector.query('#' + id + '_playButton div.value')[0].innerText = playMode;
-      qx.bom.Selector.query('#' + id + '_volume div.value')[0].innerText = volume;
-      qx.bom.Selector.query('#' + id + '_title div.value')[0].innerText = title;
-      qx.bom.Selector.query('#' + id + '_artist div.value')[0].innerText = artist;
-      qx.bom.Selector.query('#' + id + '_album div.value')[0].innerText = album;
-      qx.bom.Selector.query('#' + id + '_time div.value')[0].innerText = reltime + ' of ' + duration;
+      document.querySelector('#' + id + '_muteButton div.value').innerText = mute;
+      document.querySelector('#' + id + '_playButton div.value').innerText = playMode;
+      document.querySelector('#' + id + '_volume div.value').innerText = volume;
+      document.querySelector('#' + id + '_title div.value').innerText = title;
+      document.querySelector('#' + id + '_artist div.value').innerText = artist;
+      document.querySelector('#' + id + '_album div.value').innerText = album;
+      document.querySelector('#' + id + '_time div.value').innerText = reltime + ' of ' + duration;
 
       this.upnpcontroller_song_process_rel = this.calculateSongProcessed(reltime, duration);
       this.traceLog("song_process_rel: " + this.upnpcontroller_song_process_rel);
-      qx.bom.Selector.query('#' + id + '_progress')[0].setAttribute("value", this.upnpcontroller_song_process_rel);
+      document.querySelector('#' + id + '_progress').setAttribute("value", this.upnpcontroller_song_process_rel);
     },
 
     /**
@@ -252,7 +252,7 @@ qx.Class.define('cv.plugins.UpnpController', {
 
     callgetplaylists: function () {
       this.traceLog("click callgetplaylists");
-      var playlist = qx.bom.Selector.query('#' + this.upnpcontroller_uid + '_getplaylists')[0];
+      var playlist = document.querySelector('#' + this.upnpcontroller_uid + '_getplaylists');
       var currentValue = playlist.getAttribute('value');
       var playerIp = this.getPlayerIp();
       var playerPort = this.getPlayerPort();
@@ -287,11 +287,11 @@ qx.Class.define('cv.plugins.UpnpController', {
         }
 
         if (currentValue !== 'pressed') {
-          qx.bom.Selector.query('#' + this.upnpcontroller_uid + '_playlistsresult div.value')[0].innerHTML = playlists;
+          document.querySelector('#' + this.upnpcontroller_uid + '_playlistsresult div.value').innerHTML = playlists;
           playlists.setAttribute('value', 'pressed');
           qx.bom.element.Class.replace(playlists, 'switchUnpressed', 'switchPressed');
         } else {
-          qx.bom.Selector.query('#' + this.upnpcontroller_uid + '_playlistsresult div.value')[0].innerText = "";
+          document.querySelector('#' + this.upnpcontroller_uid + '_playlistsresult div.value').innerText = "";
           playlists.setAttribute('value', 'unpressed');
           qx.bom.element.Class.replace(playlists, 'switchUnpressed', 'switchPressed');
         }
@@ -300,7 +300,7 @@ qx.Class.define('cv.plugins.UpnpController', {
 
     callvolumedown: function () {
       this.traceLog("click callvolumedown");
-      var currentVolume = qx.bom.Selector.query('#' + this.upnpcontroller_uid + '_volume div.value')[0].innerText;
+      var currentVolume = document.querySelector('#' + this.upnpcontroller_uid + '_volume div.value').innerText;
 
       this.traceLog("currentVolume: " + currentVolume);
       var volume = Number(currentVolume) - 5;
@@ -312,7 +312,7 @@ qx.Class.define('cv.plugins.UpnpController', {
 
     callvolumeup: function () {
       this.traceLog("click callvolumeup");
-      var currentVolume = qx.bom.Selector.query('#' + this.upnpcontroller_uid + '_volume div.value')[0].innerText;
+      var currentVolume = document.querySelector('#' + this.upnpcontroller_uid + '_volume div.value').innerText;
       this.traceLog("currentVolume: " + currentVolume);
       var volume = Number(currentVolume) + 5;
 
@@ -337,8 +337,8 @@ qx.Class.define('cv.plugins.UpnpController', {
 
     toggleMute: function () {
       this.traceLog("click mute");
-      var muteButton = qx.bom.Selector.query('#' + this.upnpcontroller_uid + '_muteButton')[0];
-      var muteValue = qx.bom.Selector.query('div.value', muteButton)[0].innerText;
+      var muteButton = document.querySelector('#' + this.upnpcontroller_uid + '_muteButton');
+      var muteValue = muteButton.querySelector('div.value').innerText;
 
       this.traceLog("current muteValue: " + muteValue);
 
@@ -360,12 +360,12 @@ qx.Class.define('cv.plugins.UpnpController', {
 
     togglePlay: function () {
       this.traceLog("click play");
-      var playValue = qx.bom.Selector.query('#' + this.upnpcontroller_uid + '_playButton div.value')[0].innerText;
+      var playValue = document.querySelector('#' + this.upnpcontroller_uid + '_playButton div.value').innerText;
       var cmd;
 
       this.traceLog("current playValue: " + playValue);
 
-      var playButton = qx.bom.Selector.query('#' + this.upnpcontroller_uid + '_playButton')[0];
+      var playButton = document.querySelector('#' + this.upnpcontroller_uid + '_playButton');
       if (playValue === 'Play') {
         cmd = 'pause';
         qx.bom.element.Class.replace(playButton, 'switchUnpressed', 'switchPressed');

--- a/source/class/cv/plugins/UpnpController.js
+++ b/source/class/cv/plugins/UpnpController.js
@@ -199,13 +199,13 @@ qx.Class.define('cv.plugins.UpnpController', {
         qx.bom.element.Class.replace(qx.bom.Selector.query('#' + id + '_playButton')[0], 'switchUnpressed', 'switchPressed');
       }
 
-      qx.bom.Selector.query('#' + id + '_muteButton div.value')[0].setAttribute("text", mute);
-      qx.bom.Selector.query('#' + id + '_playButton div.value')[0].setAttribute("text", playMode);
-      qx.bom.Selector.query('#' + id + '_volume div.value')[0].setAttribute("text", volume);
-      qx.bom.Selector.query('#' + id + '_title div.value')[0].setAttribute("text", title);
-      qx.bom.Selector.query('#' + id + '_artist div.value')[0].setAttribute("text", artist);
-      qx.bom.Selector.query('#' + id + '_album div.value')[0].setAttribute("text", album);
-      qx.bom.Selector.query('#' + id + '_time div.value')[0].setAttribute("text", reltime + ' of ' + duration);
+      qx.bom.Selector.query('#' + id + '_muteButton div.value')[0].innerText = mute;
+      qx.bom.Selector.query('#' + id + '_playButton div.value')[0].innerText = playMode;
+      qx.bom.Selector.query('#' + id + '_volume div.value')[0].innerText = volume;
+      qx.bom.Selector.query('#' + id + '_title div.value')[0].innerText = title;
+      qx.bom.Selector.query('#' + id + '_artist div.value')[0].innerText = artist;
+      qx.bom.Selector.query('#' + id + '_album div.value')[0].innerText = album;
+      qx.bom.Selector.query('#' + id + '_time div.value')[0].innerText = reltime + ' of ' + duration;
 
       this.upnpcontroller_song_process_rel = this.calculateSongProcessed(reltime, duration);
       this.traceLog("song_process_rel: " + this.upnpcontroller_song_process_rel);
@@ -287,11 +287,11 @@ qx.Class.define('cv.plugins.UpnpController', {
         }
 
         if (currentValue !== 'pressed') {
-          qx.bom.Selector.query('#' + this.upnpcontroller_uid + '_playlistsresult div.value')[0].setAttribute("html", playlists);
+          qx.bom.Selector.query('#' + this.upnpcontroller_uid + '_playlistsresult div.value')[0].innerHTML = playlists;
           playlists.setAttribute('value', 'pressed');
           qx.bom.element.Class.replace(playlists, 'switchUnpressed', 'switchPressed');
         } else {
-          qx.bom.Selector.query('#' + this.upnpcontroller_uid + '_playlistsresult div.value')[0].setAttribute("text", "");
+          qx.bom.Selector.query('#' + this.upnpcontroller_uid + '_playlistsresult div.value')[0].innerText = "";
           playlists.setAttribute('value', 'unpressed');
           qx.bom.element.Class.replace(playlists, 'switchUnpressed', 'switchPressed');
         }

--- a/source/class/cv/plugins/UpnpController.js
+++ b/source/class/cv/plugins/UpnpController.js
@@ -169,7 +169,7 @@ qx.Class.define('cv.plugins.UpnpController', {
         var data = ev.getTarget().getResponse();
         try {
           if (typeof data === 'string') {
-            data = qx.lang.Json.parse(data);
+            data = JSON.parse(data);
           }
           this.traceLog("volume          : " + data.volume);
           this.traceLog("reltime         : " + data.reltimeResponse);
@@ -264,7 +264,7 @@ qx.Class.define('cv.plugins.UpnpController', {
         var data = ev.getTarget().getResponse();
         try {
           if (typeof data === 'string') {
-            data = qx.lang.Json.parse(data);
+            data = JSON.parse(data);
           }
         } catch (e) {
           this.error(e);

--- a/source/class/cv/plugins/UpnpController.js
+++ b/source/class/cv/plugins/UpnpController.js
@@ -168,7 +168,7 @@ qx.Class.define('cv.plugins.UpnpController', {
       this.__callRemote('status', {}, function (ev) {
         var data = ev.getTarget().getResponse();
         try {
-          if (qx.lang.Type.isString(data)) {
+          if (typeof data === 'string') {
             data = qx.lang.Json.parse(data);
           }
           this.traceLog("volume          : " + data.volume);
@@ -263,7 +263,7 @@ qx.Class.define('cv.plugins.UpnpController', {
       this.__callRemote('playlists', {}, function (ev) {
         var data = ev.getTarget().getResponse();
         try {
-          if (qx.lang.Type.isString(data)) {
+          if (typeof data === 'string') {
             data = qx.lang.Json.parse(data);
           }
         } catch (e) {

--- a/source/class/cv/plugins/UpnpController.js
+++ b/source/class/cv/plugins/UpnpController.js
@@ -300,7 +300,7 @@ qx.Class.define('cv.plugins.UpnpController', {
 
     callvolumedown: function () {
       this.traceLog("click callvolumedown");
-      var currentVolume = qx.bom.Selector.query('#' + this.upnpcontroller_uid + '_volume div.value')[0].getAttribute("text");
+      var currentVolume = qx.bom.Selector.query('#' + this.upnpcontroller_uid + '_volume div.value')[0].innerText;
 
       this.traceLog("currentVolume: " + currentVolume);
       var volume = Number(currentVolume) - 5;
@@ -312,7 +312,7 @@ qx.Class.define('cv.plugins.UpnpController', {
 
     callvolumeup: function () {
       this.traceLog("click callvolumeup");
-      var currentVolume = qx.bom.Selector.query('#' + this.upnpcontroller_uid + '_volume div.value')[0].getAttribute("text");
+      var currentVolume = qx.bom.Selector.query('#' + this.upnpcontroller_uid + '_volume div.value')[0].innerText;
       this.traceLog("currentVolume: " + currentVolume);
       var volume = Number(currentVolume) + 5;
 
@@ -338,7 +338,7 @@ qx.Class.define('cv.plugins.UpnpController', {
     toggleMute: function () {
       this.traceLog("click mute");
       var muteButton = qx.bom.Selector.query('#' + this.upnpcontroller_uid + '_muteButton')[0];
-      var muteValue = qx.bom.Selector.query('div.value', muteButton)[0].getAttribute("text");
+      var muteValue = qx.bom.Selector.query('div.value', muteButton)[0].innerText;
 
       this.traceLog("current muteValue: " + muteValue);
 
@@ -360,7 +360,7 @@ qx.Class.define('cv.plugins.UpnpController', {
 
     togglePlay: function () {
       this.traceLog("click play");
-      var playValue = qx.bom.Selector.query('#' + this.upnpcontroller_uid + '_playButton div.value')[0].getAttribute("text");
+      var playValue = qx.bom.Selector.query('#' + this.upnpcontroller_uid + '_playButton div.value')[0].innerText;
       var cmd;
 
       this.traceLog("current playValue: " + playValue);

--- a/source/class/cv/plugins/UpnpController.js
+++ b/source/class/cv/plugins/UpnpController.js
@@ -223,7 +223,7 @@ qx.Class.define('cv.plugins.UpnpController', {
       if (!data) {
         data = {};
       }
-      data = qx.lang.Object.mergeWith(data, {
+      data = Object.assign(data, {
         player_ip_addr: this.getPlayerIp(),
         port: this.getPlayerPort()
       });

--- a/source/class/cv/plugins/diagram/AbstractDiagram.js
+++ b/source/class/cv/plugins/diagram/AbstractDiagram.js
@@ -496,7 +496,7 @@ qx.Class.define('cv.plugins.diagram.AbstractDiagram', {
       }, this);
 
       var parent = qx.dom.Element.getParentElement(popupDiagram);
-      Object.entries({height: "100%", width: "95%", margin: "auto"}).forEach(function([key,value]){parent.style[key]=value;});// define parent as 100%!
+      Object.entries({height: "100%", width: "95%", margin: "auto"}).forEach(function(key_value){parent.style[key_value[0]]=key_value[1];});// define parent as 100%!
       qx.dom.Element.empty(popupDiagram);
       qx.event.Registration.addListener(popupDiagram, "tap", function(event) {
         // don't let the popup know about the click, or it will close

--- a/source/class/cv/plugins/diagram/AbstractDiagram.js
+++ b/source/class/cv/plugins/diagram/AbstractDiagram.js
@@ -141,7 +141,7 @@ qx.Class.define('cv.plugins.diagram.AbstractDiagram', {
       };
       var axesNameIndex = [];
 
-      qx.bom.Selector.query('axis', xmlElement).forEach(function(elem) {
+      xmlElement.querySelectorAll('axis').forEach(function(elem) {
         var unit = elem.getAttribute('unit') || "";
         retVal.axes[retVal.axesnum] = {
           axisLabel     : elem.getAttribute('label') || null,
@@ -158,7 +158,7 @@ qx.Class.define('cv.plugins.diagram.AbstractDiagram', {
         axesNameIndex[qx.dom.Node.getText(elem)] = retVal.axesnum;
       }, this);
 
-      qx.bom.Selector.query("influx,rrd", xmlElement).forEach(function(elem) {
+      xmlElement.querySelectorAll("influx,rrd").forEach(function(elem) {
         var
           src = elem.tagName === 'rrd' ? qx.dom.Node.getText(elem) : elem.getAttribute('measurement'),
           steps = (elem.getAttribute("steps") || "false") === "true",

--- a/source/class/cv/plugins/diagram/AbstractDiagram.js
+++ b/source/class/cv/plugins/diagram/AbstractDiagram.js
@@ -89,7 +89,7 @@ qx.Class.define('cv.plugins.diagram.AbstractDiagram', {
      */
     parse: function (xml, path, flavour, pageType, mappings) {
       if (mappings) {
-        mappings = qx.lang.Object.mergeWith(mappings, this.getAttributeToPropertyMappings());
+        mappings = Object.assign(mappings, this.getAttributeToPropertyMappings());
       } else {
         mappings = this.getAttributeToPropertyMappings();
       }
@@ -539,7 +539,7 @@ qx.Class.define('cv.plugins.diagram.AbstractDiagram', {
           frameRate: 20,
           triggerOnDrag : false
         },
-        yaxes  : qx.lang.Object.clone(this.getContent().axes,true), // copy to prevent side effects
+        yaxes  : JSON.parse(JSON.stringify(this.getContent().axes)), // deep copy to prevent side effects
         xaxes  : [{
           mode       : "time",
           timeformat : this.getTimeformat()
@@ -573,13 +573,13 @@ qx.Class.define('cv.plugins.diagram.AbstractDiagram', {
         }
       };
       options.yaxes.forEach(function(val) {
-        qx.lang.Object.mergeWith(val, {axisLabelColour: this.getGridcolor(), color: this.getGridcolor()});
+        Object.assign(val, {axisLabelColour: this.getGridcolor(), color: this.getGridcolor()});
       }, this);
       options.xaxes.forEach(function(val) {
-        qx.lang.Object.mergeWith(val, {axisLabelColour: this.getGridcolor(), color: this.getGridcolor()});
+        Object.assign(val, {axisLabelColour: this.getGridcolor(), color: this.getGridcolor()});
       }, this);
       if (isPopup) {
-        qx.lang.Object.mergeWith(options, {
+        Object.assign(options, {
           yaxis : {
             isPopup   : true,
             zoomRange : this.getZoomYAxis() ? [null, null] : false
@@ -596,12 +596,12 @@ qx.Class.define('cv.plugins.diagram.AbstractDiagram', {
       }
 
       if (!isPopup && !this.getPreviewlabels()) {
-        qx.lang.Object.mergeWith(options, {xaxes: [ {ticks: 0, mode: options.xaxes[0].mode } ]});
+        Object.assign(options, {xaxes: [ {ticks: 0, mode: options.xaxes[0].mode } ]});
         if( 0 === options.yaxes.length ) {
           options.yaxes[0] = {};
         }
         options.yaxes.forEach(function(val) {
-          qx.lang.Object.mergeWith(val, {ticks:0, axisLabel: null});
+          Object.assign(val, {ticks:0, axisLabel: null});
         }, this);
       }
 

--- a/source/class/cv/plugins/diagram/AbstractDiagram.js
+++ b/source/class/cv/plugins/diagram/AbstractDiagram.js
@@ -277,11 +277,12 @@ qx.Class.define('cv.plugins.diagram.AbstractDiagram', {
             this.cache[ key ].xhr.dispose();
           }
           var xhr = new qx.io.request.Xhr(url);
+          var self = this;
           xhr.set({
             accept: "application/json"
           });
-          xhr.addListener("success", qx.lang.Function.curry(this._onSuccess, ts, key), this);
-          xhr.addListener("statusError", qx.lang.Function.curry(this._onStatusError, ts, key), this);
+          xhr.addListener("success", function(ev){self._onSuccess(ts, key, ev);}, this);
+          xhr.addListener("statusError", function(ev){self._onStatusError(ts, key, ev);}, this);
           this.cache[ key ].xhr = xhr;
           xhr.send();
         }

--- a/source/class/cv/plugins/diagram/AbstractDiagram.js
+++ b/source/class/cv/plugins/diagram/AbstractDiagram.js
@@ -496,7 +496,7 @@ qx.Class.define('cv.plugins.diagram.AbstractDiagram', {
       }, this);
 
       var parent = qx.dom.Element.getParentElement(popupDiagram);
-      Object.entries({height: "100%", width: "95%", margin: "auto"}).forEach(function(key,value){parent.style[key]=value;});// define parent as 100%!
+      Object.entries({height: "100%", width: "95%", margin: "auto"}).forEach(function([key,value]){parent.style[key]=value;});// define parent as 100%!
       qx.dom.Element.empty(popupDiagram);
       qx.event.Registration.addListener(popupDiagram, "tap", function(event) {
         // don't let the popup know about the click, or it will close

--- a/source/class/cv/plugins/diagram/AbstractDiagram.js
+++ b/source/class/cv/plugins/diagram/AbstractDiagram.js
@@ -496,7 +496,7 @@ qx.Class.define('cv.plugins.diagram.AbstractDiagram', {
       }, this);
 
       var parent = qx.dom.Element.getParentElement(popupDiagram);
-      qx.bom.element.Style.setStyles(parent, {height: "100%", width: "95%", margin: "auto"});// define parent as 100%!
+      Object.entries({height: "100%", width: "95%", margin: "auto"}).forEach(function(key,value){parent.style[key]=value;});// define parent as 100%!
       qx.dom.Element.empty(popupDiagram);
       qx.event.Registration.addListener(popupDiagram, "tap", function(event) {
         // don't let the popup know about the click, or it will close

--- a/source/class/cv/plugins/diagram/AbstractDiagram.js
+++ b/source/class/cv/plugins/diagram/AbstractDiagram.js
@@ -155,12 +155,12 @@ qx.Class.define('cv.plugins.diagram.AbstractDiagram', {
           }
         };
         retVal.axesnum++;
-        axesNameIndex[qx.dom.Node.getText(elem)] = retVal.axesnum;
+        axesNameIndex[elem.innerText] = retVal.axesnum;
       }, this);
 
       xmlElement.querySelectorAll("influx,rrd").forEach(function(elem) {
         var
-          src = elem.tagName === 'rrd' ? qx.dom.Node.getText(elem) : elem.getAttribute('measurement'),
+          src = elem.tagName === 'rrd' ? elem.innerText : elem.getAttribute('measurement'),
           steps = (elem.getAttribute("steps") || "false") === "true",
           fillMissing = elem.getAttribute('fillMissing');
         retVal.ts[retVal.tsnum] = {
@@ -495,9 +495,9 @@ qx.Class.define('cv.plugins.diagram.AbstractDiagram', {
         }
       }, this);
 
-      var parent = qx.dom.Element.getParentElement(popupDiagram);
+      var parent = popupDiagram.parentNode;
       Object.entries({height: "100%", width: "95%", margin: "auto"}).forEach(function(key_value){parent.style[key_value[0]]=key_value[1];});// define parent as 100%!
-      qx.dom.Element.empty(popupDiagram);
+      popupDiagram.innerHTML = '';
       qx.event.Registration.addListener(popupDiagram, "tap", function(event) {
         // don't let the popup know about the click, or it will close
         event.stopPropagation();

--- a/source/class/cv/plugins/diagram/AbstractDiagram.js
+++ b/source/class/cv/plugins/diagram/AbstractDiagram.js
@@ -96,7 +96,7 @@ qx.Class.define('cv.plugins.diagram.AbstractDiagram', {
       cv.parser.WidgetParser.parseElement(this, xml, path, flavour, pageType, mappings);
       cv.parser.WidgetParser.parseRefresh(xml, path);
 
-      var legend = qx.bom.element.Attribute.get(xml, "legend") || "both";
+      var legend = xml.getAttribute("legend") || "both";
       return cv.data.Model.getInstance().setWidgetData( path, {
         content           : this.getDiagramElements(xml),
         legendInline      : ["both", "inline"].indexOf(legend) >= 0,

--- a/source/class/cv/plugins/openhab/Openhab.js
+++ b/source/class/cv/plugins/openhab/Openhab.js
@@ -108,7 +108,7 @@ qx.Class.define("cv.plugins.openhab.Openhab", {
       if (!e.data) {
         this.error("invalid content received from SSE: ", e);
       }
-      var json = typeof e.data === 'object' ? e.data : qx.lang.Json.parse(e.data);
+      var json = typeof e.data === 'object' ? e.data : JSON.parse(e.data);
       this.__notificationRouter.dispatchMessage(json.topic || "cv.backend", json);
     }
   },

--- a/source/class/cv/plugins/openhab/Openhab.js
+++ b/source/class/cv/plugins/openhab/Openhab.js
@@ -67,7 +67,7 @@ qx.Class.define("cv.plugins.openhab.Openhab", {
     _createSettings: function() {
       // add element structure to notification-center
       var settingsRoot = qx.dom.Element.create("section", {"id": "qxsettings", "html": "<div></div>"});
-      qx.dom.Element.insertAfter(settingsRoot, qx.bom.Selector.query("#"+cv.ui.NotificationCenter.getInstance().getRootElementId()+" section.messages")[0]);
+      qx.dom.Element.insertAfter(settingsRoot, document.querySelector("#"+cv.ui.NotificationCenter.getInstance().getRootElementId()+" section.messages"));
 
       // add a settings button to trigger opening the settings
       var button = qx.dom.Element.create("div", {
@@ -80,7 +80,7 @@ qx.Class.define("cv.plugins.openhab.Openhab", {
         this.__settings.show();
       }, this);
       cv.TemplateEngine.getInstance().getCommands().add("open-settings", this._openSettings);
-      qx.dom.Element.insertBegin(button, qx.bom.Selector.query("#notification-center footer")[0]);
+      qx.dom.Element.insertBegin(button, document.querySelector("#notification-center footer"));
       qx.event.Registration.addListener(button, "tap", function() {
         this.__settings.show();
       }, this);
@@ -92,7 +92,7 @@ qx.Class.define("cv.plugins.openhab.Openhab", {
       // and that breaks the inline container sizes)
       // qx.ui.tooltip.Manager.getInstance();
 
-      this._inline = new qx.ui.root.Inline(qx.bom.Selector.query("#qxsettings > div")[0], true, false);
+      this._inline = new qx.ui.root.Inline(document.querySelector("#qxsettings > div"), true, false);
       this._inline.setLayout(new qx.ui.layout.VBox());
       this.__settings = new cv.plugins.openhab.Settings();
       this.__settings.exclude();

--- a/source/class/cv/plugins/openhab/Openhab.js
+++ b/source/class/cv/plugins/openhab/Openhab.js
@@ -108,7 +108,7 @@ qx.Class.define("cv.plugins.openhab.Openhab", {
       if (!e.data) {
         this.error("invalid content received from SSE: ", e);
       }
-      var json = qx.lang.Type.isObject(e.data) ? e.data : qx.lang.Json.parse(e.data);
+      var json = typeof e.data === 'object' ? e.data : qx.lang.Json.parse(e.data);
       this.__notificationRouter.dispatchMessage(json.topic || "cv.backend", json);
     }
   },

--- a/source/class/cv/plugins/openhab/Settings.js
+++ b/source/class/cv/plugins/openhab/Settings.js
@@ -112,14 +112,14 @@ qx.Class.define("cv.plugins.openhab.Settings", {
       // load data
       service.get();
       this._store.addListenerOnce("changeModel", function() {
-        this.__initialValues = qx.lang.Json.parse(qx.util.Serializer.toJson(this._store.getModel()));
+        this.__initialValues = JSON.parse(qx.util.Serializer.toJson(this._store.getModel()));
       }, this);
     },
 
     _saveConfig: function() {
       var data = qx.util.Serializer.toJson(this._store.getModel());
       data = data.replace(/icons_mapping_/g, "icons.mapping>");
-      data = qx.lang.Json.parse(data.replace("icons_enableMapping", "icons>enableMapping"));
+      data = JSON.parse(data.replace("icons_enableMapping", "icons>enableMapping"));
       this.__service.put(null, data);
       this.__service.addListenerOnce("putSuccess", this.close, this);
     },

--- a/source/class/cv/plugins/tr064/CallList.js
+++ b/source/class/cv/plugins/tr064/CallList.js
@@ -274,8 +274,13 @@ qx.Class.define('cv.plugins.tr064.CallList', {
           self.__calllistUri = '<fail>';
         })
         .then( function( data ) {
-          self.__calllistUri = data;
-          self.refreshCalllist('getCallListURI');
+          if( typeof data === 'string' ) {
+            self.__calllistUri = data;
+            self.refreshCalllist('getCallListURI');
+          } else {
+            console.error('Error: reading URL "' + url + ' failed with content:', data );
+            self.__calllistUri = '<fail>';
+          }
         });
     },
 

--- a/source/class/cv/report/Record.js
+++ b/source/class/cv/report/Record.js
@@ -312,7 +312,7 @@ qx.Class.define('cv.report.Record', {
 
     recordScroll: function(ev) {
       var page = ev.getTarget();
-      var path = (undefined !== page && 'getAttribute' in page) ? qx.bom.element.Attribute.get(page, "id") : undefined;
+      var path = (undefined !== page && 'getAttribute' in page) ? page.getAttribute("id") : undefined;
       var data = {
         type: ev.getType(),
         page: path,

--- a/source/class/cv/report/Record.js
+++ b/source/class/cv/report/Record.js
@@ -85,7 +85,7 @@ qx.Class.define('cv.report.Record', {
         // add scroll listeners to all pages
         qx.event.message.Bus.subscribe("setup.dom.finished", function() {
           var throttled = qx.util.Function.throttle(record.recordScroll, 250, true);
-          qx.bom.Selector.query("#pages > .page").forEach(function (page) {
+          document.querySelectorAll("#pages > .page").forEach(function (page) {
             Reg.addListener(page, "scroll", throttled, record);
           }, this);
         }, this);

--- a/source/class/cv/report/Record.js
+++ b/source/class/cv/report/Record.js
@@ -77,8 +77,8 @@ qx.Class.define('cv.report.Record', {
         // add resize listener
         Reg.addListener(window, "resize", function() {
           this.record(this.SCREEN, "resize", {
-            w: qx.bom.Viewport.getWidth(),
-            h: qx.bom.Viewport.getHeight()
+            w: document.documentElement.clientWidth,
+            h: document.documentElement.clientHeight
           });
         }, this);
 
@@ -94,8 +94,8 @@ qx.Class.define('cv.report.Record', {
 
         // save initial size
         this.record(this.SCREEN, "resize", {
-          w: qx.bom.Viewport.getWidth(),
-          h: qx.bom.Viewport.getHeight()
+          w: document.documentElement.clientWidth,
+          h: document.documentElement.clientHeight
         });
       }
     },
@@ -118,8 +118,8 @@ qx.Class.define('cv.report.Record', {
         build: Env.get("cv.build"),
         locale: qx.bom.client.Locale.getLocale(),
         cv: {},
-        width: qx.bom.Viewport.getWidth(),
-        height: qx.bom.Viewport.getHeight(),
+        width: document.documentElement.clientWidth,
+        height: document.documentElement.clientHeight,
         anchor: req.anchor,
         query: req.queryKey,
         path: req.relative

--- a/source/class/cv/report/Record.js
+++ b/source/class/cv/report/Record.js
@@ -251,7 +251,7 @@ qx.Class.define('cv.report.Record', {
       };
 
       if (data.eventClass === "PointerEvent") {
-        qx.lang.Object.mergeWith(data.native, {
+        Object.assign(data.native, {
           pointerId : nativeEvent.pointerId,
           width : nativeEvent.width,
           height : nativeEvent.height,
@@ -262,7 +262,7 @@ qx.Class.define('cv.report.Record', {
           isPrimary : nativeEvent.isPrimary
         });
       } else if (data.eventClass === "WheelEvent") {
-        qx.lang.Object.mergeWith(data.native, {
+        Object.assign(data.native, {
           deltaX : nativeEvent.deltaX,
           deltaY : nativeEvent.deltaY,
           deltaZ : nativeEvent.deltaZ,
@@ -373,11 +373,11 @@ qx.Class.define('cv.report.Record', {
 
       var d = new Date();
       var ts = d.getFullYear()+
-        qx.lang.String.pad(""+(d.getMonth()+1), 2, "0")+
-        qx.lang.String.pad(""+d.getDate(), 2, "0")+"-"+
-        qx.lang.String.pad(""+d.getHours(), 2, "0")+
-        qx.lang.String.pad(""+d.getMinutes(), 2, "0")+
-        qx.lang.String.pad(""+d.getSeconds(), 2, "0");
+        (""+(d.getMonth()+1)).padStart(2,"0")+
+        (""+d.getDate()).padStart(2,"0")+"-"+
+        (""+d.getHours()).padStart(2,"0")+
+        (""+d.getMinutes()).padStart(2,"0")+
+        (""+d.getSeconds()).padStart(2,"0");
 
       var a = window.document.createElement('a');
       a.href = window.URL.createObjectURL(new Blob([qx.lang.Json.stringify(data)], {type: 'application/json'}));

--- a/source/class/cv/report/Record.js
+++ b/source/class/cv/report/Record.js
@@ -380,7 +380,7 @@ qx.Class.define('cv.report.Record', {
         (""+d.getSeconds()).padStart(2,"0");
 
       var a = window.document.createElement('a');
-      a.href = window.URL.createObjectURL(new Blob([qx.lang.Json.stringify(data)], {type: 'application/json'}));
+      a.href = window.URL.createObjectURL(new Blob([JSON.stringify(data)], {type: 'application/json'}));
       a.download = 'CometVisu-replay-'+ts+'.json';
 
       // Append anchor to body.

--- a/source/class/cv/report/Replay.js
+++ b/source/class/cv/report/Replay.js
@@ -229,9 +229,9 @@ qx.Class.define('cv.report.Replay', {
       qx.bom.element.Style.setStyles(this.__cursor, {top: (record.d.native.clientY-10)+"px", left: (record.d.native.clientX-10)+"px"});
 
       if (/.+(down|start)/.test(record.d.native.type)) {
-        qx.bom.element.Style.set(this.__cursor, "color", record.d.native.button === 2 ? "blue" : "red");
+        this.__cursor.style["color"] = record.d.native.button === 2 ? "blue" : "red";
       } else if (/.+(up|end)/.test(record.d.native.type)) {
-        qx.bom.element.Style.set(this.__cursor, "color", "white");
+        this.__cursor.style["color"] = "white";
       }
     },
 

--- a/source/class/cv/report/Replay.js
+++ b/source/class/cv/report/Replay.js
@@ -132,7 +132,7 @@ qx.Class.define('cv.report.Replay', {
       } else if (path === "document") {
         return document;
       } else {
-        return qx.bom.Selector.query(path)[0];
+        return document.querySelector(path);
       }
     },
 
@@ -212,7 +212,7 @@ qx.Class.define('cv.report.Replay', {
     },
 
     __playScrollEvent: function(record) {
-      var elem = qx.bom.Selector.query("#"+record.d.page)[0];
+      var elem = document.querySelector("#"+record.d.page);
       elem.scrollTop = record.d.native ? record.d.native.pageY : record.d.y;
       elem.scrollLeft = record.d.native ? record.d.native.pageX : record.d.x;
     },
@@ -224,7 +224,7 @@ qx.Class.define('cv.report.Replay', {
           style: "position: absolute; transform: rotate(-40deg); font-size: 36px; z-index: 1000000"
         });
         this.__cursor.innerHTML = "&uarr;";
-        qx.dom.Element.insertEnd(this.__cursor, qx.bom.Selector.query("body")[0]);
+        qx.dom.Element.insertEnd(this.__cursor, document.querySelector("body"));
       }
       qx.bom.element.Style.setStyles(this.__cursor, {top: (record.d.native.clientY-10)+"px", left: (record.d.native.clientX-10)+"px"});
 

--- a/source/class/cv/report/Replay.js
+++ b/source/class/cv/report/Replay.js
@@ -224,7 +224,7 @@ qx.Class.define('cv.report.Replay', {
           style: "position: absolute; transform: rotate(-40deg); font-size: 36px; z-index: 1000000"
         });
         this.__cursor.innerHTML = "&uarr;";
-        qx.dom.Element.insertEnd(this.__cursor, document.querySelector("body"));
+        document.querySelector("body").appendChild(this.__cursor);
       }
       Object.entries({top: (record.d.native.clientY-10)+"px", left: (record.d.native.clientX-10)+"px"}).forEach(function(key_value){this.__cursor.style[key_value[0]]=key_value[1];});
 

--- a/source/class/cv/report/Replay.js
+++ b/source/class/cv/report/Replay.js
@@ -102,7 +102,7 @@ qx.Class.define('cv.report.Replay', {
       this.__config = qx.xml.Document.fromString(log.config);
       if (log.data.cache && qx.core.Environment.get("html.storage.local") === true) {
         localStorage.setItem(cv.Config.configSuffix + ".body", log.data.cache.body);
-        localStorage.setItem(cv.Config.configSuffix + ".data", qx.lang.Json.stringify(log.data.cache.data));
+        localStorage.setItem(cv.Config.configSuffix + ".data", JSON.stringify(log.data.cache.data));
       }
       cv.report.utils.FakeServer.init(log.xhr, this.__data.runtime.build);
     },
@@ -165,7 +165,7 @@ qx.Class.define('cv.report.Replay', {
 
         case cv.report.Record.SCREEN:
           // most browsers do not allow resizing the window
-          console.log("resize event received "+qx.lang.Json.stringify(record.d));
+          console.log("resize event received "+JSON.stringify(record.d));
           window.resizeTo(record.d.w, record.d.h);
           break;
 

--- a/source/class/cv/report/Replay.js
+++ b/source/class/cv/report/Replay.js
@@ -226,7 +226,7 @@ qx.Class.define('cv.report.Replay', {
         this.__cursor.innerHTML = "&uarr;";
         qx.dom.Element.insertEnd(this.__cursor, document.querySelector("body"));
       }
-      Object.entries({top: (record.d.native.clientY-10)+"px", left: (record.d.native.clientX-10)+"px"}).forEach(function([key,value]){this.__cursor.style[key]=value;});
+      Object.entries({top: (record.d.native.clientY-10)+"px", left: (record.d.native.clientX-10)+"px"}).forEach(function(key_value){this.__cursor.style[key_value[0]]=key_value[1];});
 
       if (/.+(down|start)/.test(record.d.native.type)) {
         this.__cursor.style.color = record.d.native.button === 2 ? "blue" : "red";

--- a/source/class/cv/report/Replay.js
+++ b/source/class/cv/report/Replay.js
@@ -226,7 +226,7 @@ qx.Class.define('cv.report.Replay', {
         this.__cursor.innerHTML = "&uarr;";
         qx.dom.Element.insertEnd(this.__cursor, document.querySelector("body"));
       }
-      qx.bom.element.Style.setStyles(this.__cursor, {top: (record.d.native.clientY-10)+"px", left: (record.d.native.clientX-10)+"px"});
+      Object.entries({top: (record.d.native.clientY-10)+"px", left: (record.d.native.clientX-10)+"px"}).forEach(function(key,value){this.__cursor.style[key]=value;});
 
       if (/.+(down|start)/.test(record.d.native.type)) {
         this.__cursor.style["color"] = record.d.native.button === 2 ? "blue" : "red";

--- a/source/class/cv/report/Replay.js
+++ b/source/class/cv/report/Replay.js
@@ -112,7 +112,7 @@ qx.Class.define('cv.report.Replay', {
      */
     start: function() {
       var runtime = Math.round((this.__end - this.__start)/1000);
-      console.log("Replay time: "+Math.floor(runtime/60)+":"+ qx.lang.String.pad(""+(runtime  % 60), 2, "0"));
+      console.log("Replay time: "+Math.floor(runtime/60)+":"+ (""+(runtime  % 60)).padStart(2,"0"));
       this.__startTime = Date.now();
 
       var delay = this.__log[0].t - this.__start;
@@ -146,7 +146,7 @@ qx.Class.define('cv.report.Replay', {
           qx.bom.Notification.getInstance().show("Replay", "Replay finished");
           cv.io.Client.stopAll();
           var runtime = Math.round((Date.now() - this.__startTime) / 1000);
-          console.log("Log replayed in: "+Math.floor(runtime/60)+":"+ qx.lang.String.pad(""+(runtime  % 60), 2, "0"));
+          console.log("Log replayed in: "+Math.floor(runtime/60)+":"+ (""+(runtime  % 60)).padStart(2,"0"));
         }, this, this.__end - this.__log[index].t);
         return;
       }

--- a/source/class/cv/report/Replay.js
+++ b/source/class/cv/report/Replay.js
@@ -223,7 +223,7 @@ qx.Class.define('cv.report.Replay', {
         this.__cursor = qx.dom.Element.create("span", {
           style: "position: absolute; transform: rotate(-40deg); font-size: 36px; z-index: 1000000"
         });
-        qx.bom.element.Attribute.set(this.__cursor, "html", "&uarr;");
+        this.__cursor.setAttribute("html", "&uarr;");
         qx.dom.Element.insertEnd(this.__cursor, qx.bom.Selector.query("body")[0]);
       }
       qx.bom.element.Style.setStyles(this.__cursor, {top: (record.d.native.clientY-10)+"px", left: (record.d.native.clientX-10)+"px"});

--- a/source/class/cv/report/Replay.js
+++ b/source/class/cv/report/Replay.js
@@ -226,7 +226,7 @@ qx.Class.define('cv.report.Replay', {
         this.__cursor.innerHTML = "&uarr;";
         qx.dom.Element.insertEnd(this.__cursor, document.querySelector("body"));
       }
-      Object.entries({top: (record.d.native.clientY-10)+"px", left: (record.d.native.clientX-10)+"px"}).forEach(function(key,value){this.__cursor.style[key]=value;});
+      Object.entries({top: (record.d.native.clientY-10)+"px", left: (record.d.native.clientX-10)+"px"}).forEach(function([key,value]){this.__cursor.style[key]=value;});
 
       if (/.+(down|start)/.test(record.d.native.type)) {
         this.__cursor.style["color"] = record.d.native.button === 2 ? "blue" : "red";

--- a/source/class/cv/report/Replay.js
+++ b/source/class/cv/report/Replay.js
@@ -223,7 +223,7 @@ qx.Class.define('cv.report.Replay', {
         this.__cursor = qx.dom.Element.create("span", {
           style: "position: absolute; transform: rotate(-40deg); font-size: 36px; z-index: 1000000"
         });
-        this.__cursor.setAttribute("html", "&uarr;");
+        this.__cursor.innerHTML = "&uarr;";
         qx.dom.Element.insertEnd(this.__cursor, qx.bom.Selector.query("body")[0]);
       }
       qx.bom.element.Style.setStyles(this.__cursor, {top: (record.d.native.clientY-10)+"px", left: (record.d.native.clientX-10)+"px"});

--- a/source/class/cv/report/Replay.js
+++ b/source/class/cv/report/Replay.js
@@ -229,9 +229,9 @@ qx.Class.define('cv.report.Replay', {
       Object.entries({top: (record.d.native.clientY-10)+"px", left: (record.d.native.clientX-10)+"px"}).forEach(function([key,value]){this.__cursor.style[key]=value;});
 
       if (/.+(down|start)/.test(record.d.native.type)) {
-        this.__cursor.style["color"] = record.d.native.button === 2 ? "blue" : "red";
+        this.__cursor.style.color = record.d.native.button === 2 ? "blue" : "red";
       } else if (/.+(up|end)/.test(record.d.native.type)) {
-        this.__cursor.style["color"] = "white";
+        this.__cursor.style.color = "white";
       }
     },
 

--- a/source/class/cv/report/utils/MXhrHook.js
+++ b/source/class/cv/report/utils/MXhrHook.js
@@ -34,7 +34,7 @@ qx.Mixin.define('cv.report.utils.MXhrHook', {
      */
     getRequestHash: function() {
       return cv.ConfigCache.hashCode(cv.report.Record.normalizeUrl(this._getConfiguredUrl()) +
-        this.getMethod()+qx.lang.Json.stringify(this.getRequestData()));
+        this.getMethod()+JSON.stringify(this.getRequestData()));
     },
 
     _onPhaseChange: function(ev) {

--- a/source/class/cv/transforms/Knx.js
+++ b/source/class/cv/transforms/Knx.js
@@ -155,7 +155,7 @@ qx.Class.define('cv.transforms.Knx', {
       '7.001': {
         name: 'DPT_Value_2_Ucount',
         encode: function (phy) {
-          var val = qx.lang.String.pad(parseInt(phy).toString(16), 4, "0");
+          var val = parseInt(phy).toString(16).padStart(4,"0");
           return '80' + val;
         },
         decode: function (hex) {
@@ -171,7 +171,7 @@ qx.Class.define('cv.transforms.Knx', {
         encode: function (phy) {
           var val = parseInt(phy);
           val = val < 0 ? val + 65536 : val;
-          return '80' + qx.lang.String.pad(val.toString(16), 4, "0");
+          return '80' + val.toString(16).padStart(4,"0");
         },
         decode: function (hex) {
           var val = parseInt(hex, 16);
@@ -231,9 +231,9 @@ qx.Class.define('cv.transforms.Knx', {
       '10.001': {
         name: 'DPT_TimeOfDay',
         encode: function (phy) {
-          var val = qx.lang.String.pad(((phy.getDay() << 5) + phy.getHours()).toString(16), 2, "0");
-          val += qx.lang.String.pad(phy.getMinutes().toString(16), 2, "0");
-          val += qx.lang.String.pad(phy.getSeconds().toString(16), 2, "0");
+          var val = ((phy.getDay() << 5) + phy.getHours()).toString(16).padStart(2,"0");
+          val += phy.getMinutes().toString(16).padStart(2,"0");
+          val += phy.getSeconds().toString(16).padStart(2,"0");
           return '80' + val;
         },
         decode: function (hex) {
@@ -268,7 +268,7 @@ qx.Class.define('cv.transforms.Knx', {
       '12.001': {
         name: 'DPT_Value_4_Ucount',
         encode: function (phy) {
-          var val = qx.lang.String.pad(parseInt(phy).toString(16), 8, "0");
+          var val = parseInt(phy).toString(16).padStart(8,"0");
           return '80' + val;
         },
         decode: function (hex) {
@@ -284,7 +284,7 @@ qx.Class.define('cv.transforms.Knx', {
         encode: function (phy) {
           var val = parseInt(phy);
           val = val < 0 ? val + 4294967296 : val;
-          return '80' + qx.lang.String.pad(val.toString(16), 8, "0");
+          return '80' + val.toString(16).padStart(8,"0");
         },
         decode: function (hex) {
           var val = parseInt(hex, 16);

--- a/source/class/cv/ui/BodyBlocker.js
+++ b/source/class/cv/ui/BodyBlocker.js
@@ -57,7 +57,7 @@ qx.Class.define('cv.ui.BodyBlocker', {
         this.__counters[topic]++;
       }
       document.querySelectorAll("#centerContainer, #navbarTop, #top, #navbarBottom").forEach(function(elem) {
-        qx.bom.element.Class.add(elem, "blurred");
+        elem.classList.add("blurred");
       });
     },
 
@@ -70,7 +70,7 @@ qx.Class.define('cv.ui.BodyBlocker', {
             if (Object.keys(this.__counters).length === 0) {
               this.base(arguments);
               document.querySelectorAll("#centerContainer, #navbarTop, #top, #navbarBottom").forEach(function (elem) {
-                qx.bom.element.Class.remove(elem, "blurred");
+                elem.classList.remove("blurred");
               });
             }
           }
@@ -80,7 +80,7 @@ qx.Class.define('cv.ui.BodyBlocker', {
         this.__counters = {};
         this.base(arguments);
         document.querySelectorAll("#centerContainer, #navbarTop, #top, #navbarBottom").forEach(function (elem) {
-          qx.bom.element.Class.remove(elem, "blurred");
+          elem.classList.remove("blurred");
         });
       }
     },

--- a/source/class/cv/ui/BodyBlocker.js
+++ b/source/class/cv/ui/BodyBlocker.js
@@ -87,7 +87,7 @@ qx.Class.define('cv.ui.BodyBlocker', {
 
     __getBody: function() {
       if (!this.__body) {
-        this.__body = qx.bom.Selector.query("body")[0];
+        this.__body = document.querySelector("body");
       }
       return this.__body;
     }

--- a/source/class/cv/ui/BodyBlocker.js
+++ b/source/class/cv/ui/BodyBlocker.js
@@ -56,7 +56,7 @@ qx.Class.define('cv.ui.BodyBlocker', {
       } else if (!unique) {
         this.__counters[topic]++;
       }
-      qx.bom.Selector.query("#centerContainer, #navbarTop, #top, #navbarBottom").forEach(function(elem) {
+      document.querySelectorAll("#centerContainer, #navbarTop, #top, #navbarBottom").forEach(function(elem) {
         qx.bom.element.Class.add(elem, "blurred");
       });
     },
@@ -69,7 +69,7 @@ qx.Class.define('cv.ui.BodyBlocker', {
             delete this.__counters[topic];
             if (Object.keys(this.__counters).length === 0) {
               this.base(arguments);
-              qx.bom.Selector.query("#centerContainer, #navbarTop, #top, #navbarBottom").forEach(function (elem) {
+              document.querySelectorAll("#centerContainer, #navbarTop, #top, #navbarBottom").forEach(function (elem) {
                 qx.bom.element.Class.remove(elem, "blurred");
               });
             }
@@ -79,7 +79,7 @@ qx.Class.define('cv.ui.BodyBlocker', {
         // not topic given unblock all
         this.__counters = {};
         this.base(arguments);
-        qx.bom.Selector.query("#centerContainer, #navbarTop, #top, #navbarBottom").forEach(function (elem) {
+        document.querySelectorAll("#centerContainer, #navbarTop, #top, #navbarBottom").forEach(function (elem) {
           qx.bom.element.Class.remove(elem, "blurred");
         });
       }

--- a/source/class/cv/ui/MHandleMessage.js
+++ b/source/class/cv/ui/MHandleMessage.js
@@ -225,7 +225,7 @@ qx.Mixin.define("cv.ui.MHandleMessage", {
       var target = ev.getTarget();
       var deleteTarget = null;
       var messageId = -1;
-      var id = qx.bom.element.Attribute.get(target, "id");
+      var id = target.getAttribute("id");
       var rootId = this.getRootElementId();
       var messageElementId = this.getMessageElementId();
       while (!id || !id.startsWith(rootId)) {
@@ -241,7 +241,7 @@ qx.Mixin.define("cv.ui.MHandleMessage", {
         if (!target) {
           break;
         }
-        id = qx.bom.element.Attribute.get(target, "id");
+        id = target.getAttribute("id");
       }
       return [messageId, deleteTarget ? "delete" : "action"];
     },

--- a/source/class/cv/ui/MHandleMessage.js
+++ b/source/class/cv/ui/MHandleMessage.js
@@ -332,7 +332,7 @@ qx.Mixin.define("cv.ui.MHandleMessage", {
         return;
       }
       Object.getOwnPropertyNames(message.actions).forEach(function(type) {
-        var typeActions = qx.lang.Type.isArray(message.actions[type]) ? message.actions[type] : [message.actions[type]];
+        var typeActions = Array.isArray(message.actions[type]) ? message.actions[type] : [message.actions[type]];
         typeActions.forEach(function(action) {
           if (!action.needsConfirmation) {
             var handler = cv.core.notifications.ActionRegistry.getActionHandler(type, action);

--- a/source/class/cv/ui/MHandleMessage.js
+++ b/source/class/cv/ui/MHandleMessage.js
@@ -229,7 +229,7 @@ qx.Mixin.define("cv.ui.MHandleMessage", {
       var rootId = this.getRootElementId();
       var messageElementId = this.getMessageElementId();
       while (!id || !id.startsWith(rootId)) {
-        if (qx.bom.element.Class.has(target, "delete")) {
+        if (target.classList.contains("delete")) {
           deleteTarget = target;
         }
         if (id && id.startsWith(messageElementId)) {

--- a/source/class/cv/ui/NotificationCenter.js
+++ b/source/class/cv/ui/NotificationCenter.js
@@ -272,7 +272,7 @@ qx.Class.define("cv.ui.NotificationCenter", {
     },
 
     __updateBadge: function() {
-      var currentContent = parseInt(this.__badge.getAttribute("html"));
+      var currentContent = parseInt(this.__badge.innerHTML);
       if (isNaN(currentContent)) {
         currentContent = 0;
       }

--- a/source/class/cv/ui/NotificationCenter.js
+++ b/source/class/cv/ui/NotificationCenter.js
@@ -235,7 +235,7 @@ qx.Class.define("cv.ui.NotificationCenter", {
           style: "visibility: hidden;",
           html: '<div class="badge"></div><header><h3>' + qx.locale.Manager.tr("Message center") + '<div class="action hide"><a href="#" onclick="cv.ui.NotificationCenter.hide()">X</a></div></h3></header><section class="messages"></section><footer><div class="action clear" onclick="cv.ui.NotificationCenter.clear()">' + qx.locale.Manager.tr("Delete all") + '<div></div></footer>'
         });
-        qx.dom.Element.insertEnd(elem, body);
+        body.appendChild(elem);
 
         // create the template
         var templateCode = '<div class="message {{severity}}{{#actions}} selectable{{/actions}}" title="{{tooltip}}" id="'+this.getMessageElementId()+'{{ id }}">';
@@ -249,7 +249,7 @@ qx.Class.define("cv.ui.NotificationCenter", {
           type: "text/template",
           html: templateCode
         });
-        qx.dom.Element.insertEnd(template, body);
+        body.appendChild(template);
       }
 
       this.__messagesContainer = elem.querySelector("section.messages");

--- a/source/class/cv/ui/NotificationCenter.js
+++ b/source/class/cv/ui/NotificationCenter.js
@@ -195,10 +195,8 @@ qx.Class.define("cv.ui.NotificationCenter", {
     _onResize: function() {
       var height = qx.bom.Viewport.getHeight();
       if (this.__element) {
-        qx.bom.element.Style.setStyles(this.__element, {
-          left: qx.bom.Viewport.getWidth() + "px",
-          height: height + "px"
-        }, false);
+        this.__element.style.left = qx.bom.Viewport.getWidth() + "px";
+        this.__element.style.height = height + "px";
       }
 
       if (this.__messagesContainer) {
@@ -206,9 +204,7 @@ qx.Class.define("cv.ui.NotificationCenter", {
         var messageBoxHeight = height -
           qx.bom.element.Dimension.getHeight(this.__element.querySelector(":scope > header")) -
           qx.bom.element.Dimension.getHeight(this.__element.querySelector(":scope > footer"));
-        qx.bom.element.Style.setStyles(this.__messagesContainer, {
-          height: messageBoxHeight + "px"
-        }, false);
+        this.__messagesContainer.style.height = messageBoxHeight + "px";
       }
     },
 
@@ -283,7 +279,7 @@ qx.Class.define("cv.ui.NotificationCenter", {
         if (this.getMessages().getLength() === 0) {
           this.hide();
         } else {
-          qx.bom.element.Style.reset(this.__element, "visibility");
+          this.__element.style.visibility = '';
           this._onSeverityChange();
         }
       }.bind(this);
@@ -328,7 +324,7 @@ qx.Class.define("cv.ui.NotificationCenter", {
       if (!this.__visible) {
         this.__visible = true;
         this.__blocker.block();
-        qx.bom.element.Style.reset(this.__element, "visibility");
+        this.__element.style.visibility = '';
         qx.event.Registration.addListener(this.__blocker.getBlockerElement(), "tap", this.hide, this);
         if (cv.ui.NotificationCenter.SLIDE.duration > 0) {
           var anim = qx.bom.element.Animation.animate(this.__element, cv.ui.NotificationCenter.SLIDE);

--- a/source/class/cv/ui/NotificationCenter.js
+++ b/source/class/cv/ui/NotificationCenter.js
@@ -204,8 +204,8 @@ qx.Class.define("cv.ui.NotificationCenter", {
       if (this.__messagesContainer) {
         // get header+footer heights
         var messageBoxHeight = height -
-          qx.bom.element.Dimension.getHeight(qx.bom.Selector.query("> header", this.__element)[0]) -
-          qx.bom.element.Dimension.getHeight(qx.bom.Selector.query("> footer", this.__element)[0]);
+          qx.bom.element.Dimension.getHeight(this.__element.querySelector(":scope > header")) -
+          qx.bom.element.Dimension.getHeight(this.__element.querySelector(":scope > footer"));
         qx.bom.element.Style.setStyles(this.__messagesContainer, {
           height: messageBoxHeight + "px"
         }, false);
@@ -217,7 +217,7 @@ qx.Class.define("cv.ui.NotificationCenter", {
      * @private
      */
     _init: function() {
-      var body = qx.bom.Selector.query("body")[0];
+      var body = document.querySelector("body");
       
       this.__blocker = cv.ui.BodyBlocker.getInstance();
 
@@ -227,7 +227,7 @@ qx.Class.define("cv.ui.NotificationCenter", {
       });
 
       // check if the element is already there (might have been cached)
-      var elem = this.__element = qx.bom.Selector.query(this.getRootElementId())[0];
+      var elem = this.__element = document.querySelector(this.getRootElementId());
 
       if (!elem) {
         // create new element
@@ -253,8 +253,8 @@ qx.Class.define("cv.ui.NotificationCenter", {
         qx.dom.Element.insertEnd(template, body);
       }
 
-      this.__messagesContainer = qx.bom.Selector.query("section.messages", elem)[0];
-      this.__badge = qx.bom.Selector.query(".badge", elem)[0];
+      this.__messagesContainer = elem.querySelector("section.messages");
+      this.__badge = elem.querySelector(".badge");
       qx.event.Registration.addListener(this.__badge, "tap", this.toggleVisibility, this);
 
       // add HTML template for messages to header

--- a/source/class/cv/ui/NotificationCenter.js
+++ b/source/class/cv/ui/NotificationCenter.js
@@ -272,7 +272,7 @@ qx.Class.define("cv.ui.NotificationCenter", {
     },
 
     __updateBadge: function() {
-      var currentContent = parseInt(qx.bom.element.Attribute.get(this.__badge, "html"));
+      var currentContent = parseInt(this.__badge.getAttribute("html"));
       if (isNaN(currentContent)) {
         currentContent = 0;
       }

--- a/source/class/cv/ui/NotificationCenter.js
+++ b/source/class/cv/ui/NotificationCenter.js
@@ -332,10 +332,10 @@ qx.Class.define("cv.ui.NotificationCenter", {
         if (cv.ui.NotificationCenter.SLIDE.duration > 0) {
           var anim = qx.bom.element.Animation.animate(this.__element, cv.ui.NotificationCenter.SLIDE);
           anim.on("end", function () {
-            qx.bom.element.Transform.translate(this.__element, "-300px");
+            this.__element.style.transform = 'translate(-300px)';
           }, this);
         } else {
-          qx.bom.element.Transform.translate(this.__element, "-300px");
+          this.__element.style.transform = 'translate(-300px)';
         }
       }
     },
@@ -361,11 +361,11 @@ qx.Class.define("cv.ui.NotificationCenter", {
         if (cv.ui.NotificationCenter.SLIDE.duration > 0) {
           var anim = qx.bom.element.Animation.animateReverse(this.__element, cv.ui.NotificationCenter.SLIDE);
           anim.on("end", function () {
-            qx.bom.element.Transform.translate(this.__element, "-0px");
+            this.__element.style.transform = 'translate(-0px)';
             this.__blocker.unblock();
           }, this);
         } else {
-          qx.bom.element.Transform.translate(this.__element, "-0px");
+          this.__element.style.transform = 'translate(-0px)';
           this.__blocker.unblock();
         }
       }

--- a/source/class/cv/ui/NotificationCenter.js
+++ b/source/class/cv/ui/NotificationCenter.js
@@ -186,9 +186,9 @@ qx.Class.define("cv.ui.NotificationCenter", {
 
     disableBadge: function(value) {
       if (value) {
-        qx.bom.element.Class.add(this.__badge, "hidden");
+        this.__badge.classList.add("hidden");
       } else {
-        qx.bom.element.Class.remove(this.__badge, "hidden");
+        this.__badge.classList.remove("hidden");
       }
     },
 
@@ -309,8 +309,8 @@ qx.Class.define("cv.ui.NotificationCenter", {
     _onSeverityChange: function() {
       var severity = this.getGlobalSeverity();
       if (this.__badge) {
-        qx.bom.element.Class.removeClasses(this.__badge, this._severities);
-        qx.bom.element.Class.add(this.__badge, severity);
+        this.__badge.classList.remove.apply( this.__badge.classList, this._severities );
+        this.__badge.classList.add(severity);
       }
 
       if (this.__favico) {

--- a/source/class/cv/ui/NotificationCenter.js
+++ b/source/class/cv/ui/NotificationCenter.js
@@ -298,9 +298,9 @@ qx.Class.define("cv.ui.NotificationCenter", {
         qx.bom.element.Animation.animate(this.__badge, cv.ui.NotificationCenter.BLINK);
       }
       if (messages) {
-        qx.bom.element.Attribute.set(this.__badge, "html", ""+messages);
+        this.__badge.setAttribute("html", ""+messages);
       } else{
-        qx.bom.element.Attribute.set(this.__badge, "html", "");
+        this.__badge.setAttribute("html", "");
       }
 
 

--- a/source/class/cv/ui/NotificationCenter.js
+++ b/source/class/cv/ui/NotificationCenter.js
@@ -193,9 +193,9 @@ qx.Class.define("cv.ui.NotificationCenter", {
     },
 
     _onResize: function() {
-      var height = qx.bom.Viewport.getHeight();
+      var height = document.documentElement.clientHeight;
       if (this.__element) {
-        this.__element.style.left = qx.bom.Viewport.getWidth() + "px";
+        this.__element.style.left = document.documentElement.clientWidth + "px";
         this.__element.style.height = height + "px";
       }
 

--- a/source/class/cv/ui/NotificationCenter.js
+++ b/source/class/cv/ui/NotificationCenter.js
@@ -272,7 +272,7 @@ qx.Class.define("cv.ui.NotificationCenter", {
     },
 
     __updateBadge: function() {
-      var currentContent = parseInt(this.__badge.innerHTML);
+      var currentContent = parseInt(this.__badge.getAttribute("html"));
       if (isNaN(currentContent)) {
         currentContent = 0;
       }

--- a/source/class/cv/ui/NotificationCenter.js
+++ b/source/class/cv/ui/NotificationCenter.js
@@ -201,9 +201,12 @@ qx.Class.define("cv.ui.NotificationCenter", {
 
       if (this.__messagesContainer) {
         // get header+footer heights
-        var messageBoxHeight = height -
-          qx.bom.element.Dimension.getHeight(this.__element.querySelector(":scope > header")) -
-          qx.bom.element.Dimension.getHeight(this.__element.querySelector(":scope > footer"));
+        var
+          headerRect = this.__element.querySelector(":scope > header").getBoundingClientRect(),
+          footerRect = this.__element.querySelector(":scope > footer").getBoundingClientRect(),
+          messageBoxHeight = height -
+            Math.round(headerRect.bottom - headerRect.top) -
+            Math.round(footerRect.bottom - footerRect.top);
         this.__messagesContainer.style.height = messageBoxHeight + "px";
       }
     },

--- a/source/class/cv/ui/NotificationCenter.js
+++ b/source/class/cv/ui/NotificationCenter.js
@@ -298,9 +298,9 @@ qx.Class.define("cv.ui.NotificationCenter", {
         qx.bom.element.Animation.animate(this.__badge, cv.ui.NotificationCenter.BLINK);
       }
       if (messages) {
-        this.__badge.setAttribute("html", ""+messages);
+        this.__badge.innerHTML = ""+messages;
       } else{
-        this.__badge.setAttribute("html", "");
+        this.__badge.innerHTML = "";
       }
 
 

--- a/source/class/cv/ui/PageHandler.js
+++ b/source/class/cv/ui/PageHandler.js
@@ -183,7 +183,7 @@ qx.Class.define('cv.ui.PageHandler', {
      * @param oldPageWidget {cv.ui.structure.pure.Page}
      */
     __onLeavePage: function(oldPageWidget) {
-      qx.bom.element.Class.removeClasses(oldPageWidget.getDomElement(), ['pageActive', 'activePage']);
+      oldPageWidget.getDomElement().classList.remove('pageActive', 'activePage');
       qx.bom.element.Style.set(oldPageWidget.getDomElement(), "overflow", null);
       qx.event.message.Bus.dispatchByName("path." + oldPageWidget.getPath() + ".afterPageChange", oldPageWidget.getPath());
       qx.event.message.Bus.dispatchByName("path.pageLeft", oldPageWidget.getPath());
@@ -199,7 +199,7 @@ qx.Class.define('cv.ui.PageHandler', {
     __onEnterPage: function(pageWidget, oldPos, updateVisibility) {
       var page = pageWidget.getDomElement();
       var target = pageWidget.getPath();
-      qx.bom.element.Class.addClasses(page, ['pageActive', 'activePage']);// show new page
+      page.classList.add('pageActive', 'activePage');// show new page
       if (updateVisibility === true) {
         // set it to visible
         pageWidget.setVisible(true);

--- a/source/class/cv/ui/PageHandler.js
+++ b/source/class/cv/ui/PageHandler.js
@@ -123,11 +123,11 @@ qx.Class.define('cv.ui.PageHandler', {
       } else {
         if (oldPageWidget) {
           var outAnim = qx.bom.element.Animation.animate(oldPageWidget.getDomElement(), animationConfig.out, speed);
-          qx.bom.element.Style.set(oldPageWidget.getDomElement(), "overflowY", "hidden");
+          oldPageWidget.getDomElement().style["overflowY"] = "hidden";
           outAnim.addListenerOnce("end", qx.lang.Function.curry(this.__onLeavePage, oldPageWidget), this);
         }
-        var oldPos = qx.bom.element.Style.get(pageWidget.getDomElement(), "position");
-        qx.bom.element.Style.set(pageWidget.getDomElement(), "position", "absolute");
+        var oldPos = window.getComputedStyle(pageWidget.getDomElement())["position"];
+        pageWidget.getDomElement().style["position"] = "absolute";
         qx.bom.AnimationFrame.request(function() {
           var animation = qx.bom.element.Animation.animate(pageWidget.getDomElement(), animationConfig["in"], speed);
           animation.addListenerOnce("end", qx.lang.Function.curry(this.__onEnterPage, pageWidget, oldPos), this);
@@ -184,7 +184,7 @@ qx.Class.define('cv.ui.PageHandler', {
      */
     __onLeavePage: function(oldPageWidget) {
       oldPageWidget.getDomElement().classList.remove('pageActive', 'activePage');
-      qx.bom.element.Style.set(oldPageWidget.getDomElement(), "overflow", null);
+      oldPageWidget.getDomElement().style["overflow"] = null;
       qx.event.message.Bus.dispatchByName("path." + oldPageWidget.getPath() + ".afterPageChange", oldPageWidget.getPath());
       qx.event.message.Bus.dispatchByName("path.pageLeft", oldPageWidget.getPath());
       oldPageWidget.setVisible(false);

--- a/source/class/cv/ui/PageHandler.js
+++ b/source/class/cv/ui/PageHandler.js
@@ -110,7 +110,7 @@ qx.Class.define('cv.ui.PageHandler', {
         Object.entries({
           "display": "block",
           "overflow": "hidden"
-        }).forEach(function([key,value]){pageWidget.getDomElement().style[key]=value;});
+        }).forEach(function(key_value){pageWidget.getDomElement().style[key_value[0]]=key_value[1];});
         // set it to visible
         pageWidget.setVisible(true);
       }
@@ -215,7 +215,7 @@ qx.Class.define('cv.ui.PageHandler', {
       if (oldPos) {
         styles.position = oldPos;
       }
-      Object.entries(styles).forEach(function([key,value]){page.style[key]=value;});
+      Object.entries(styles).forEach(function(key_value){page.style[key_value[0]]=key_value[1];});
     }
   }
 });

--- a/source/class/cv/ui/PageHandler.js
+++ b/source/class/cv/ui/PageHandler.js
@@ -107,10 +107,10 @@ qx.Class.define('cv.ui.PageHandler', {
         animationConfig = this.__getAnimationConfig(direction);
 
         // show the new page (because animations do not work on hidden elements) + hide scrollbar
-        qx.bom.element.Style.setStyles(pageWidget.getDomElement(), {
+        Object.entries({
           "display": "block",
           "overflow": "hidden"
-        });
+        }).forEach(function(key,value){pageWidget.getDomElement().style[key]=value;});
         // set it to visible
         pageWidget.setVisible(true);
       }
@@ -215,7 +215,7 @@ qx.Class.define('cv.ui.PageHandler', {
       if (oldPos) {
         styles.position = oldPos;
       }
-      qx.bom.element.Style.setStyles(page, styles);
+      Object.entries(styles).forEach(function(key,value){page.style[key]=value;});
     }
   }
 });

--- a/source/class/cv/ui/PageHandler.js
+++ b/source/class/cv/ui/PageHandler.js
@@ -121,16 +121,17 @@ qx.Class.define('cv.ui.PageHandler', {
         }
         this.__onEnterPage(pageWidget, 0, true);
       } else {
+        var self = this;
         if (oldPageWidget) {
           var outAnim = qx.bom.element.Animation.animate(oldPageWidget.getDomElement(), animationConfig.out, speed);
           oldPageWidget.getDomElement().style["overflow-y"] = "hidden";
-          outAnim.addListenerOnce("end", qx.lang.Function.curry(this.__onLeavePage, oldPageWidget), this);
+          outAnim.addListenerOnce("end", function(){self.__onLeavePage(oldPageWidget);}, this);
         }
         var oldPos = window.getComputedStyle(pageWidget.getDomElement()).position;
         pageWidget.getDomElement().style.position = "absolute";
         qx.bom.AnimationFrame.request(function() {
           var animation = qx.bom.element.Animation.animate(pageWidget.getDomElement(), animationConfig["in"], speed);
-          animation.addListenerOnce("end", qx.lang.Function.curry(this.__onEnterPage, pageWidget, oldPos), this);
+          animation.addListenerOnce("end", function(updateVisibility){self.__onEnterPage(pageWidget,oldPos,updateVisibility);}, this);
         }, this);
       }
     },

--- a/source/class/cv/ui/PageHandler.js
+++ b/source/class/cv/ui/PageHandler.js
@@ -110,7 +110,7 @@ qx.Class.define('cv.ui.PageHandler', {
         Object.entries({
           "display": "block",
           "overflow": "hidden"
-        }).forEach(function(key,value){pageWidget.getDomElement().style[key]=value;});
+        }).forEach(function([key,value]){pageWidget.getDomElement().style[key]=value;});
         // set it to visible
         pageWidget.setVisible(true);
       }

--- a/source/class/cv/ui/PageHandler.js
+++ b/source/class/cv/ui/PageHandler.js
@@ -123,11 +123,11 @@ qx.Class.define('cv.ui.PageHandler', {
       } else {
         if (oldPageWidget) {
           var outAnim = qx.bom.element.Animation.animate(oldPageWidget.getDomElement(), animationConfig.out, speed);
-          oldPageWidget.getDomElement().style["overflowY"] = "hidden";
+          oldPageWidget.getDomElement().style["overflow-y"] = "hidden";
           outAnim.addListenerOnce("end", qx.lang.Function.curry(this.__onLeavePage, oldPageWidget), this);
         }
-        var oldPos = window.getComputedStyle(pageWidget.getDomElement())["position"];
-        pageWidget.getDomElement().style["position"] = "absolute";
+        var oldPos = window.getComputedStyle(pageWidget.getDomElement()).position;
+        pageWidget.getDomElement().style.position = "absolute";
         qx.bom.AnimationFrame.request(function() {
           var animation = qx.bom.element.Animation.animate(pageWidget.getDomElement(), animationConfig["in"], speed);
           animation.addListenerOnce("end", qx.lang.Function.curry(this.__onEnterPage, pageWidget, oldPos), this);
@@ -184,7 +184,7 @@ qx.Class.define('cv.ui.PageHandler', {
      */
     __onLeavePage: function(oldPageWidget) {
       oldPageWidget.getDomElement().classList.remove('pageActive', 'activePage');
-      oldPageWidget.getDomElement().style["overflow"] = null;
+      oldPageWidget.getDomElement().style.overflow = null;
       qx.event.message.Bus.dispatchByName("path." + oldPageWidget.getPath() + ".afterPageChange", oldPageWidget.getPath());
       qx.event.message.Bus.dispatchByName("path.pageLeft", oldPageWidget.getPath());
       oldPageWidget.setVisible(false);
@@ -215,7 +215,7 @@ qx.Class.define('cv.ui.PageHandler', {
       if (oldPos) {
         styles.position = oldPos;
       }
-      Object.entries(styles).forEach(function(key,value){page.style[key]=value;});
+      Object.entries(styles).forEach(function([key,value]){page.style[key]=value;});
     }
   }
 });

--- a/source/class/cv/ui/PagePartsHandler.js
+++ b/source/class/cv/ui/PagePartsHandler.js
@@ -267,7 +267,7 @@ qx.Class.define('cv.ui.PagePartsHandler', {
      */
     initializeNavbars: function (page_id) {
       this.removeInactiveNavbars(page_id);
-      var tree = document.querySelectorAll('#id_');
+      var tree = Array.from( document.querySelectorAll('#id_') );
       if (page_id !== "id_") {
         var parts = page_id.split("_");
         parts.pop();

--- a/source/class/cv/ui/PagePartsHandler.js
+++ b/source/class/cv/ui/PagePartsHandler.js
@@ -94,7 +94,7 @@ qx.Class.define('cv.ui.PagePartsHandler', {
           Object.entries({
             width: cssSize,
             'margin-right': '-' + cssSize
-          }).forEach(function([key,value]){document.querySelector('#navbarRight').style[key]=value;});
+          }).forEach(function(key_value){document.querySelector('#navbarRight').style[key_value[0]]=key_value[1];});
           cv.ui.layout.ResizeHandler.invalidateNavbar();
           break;
       }

--- a/source/class/cv/ui/PagePartsHandler.js
+++ b/source/class/cv/ui/PagePartsHandler.js
@@ -91,10 +91,10 @@ qx.Class.define('cv.ui.PagePartsHandler', {
 
         case 'right':
           document.querySelector('#centerContainer').style["padding-right"] = cssSize;
-          qx.bom.element.Style.setStyles(document.querySelector('#navbarRight'), {
+          Object.entries({
             width: cssSize,
             'margin-right': '-' + cssSize
-          });
+          }).forEach(function(key,value){document.querySelector('#navbarRight').style[key]=value;});
           cv.ui.layout.ResizeHandler.invalidateNavbar();
           break;
       }
@@ -240,9 +240,9 @@ qx.Class.define('cv.ui.PagePartsHandler', {
           }
           break;
       }
-      qx.bom.element.Style.setStyles(navbar, initCss);
+      Object.entries(initCss).forEach(function(key,value){navbar.style[key]=value;});
       if (speed === 0) {
-        qx.bom.element.Style.setStyles(navbar, targetCss);
+        Object.entries(targetCss).forEach(function(key,value){navbar.style[key]=value;});
         onAnimationEnd();
       } else {
         var spec = {

--- a/source/class/cv/ui/PagePartsHandler.js
+++ b/source/class/cv/ui/PagePartsHandler.js
@@ -85,7 +85,7 @@ qx.Class.define('cv.ui.PagePartsHandler', {
       var cssSize = size + (isFinite(size) ? 'px' : '');
       switch (position) {
         case 'left':
-          document.querySelector('#navbarLeft').style["width"] = cssSize;
+          document.querySelector('#navbarLeft').style.width = cssSize;
           cv.ui.layout.ResizeHandler.invalidateNavbar();
           break;
 
@@ -149,24 +149,24 @@ qx.Class.define('cv.ui.PagePartsHandler', {
       if (showtopnavigation) {
         if (topDisplay === "none") {
           document.querySelectorAll('#top, #top > *').forEach(function(elem) {
-            elem.style["display"] = "block";
+            elem.style.display = "block";
           }, this);
           this.removeInactiveNavbars(page.getPath());
         }
       } else {
         if (topDisplay !== "none") {
-          document.querySelector("#top").style["display"] = "none";
+          document.querySelector("#top").style.display = "none";
           this.removeInactiveNavbars(page.getPath());
         }
       }
       if (showfooter) {
         if (bottomDisplay === "none") {
-          document.querySelector("#bottom").style["display"] = "block";
+          document.querySelector("#bottom").style.display = "block";
           this.removeInactiveNavbars(page.getPath());
         }
       } else {
         if (bottomDisplay !== "none") {
-          document.querySelector("#bottom").style["display"] = "none";
+          document.querySelector("#bottom").style.display = "none";
           this.removeInactiveNavbars(page.getPath());
         }
       }
@@ -225,7 +225,7 @@ qx.Class.define('cv.ui.PagePartsHandler', {
           break;
         case "out":
           onAnimationEnd = function () {
-            navbar.style["display"] = "none";
+            navbar.style.display = "none";
             cv.ui.layout.ResizeHandler.invalidateNavbar();
           };
           switch (position) {

--- a/source/class/cv/ui/PagePartsHandler.js
+++ b/source/class/cv/ui/PagePartsHandler.js
@@ -108,7 +108,7 @@ qx.Class.define('cv.ui.PagePartsHandler', {
       if (typeof page === "string") {
         page = cv.ui.structure.WidgetFactory.getInstanceById(page);
       } else if (page.attributes ) {
-        page = cv.ui.structure.WidgetFactory.getInstanceById(qx.bom.element.Attribute.get(page, 'id'));
+        page = cv.ui.structure.WidgetFactory.getInstanceById(page.getAttribute('id'));
       }
 
       if (!page) {
@@ -284,7 +284,7 @@ qx.Class.define('cv.ui.PagePartsHandler', {
       }
       var level = 1;
       tree.forEach(function (elem) {
-        var id = qx.bom.element.Attribute.get(elem, 'id');
+        var id = elem.getAttribute('id');
         var topNav = qx.bom.Selector.query('#' + id + 'top_navbar')[0];
         var topData = cv.data.Model.getInstance().getWidgetData(id + 'top_navbar');
         var rightNav = qx.bom.Selector.query('#' + id + 'right_navbar')[0];
@@ -330,7 +330,7 @@ qx.Class.define('cv.ui.PagePartsHandler', {
     removeInactiveNavbars: function (page_id) {
       // remove all navbars that do not belong to this page
       qx.bom.Selector.query('.navbar.navbarActive').forEach(function (elem) {
-        var navBarPath = qx.bom.element.Attribute.get(elem, 'id').split('_');
+        var navBarPath = elem.getAttribute('id').split('_');
         // skip last 2 elements e.g. '_top_navbar'
         navBarPath = navBarPath.slice(0, navBarPath.length - 2).join('_');
         var expr = new RegExp("^" + navBarPath + ".*", "i");

--- a/source/class/cv/ui/PagePartsHandler.js
+++ b/source/class/cv/ui/PagePartsHandler.js
@@ -138,7 +138,8 @@ qx.Class.define('cv.ui.PagePartsHandler', {
       if (page) {
         if (!page.isInitialized()) {
           // page is not ready, defer this update
-          page.addListenerOnce("changeInitialized", qx.lang.Function.curry(this.updatePageParts, page, speed), this);
+          var self = this;
+          page.addListenerOnce("changeInitialized", function(){self.updatePageParts(page,speed);}, this);
           return;
         }
         showtopnavigation = page.getShowTopNavigation();

--- a/source/class/cv/ui/PagePartsHandler.js
+++ b/source/class/cv/ui/PagePartsHandler.js
@@ -148,7 +148,7 @@ qx.Class.define('cv.ui.PagePartsHandler', {
       var bottomDisplay = qx.bom.element.Style.get(document.querySelector("#bottom"), "display");
       if (showtopnavigation) {
         if (topDisplay === "none") {
-          qx.bom.Selector.query('#top, #top > *').forEach(function(elem) {
+          document.querySelectorAll('#top, #top > *').forEach(function(elem) {
             qx.bom.element.Style.set(elem, "display", "block");
           }, this);
           this.removeInactiveNavbars(page.getPath());
@@ -267,7 +267,7 @@ qx.Class.define('cv.ui.PagePartsHandler', {
      */
     initializeNavbars: function (page_id) {
       this.removeInactiveNavbars(page_id);
-      var tree = qx.bom.Selector.query('#id_');
+      var tree = document.querySelectorAll('#id_');
       if (page_id !== "id_") {
         var parts = page_id.split("_");
         parts.pop();
@@ -275,7 +275,7 @@ qx.Class.define('cv.ui.PagePartsHandler', {
         for (var i = 0; i < parts.length; i++) {
           var subPath = parts.slice(0, i + 1).join('_');
           if (subPath) {
-            var item = qx.bom.Selector.query('#id' + subPath + "_.page");
+            var item = document.querySelectorAll('#id' + subPath + "_.page");
             if (item.length === 1) {
               tree.push(item[0]);
             }
@@ -329,7 +329,7 @@ qx.Class.define('cv.ui.PagePartsHandler', {
 
     removeInactiveNavbars: function (page_id) {
       // remove all navbars that do not belong to this page
-      qx.bom.Selector.query('.navbar.navbarActive').forEach(function (elem) {
+      document.querySelectorAll('.navbar.navbarActive').forEach(function (elem) {
         var navBarPath = elem.getAttribute('id').split('_');
         // skip last 2 elements e.g. '_top_navbar'
         navBarPath = navBarPath.slice(0, navBarPath.length - 2).join('_');

--- a/source/class/cv/ui/PagePartsHandler.js
+++ b/source/class/cv/ui/PagePartsHandler.js
@@ -85,12 +85,12 @@ qx.Class.define('cv.ui.PagePartsHandler', {
       var cssSize = size + (isFinite(size) ? 'px' : '');
       switch (position) {
         case 'left':
-          qx.bom.element.Style.set(document.querySelector('#navbarLeft'), "width", cssSize);
+          document.querySelector('#navbarLeft').style["width"] = cssSize;
           cv.ui.layout.ResizeHandler.invalidateNavbar();
           break;
 
         case 'right':
-          qx.bom.element.Style.set(document.querySelector('#centerContainer'), "padding-right", cssSize);
+          document.querySelector('#centerContainer').style["padding-right"] = cssSize;
           qx.bom.element.Style.setStyles(document.querySelector('#navbarRight'), {
             width: cssSize,
             'margin-right': '-' + cssSize
@@ -144,29 +144,29 @@ qx.Class.define('cv.ui.PagePartsHandler', {
         showtopnavigation = page.getShowTopNavigation();
         showfooter = page.getShowFooter();
       }
-      var topDisplay = qx.bom.element.Style.get(document.querySelector("#top"), "display");
-      var bottomDisplay = qx.bom.element.Style.get(document.querySelector("#bottom"), "display");
+      var topDisplay = window.getComputedStyle(document.querySelector("#top"))["display"];
+      var bottomDisplay = window.getComputedStyle(document.querySelector("#bottom"))["display"];
       if (showtopnavigation) {
         if (topDisplay === "none") {
           document.querySelectorAll('#top, #top > *').forEach(function(elem) {
-            qx.bom.element.Style.set(elem, "display", "block");
+            elem.style["display"] = "block";
           }, this);
           this.removeInactiveNavbars(page.getPath());
         }
       } else {
         if (topDisplay !== "none") {
-          qx.bom.element.Style.set(document.querySelector("#top"), "display", "none");
+          document.querySelector("#top").style["display"] = "none";
           this.removeInactiveNavbars(page.getPath());
         }
       }
       if (showfooter) {
         if (bottomDisplay === "none") {
-          qx.bom.element.Style.set(document.querySelector("#bottom"), "display", "block");
+          document.querySelector("#bottom").style["display"] = "block";
           this.removeInactiveNavbars(page.getPath());
         }
       } else {
         if (bottomDisplay !== "none") {
-          qx.bom.element.Style.set(document.querySelector("#bottom"), "display", "none");
+          document.querySelector("#bottom").style["display"] = "none";
           this.removeInactiveNavbars(page.getPath());
         }
       }
@@ -174,7 +174,7 @@ qx.Class.define('cv.ui.PagePartsHandler', {
         var
           key = value.toLowerCase(),
           navbar = document.querySelector('#navbar' + value),
-          display = qx.bom.element.Style.get(navbar, "display"),
+          display = window.getComputedStyle(navbar)["display"],
           isLoading = navbar.classList.contains('loading');
         if (shownavbar[key] === true) {
           if (display === "none" || isLoading) {
@@ -208,7 +208,7 @@ qx.Class.define('cv.ui.PagePartsHandler', {
       };
       switch (direction) {
         case "in":
-          if (qx.bom.element.Style.get(navbar, "display") === 'none') {
+          if (window.getComputedStyle(navbar)["display"] === 'none') {
             initCss.display = 'block';
           }
           targetCss[key] = 0;
@@ -225,7 +225,7 @@ qx.Class.define('cv.ui.PagePartsHandler', {
           break;
         case "out":
           onAnimationEnd = function () {
-            qx.bom.element.Style.set(navbar, "display", "none");
+            navbar.style["display"] = "none";
             cv.ui.layout.ResizeHandler.invalidateNavbar();
           };
           switch (position) {

--- a/source/class/cv/ui/PagePartsHandler.js
+++ b/source/class/cv/ui/PagePartsHandler.js
@@ -58,20 +58,20 @@ qx.Class.define('cv.ui.PagePartsHandler', {
     updateTopNavigation: function (path) {
       path = path.split('_'); path.pop();
       var id = "id_"; //path[0];
-      var pageTitle = qx.bom.Selector.query("#"+id+" h1")[0].textContent;
+      var pageTitle = document.querySelector("#"+id+" h1").textContent;
       var nav = '<a href="javascript:cv.TemplateEngine.getInstance().scrollToPage(\'' + id + '\')" id="breadcrump_pagejump_'+id+'">' +
         pageTitle + '</a>';
       for (var i = 1; i < path.length; i++) { // element 0 is id_ (JNK)
         id += path[i] + '_';
-        var pageElem = qx.bom.Selector.query("#"+id)[0];
+        var pageElem = document.querySelector("#"+id);
         if (pageElem && qx.bom.element.Class.has(pageElem, "page")) { // FIXME is this still needed?!?
-          pageTitle = qx.bom.Selector.query("#"+id+" h1")[0].textContent;
+          pageTitle = document.querySelector("#"+id+" h1").textContent;
           nav += '<span> &#x25ba; </span>' +
             '<a href="javascript:cv.TemplateEngine.getInstance().scrollToPage(\'' + id + '\')" id="breadcrump_pagejump_'+id+'">' +
             pageTitle + '</a>';
         }
       }
-      qx.bom.Selector.query(".nav_path")[0].innerHTML = nav;
+      document.querySelector(".nav_path").innerHTML = nav;
       // cv.TemplateEngine.getInstance().handleResize(); - TODO CM160528: why? This shouldn't have
       //                             any effect on the page size => commented out
     },
@@ -85,13 +85,13 @@ qx.Class.define('cv.ui.PagePartsHandler', {
       var cssSize = size + (isFinite(size) ? 'px' : '');
       switch (position) {
         case 'left':
-          qx.bom.element.Style.set(qx.bom.Selector.query('#navbarLeft')[0], "width", cssSize);
+          qx.bom.element.Style.set(document.querySelector('#navbarLeft'), "width", cssSize);
           cv.ui.layout.ResizeHandler.invalidateNavbar();
           break;
 
         case 'right':
-          qx.bom.element.Style.set(qx.bom.Selector.query('#centerContainer')[0], "padding-right", cssSize);
-          qx.bom.element.Style.setStyles(qx.bom.Selector.query('#navbarRight')[0], {
+          qx.bom.element.Style.set(document.querySelector('#centerContainer'), "padding-right", cssSize);
+          qx.bom.element.Style.setStyles(document.querySelector('#navbarRight'), {
             width: cssSize,
             'margin-right': '-' + cssSize
           });
@@ -144,8 +144,8 @@ qx.Class.define('cv.ui.PagePartsHandler', {
         showtopnavigation = page.getShowTopNavigation();
         showfooter = page.getShowFooter();
       }
-      var topDisplay = qx.bom.element.Style.get(qx.bom.Selector.query("#top")[0], "display");
-      var bottomDisplay = qx.bom.element.Style.get(qx.bom.Selector.query("#bottom")[0], "display");
+      var topDisplay = qx.bom.element.Style.get(document.querySelector("#top"), "display");
+      var bottomDisplay = qx.bom.element.Style.get(document.querySelector("#bottom"), "display");
       if (showtopnavigation) {
         if (topDisplay === "none") {
           qx.bom.Selector.query('#top, #top > *').forEach(function(elem) {
@@ -155,25 +155,25 @@ qx.Class.define('cv.ui.PagePartsHandler', {
         }
       } else {
         if (topDisplay !== "none") {
-          qx.bom.element.Style.set(qx.bom.Selector.query("#top")[0], "display", "none");
+          qx.bom.element.Style.set(document.querySelector("#top"), "display", "none");
           this.removeInactiveNavbars(page.getPath());
         }
       }
       if (showfooter) {
         if (bottomDisplay === "none") {
-          qx.bom.element.Style.set(qx.bom.Selector.query("#bottom")[0], "display", "block");
+          qx.bom.element.Style.set(document.querySelector("#bottom"), "display", "block");
           this.removeInactiveNavbars(page.getPath());
         }
       } else {
         if (bottomDisplay !== "none") {
-          qx.bom.element.Style.set(qx.bom.Selector.query("#bottom")[0], "display", "none");
+          qx.bom.element.Style.set(document.querySelector("#bottom"), "display", "none");
           this.removeInactiveNavbars(page.getPath());
         }
       }
       ['Left', 'Top', 'Right', 'Bottom'].forEach(function (value) {
         var
           key = value.toLowerCase(),
-          navbar = qx.bom.Selector.query('#navbar' + value)[0],
+          navbar = document.querySelector('#navbar' + value),
           display = qx.bom.element.Style.get(navbar, "display"),
           isLoading = qx.bom.element.Class.has(navbar, 'loading');
         if (shownavbar[key] === true) {
@@ -201,7 +201,7 @@ qx.Class.define('cv.ui.PagePartsHandler', {
       speed = (speed !== undefined) ? speed : cv.TemplateEngine.getInstance().main_scroll.getSpeed();
       var initCss = {};
       var targetCss = {};
-      var navbar = qx.bom.Selector.query('#navbar' + position)[0];
+      var navbar = document.querySelector('#navbar' + position);
       var key = position.toLowerCase();
       var onAnimationEnd = function () {
         cv.ui.layout.ResizeHandler.invalidateNavbar();
@@ -285,13 +285,13 @@ qx.Class.define('cv.ui.PagePartsHandler', {
       var level = 1;
       tree.forEach(function (elem) {
         var id = elem.getAttribute('id');
-        var topNav = qx.bom.Selector.query('#' + id + 'top_navbar')[0];
+        var topNav = document.querySelector('#' + id + 'top_navbar');
         var topData = cv.data.Model.getInstance().getWidgetData(id + 'top_navbar');
-        var rightNav = qx.bom.Selector.query('#' + id + 'right_navbar')[0];
+        var rightNav = document.querySelector('#' + id + 'right_navbar');
         var rightData = cv.data.Model.getInstance().getWidgetData(id + 'right_navbar');
-        var bottomNav = qx.bom.Selector.query('#' + id + 'bottom_navbar')[0];
+        var bottomNav = document.querySelector('#' + id + 'bottom_navbar');
         var bottomData = cv.data.Model.getInstance().getWidgetData(id + 'bottom_navbar');
-        var leftNav = qx.bom.Selector.query('#' + id + 'left_navbar')[0];
+        var leftNav = document.querySelector('#' + id + 'left_navbar');
         var leftData = cv.data.Model.getInstance().getWidgetData(id + 'left_navbar');
         // console.log(tree.length+"-"+level+"<="+topData.scope);
         if (topNav) {

--- a/source/class/cv/ui/PagePartsHandler.js
+++ b/source/class/cv/ui/PagePartsHandler.js
@@ -94,7 +94,7 @@ qx.Class.define('cv.ui.PagePartsHandler', {
           Object.entries({
             width: cssSize,
             'margin-right': '-' + cssSize
-          }).forEach(function(key,value){document.querySelector('#navbarRight').style[key]=value;});
+          }).forEach(function([key,value]){document.querySelector('#navbarRight').style[key]=value;});
           cv.ui.layout.ResizeHandler.invalidateNavbar();
           break;
       }

--- a/source/class/cv/ui/PagePartsHandler.js
+++ b/source/class/cv/ui/PagePartsHandler.js
@@ -64,7 +64,7 @@ qx.Class.define('cv.ui.PagePartsHandler', {
       for (var i = 1; i < path.length; i++) { // element 0 is id_ (JNK)
         id += path[i] + '_';
         var pageElem = document.querySelector("#"+id);
-        if (pageElem && qx.bom.element.Class.has(pageElem, "page")) { // FIXME is this still needed?!?
+        if (pageElem && pageElem.classList.contains("page")) { // FIXME is this still needed?!?
           pageTitle = document.querySelector("#"+id+" h1").textContent;
           nav += '<span> &#x25ba; </span>' +
             '<a href="javascript:cv.TemplateEngine.getInstance().scrollToPage(\'' + id + '\')" id="breadcrump_pagejump_'+id+'">' +
@@ -175,7 +175,7 @@ qx.Class.define('cv.ui.PagePartsHandler', {
           key = value.toLowerCase(),
           navbar = document.querySelector('#navbar' + value),
           display = qx.bom.element.Style.get(navbar, "display"),
-          isLoading = qx.bom.element.Class.has(navbar, 'loading');
+          isLoading = navbar.classList.contains('loading');
         if (shownavbar[key] === true) {
           if (display === "none" || isLoading) {
             this.fadeNavbar(value, "in", speed);
@@ -296,30 +296,30 @@ qx.Class.define('cv.ui.PagePartsHandler', {
         // console.log(tree.length+"-"+level+"<="+topData.scope);
         if (topNav) {
           if (topData.scope === undefined || topData.scope < 0 || tree.length - level <= topData.scope) {
-            qx.bom.element.Class.add(topNav, 'navbarActive');
+            topNav.classList.add('navbarActive');
           } else {
-            qx.bom.element.Class.remove(topNav, 'navbarActive');
+            topNav.classList.remove('navbarActive');
           }
         }
         if (rightNav) {
           if (rightData.scope === undefined || rightData.scope < 0 || tree.length - level <= rightData.scope) {
-            qx.bom.element.Class.add(rightNav, 'navbarActive');
+            rightNav.classList.add('navbarActive');
           } else {
-            qx.bom.element.Class.remove(rightNav, 'navbarActive');
+            rightNav.classList.remove('navbarActive');
           }
         }
         if (bottomNav) {
           if (bottomData.scope === undefined || bottomData.scope < 0 || tree.length - level <= bottomData.scope) {
-            qx.bom.element.Class.add(bottomNav, 'navbarActive');
+            bottomNav.classList.add('navbarActive');
           } else {
-            qx.bom.element.Class.remove(bottomNav, 'navbarActive');
+            bottomNav.classList.remove('navbarActive');
           }
         }
         if (leftNav) {
           if (leftData.scope === undefined || leftData.scope < 0 || tree.length - level <= leftData.scope) {
-            qx.bom.element.Class.add(leftNav, 'navbarActive');
+            leftNav.classList.add('navbarActive');
           } else {
-            qx.bom.element.Class.remove(leftNav, 'navbarActive');
+            leftNav.classList.remove('navbarActive');
           }
         }
         level++;
@@ -335,7 +335,7 @@ qx.Class.define('cv.ui.PagePartsHandler', {
         navBarPath = navBarPath.slice(0, navBarPath.length - 2).join('_');
         var expr = new RegExp("^" + navBarPath + ".*", "i");
         if (navBarPath !== page_id && !expr.test(page_id)) {
-          qx.bom.element.Class.remove(elem, 'navbarActive');
+          elem.classList.remove('navbarActive');
         }
       });
     }

--- a/source/class/cv/ui/Popup.js
+++ b/source/class/cv/ui/Popup.js
@@ -98,7 +98,7 @@ qx.Class.define('cv.ui.Popup', {
           html: closable ? '<div class="popup_close">X</div>' : ""
         });
         qx.dom.Element.insertEnd(ret_val, body);
-        this.__elementMap.close = qx.bom.Selector.query("div.popup_close", ret_val);
+        this.__elementMap.close = ret_val.querySelectorAll("div.popup_close");
         addCloseListeners = true;
       } else {
         isNew = false;

--- a/source/class/cv/ui/Popup.js
+++ b/source/class/cv/ui/Popup.js
@@ -158,7 +158,7 @@ qx.Class.define('cv.ui.Popup', {
             qx.dom.Element.insertBegin(this.__elementMap.icon, this.__elementMap.content);
           } else {
             var use = qx.bom.Selector.query("use", this.__elementMap.icon)[0];
-            var currentIconPath = qx.bom.element.Attribute.get(use, "xlink:href");
+            var currentIconPath = use.getAttribute("xlink:href");
             if (!currentIconPath.endsWith("#kuf-"+attributes.icon)) {
               var parts = currentIconPath.split("#");
               qx.bom.element.Attribute.set(use, "xlink:href", parts[0]+"#kuf-"+attributes.icon);

--- a/source/class/cv/ui/Popup.js
+++ b/source/class/cv/ui/Popup.js
@@ -122,7 +122,7 @@ qx.Class.define('cv.ui.Popup', {
           ret_val.appendChild(this.__elementMap.title);
         }
 
-        if (qx.lang.Type.isString(attributes.title)) {
+        if (typeof attributes.title === 'string') {
           this.__elementMap.title.innerHTML = "" + attributes.title;
         } else {
           this.__elementMap.title.appendChild(attributes.title);
@@ -141,7 +141,7 @@ qx.Class.define('cv.ui.Popup', {
             this.__elementMap.messageContent = qx.dom.Element.create("div", {"class": "message"});
             qx.dom.Element.insertBegin(this.__elementMap.messageContent, this.__elementMap.content);
           }
-          if (qx.lang.Type.isString(attributes.content)) {
+          if (typeof attributes.content === 'string') {
             this.__elementMap.messageContent.innerHTML = attributes.content;
           } else {
             this.__elementMap.messageContent.parentNode.replaceChild(attributes.content, this.__elementMap.messageContent);
@@ -190,7 +190,7 @@ qx.Class.define('cv.ui.Popup', {
         }
         var actionTypes = Object.getOwnPropertyNames(attributes.actions).length;
         Object.getOwnPropertyNames(attributes.actions).forEach(function (type, index) {
-          var typeActions = qx.lang.Type.isArray(attributes.actions[type]) ? attributes.actions[type] : [attributes.actions[type]];
+          var typeActions = Array.isArray(attributes.actions[type]) ? attributes.actions[type] : [attributes.actions[type]];
 
           var target = this.__elementMap.actions;
           var wrapper = null;

--- a/source/class/cv/ui/Popup.js
+++ b/source/class/cv/ui/Popup.js
@@ -194,8 +194,8 @@ qx.Class.define('cv.ui.Popup', {
 
           var target = this.__elementMap.actions;
           var wrapper = null;
-          if (cv.core.notifications.actions[qx.lang.String.firstUp(type)] && cv.core.notifications.actions[qx.lang.String.firstUp(type)].getWrapper) {
-            wrapper = cv.core.notifications.actions[qx.lang.String.firstUp(type)].getWrapper();
+          if (cv.core.notifications.actions[type.charAt(0).toUpperCase() + type.substr(1)] && cv.core.notifications.actions[type.charAt(0).toUpperCase() + type.substr(1)].getWrapper) {
+            wrapper = cv.core.notifications.actions[type.charAt(0).toUpperCase() + type.substr(1)].getWrapper();
           } else {
             wrapper = qx.dom.Element.create('div', (actionTypes > index + 1) ? {style: "margin-bottom: 20px"} : {});
           }

--- a/source/class/cv/ui/Popup.js
+++ b/source/class/cv/ui/Popup.js
@@ -253,9 +253,11 @@ qx.Class.define('cv.ui.Popup', {
       if (attributes.align !== undefined) {
         align = attributes.align;
       }
-      var placement = cv.ui.PopupHandler.placementStrategy(
+      var
+        ret_valRect = ret_val.getBoundingClientRect(),
+        placement = cv.ui.PopupHandler.placementStrategy(
         anchor,
-        {w: qx.bom.element.Dimension.getWidth(ret_val), h: qx.bom.element.Dimension.getHeight(ret_val)},
+        {w: Math.round(ret_valRect.right - ret_valRect.left), h: Math.round(ret_valRect.bottom - ret_valRect.top)},
         {w: qx.bom.Viewport.getWidth(), h: qx.bom.Viewport.getHeight()},
         align
       );

--- a/source/class/cv/ui/Popup.js
+++ b/source/class/cv/ui/Popup.js
@@ -123,7 +123,7 @@ qx.Class.define('cv.ui.Popup', {
         }
 
         if (qx.lang.Type.isString(attributes.title)) {
-          this.__elementMap.title.setAttribute("html", "" + attributes.title);
+          this.__elementMap.title.innerHTML = "" + attributes.title;
         } else {
           qx.dom.Element.insertEnd(attributes.title, this.__elementMap.title);
         }
@@ -142,7 +142,7 @@ qx.Class.define('cv.ui.Popup', {
             qx.dom.Element.insertBegin(this.__elementMap.messageContent, this.__elementMap.content);
           }
           if (qx.lang.Type.isString(attributes.content)) {
-            this.__elementMap.messageContent.setAttribute("html", attributes.content);
+            this.__elementMap.messageContent.innerHTML = attributes.content;
           } else {
             qx.dom.Element.replaceChild(attributes.content, this.__elementMap.messageContent);
             this.__elementMap.messageContent = attributes.content;
@@ -186,7 +186,7 @@ qx.Class.define('cv.ui.Popup', {
           qx.dom.Element.insertEnd(this.__elementMap.actions, ret_val);
         } else {
           // clear content
-          this.__elementMap.actions.setAttribute("html", "");
+          this.__elementMap.actions.innerHTML = "";
         }
         var actionTypes = Object.getOwnPropertyNames(attributes.actions).length;
         Object.getOwnPropertyNames(attributes.actions).forEach(function (type, index) {

--- a/source/class/cv/ui/Popup.js
+++ b/source/class/cv/ui/Popup.js
@@ -81,7 +81,7 @@ qx.Class.define('cv.ui.Popup', {
     create: function (attributes) {
       cv.ui.BodyBlocker.getInstance().block(attributes.unique, attributes.topic);
       var closable = !attributes.hasOwnProperty("closable") || attributes.closable;
-      var body = qx.bom.Selector.query('body')[0];
+      var body = document.querySelector('body');
       var ret_val;
       var classes = ["popup", "popup_background", this.getType()];
       var isNew = true;
@@ -157,7 +157,7 @@ qx.Class.define('cv.ui.Popup', {
             this.__elementMap.icon = qx.dom.Element.create("div", {"html": cv.util.IconTools.svgKUF(attributes.icon)(null, null, "icon" + iconClasses)});
             qx.dom.Element.insertBegin(this.__elementMap.icon, this.__elementMap.content);
           } else {
-            var use = qx.bom.Selector.query("use", this.__elementMap.icon)[0];
+            var use = this.__elementMap.icon.querySelector("use");
             var currentIconPath = use.getAttribute("xlink:href");
             if (!currentIconPath.endsWith("#kuf-"+attributes.icon)) {
               var parts = currentIconPath.split("#");
@@ -270,7 +270,7 @@ qx.Class.define('cv.ui.Popup', {
           //       one for the popup_background.
           this.fireEvent('close');
         }, this);
-        var close = qx.bom.Selector.query(".popup_close", ret_val)[0];
+        var close = ret_val.querySelector(".popup_close");
         qx.event.Registration.addListener(close, 'tap', function () {
           this.fireEvent('close');
         }, this);

--- a/source/class/cv/ui/Popup.js
+++ b/source/class/cv/ui/Popup.js
@@ -258,7 +258,7 @@ qx.Class.define('cv.ui.Popup', {
         placement = cv.ui.PopupHandler.placementStrategy(
         anchor,
         {w: Math.round(ret_valRect.right - ret_valRect.left), h: Math.round(ret_valRect.bottom - ret_valRect.top)},
-        {w: qx.bom.Viewport.getWidth(), h: qx.bom.Viewport.getHeight()},
+        {w: document.documentElement.clientWidth, h: document.documentElement.clientHeight},
         align
       );
 

--- a/source/class/cv/ui/Popup.js
+++ b/source/class/cv/ui/Popup.js
@@ -260,8 +260,8 @@ qx.Class.define('cv.ui.Popup', {
         align
       );
 
-      qx.bom.element.Style.set(ret_val, 'left', placement.x);
-      qx.bom.element.Style.set(ret_val, 'top', placement.y);
+      ret_val.style['left'] = placement.x;
+      ret_val.style['top'] = placement.y;
 
       if (closable && addCloseListeners) {
         this.addListener('close', this.close, this);
@@ -278,7 +278,7 @@ qx.Class.define('cv.ui.Popup', {
 
       attributes.id = this.__counter;
       if (isNew) {
-        qx.bom.element.Style.set(ret_val, 'display', 'block');
+        ret_val.style['display'] = 'block';
         this.__counter++;
       }
       return ret_val;

--- a/source/class/cv/ui/Popup.js
+++ b/source/class/cv/ui/Popup.js
@@ -103,7 +103,7 @@ qx.Class.define('cv.ui.Popup', {
       } else {
         isNew = false;
         ret_val = this.__domElement;
-        qx.bom.element.Attribute.set(ret_val, "class", classes.join(" "));
+        ret_val.setAttribute("class", classes.join(" "));
         if (closable && !this.__elementMap.close) {
           this.__domElement.close = qx.dom.Element.create("div", {"class": "popup_close", "html": "X"});
           qx.dom.Element.insertBegin(this.__domElement.close, body);
@@ -123,7 +123,7 @@ qx.Class.define('cv.ui.Popup', {
         }
 
         if (qx.lang.Type.isString(attributes.title)) {
-          qx.bom.element.Attribute.set(this.__elementMap.title, "html", "" + attributes.title);
+          this.__elementMap.title.setAttribute("html", "" + attributes.title);
         } else {
           qx.dom.Element.insertEnd(attributes.title, this.__elementMap.title);
         }
@@ -142,7 +142,7 @@ qx.Class.define('cv.ui.Popup', {
             qx.dom.Element.insertBegin(this.__elementMap.messageContent, this.__elementMap.content);
           }
           if (qx.lang.Type.isString(attributes.content)) {
-            qx.bom.element.Attribute.set(this.__elementMap.messageContent, "html", attributes.content);
+            this.__elementMap.messageContent.setAttribute("html", attributes.content);
           } else {
             qx.dom.Element.replaceChild(attributes.content, this.__elementMap.messageContent);
             this.__elementMap.messageContent = attributes.content;
@@ -161,7 +161,7 @@ qx.Class.define('cv.ui.Popup', {
             var currentIconPath = use.getAttribute("xlink:href");
             if (!currentIconPath.endsWith("#kuf-"+attributes.icon)) {
               var parts = currentIconPath.split("#");
-              qx.bom.element.Attribute.set(use, "xlink:href", parts[0]+"#kuf-"+attributes.icon);
+              use.setAttribute("xlink:href", parts[0]+"#kuf-"+attributes.icon);
             }
           }
         } else  {
@@ -186,7 +186,7 @@ qx.Class.define('cv.ui.Popup', {
           qx.dom.Element.insertEnd(this.__elementMap.actions, ret_val);
         } else {
           // clear content
-          qx.bom.element.Attribute.set(this.__elementMap.actions, "html", "");
+          this.__elementMap.actions.setAttribute("html", "");
         }
         var actionTypes = Object.getOwnPropertyNames(attributes.actions).length;
         Object.getOwnPropertyNames(attributes.actions).forEach(function (type, index) {

--- a/source/class/cv/ui/Popup.js
+++ b/source/class/cv/ui/Popup.js
@@ -97,7 +97,7 @@ qx.Class.define('cv.ui.Popup', {
           style: "display:none",
           html: closable ? '<div class="popup_close">X</div>' : ""
         });
-        qx.dom.Element.insertEnd(ret_val, body);
+        body.appendChild(ret_val);
         this.__elementMap.close = ret_val.querySelectorAll("div.popup_close");
         addCloseListeners = true;
       } else {
@@ -119,13 +119,13 @@ qx.Class.define('cv.ui.Popup', {
       if (attributes.title) {
         if (!this.__elementMap.title) {
           this.__elementMap.title = qx.dom.Element.create("div", {"class": "head"});
-          qx.dom.Element.insertEnd(this.__elementMap.title, ret_val);
+          ret_val.appendChild(this.__elementMap.title);
         }
 
         if (qx.lang.Type.isString(attributes.title)) {
           this.__elementMap.title.innerHTML = "" + attributes.title;
         } else {
-          qx.dom.Element.insertEnd(attributes.title, this.__elementMap.title);
+          this.__elementMap.title.appendChild(attributes.title);
         }
 
       }
@@ -133,7 +133,7 @@ qx.Class.define('cv.ui.Popup', {
       if (attributes.content || attributes.icon || attributes.progress) {
         if (!this.__elementMap.content) {
           this.__elementMap.content = qx.dom.Element.create("div", {"class": "main"});
-          qx.dom.Element.insertEnd(this.__elementMap.content, ret_val);
+          ret_val.appendChild(this.__elementMap.content);
         }
 
         if (attributes.content) {
@@ -144,7 +144,7 @@ qx.Class.define('cv.ui.Popup', {
           if (qx.lang.Type.isString(attributes.content)) {
             this.__elementMap.messageContent.innerHTML = attributes.content;
           } else {
-            qx.dom.Element.replaceChild(attributes.content, this.__elementMap.messageContent);
+            this.__elementMap.messageContent.parentNode.replaceChild(attributes.content, this.__elementMap.messageContent);
             this.__elementMap.messageContent = attributes.content;
           }
         } else {
@@ -172,7 +172,7 @@ qx.Class.define('cv.ui.Popup', {
           if (!this.__elementMap.progress) {
             var bar = new cv.ui.util.ProgressBar();
             this.__elementMap.progress = bar.getDomElement();
-            qx.dom.Element.insertEnd(this.__elementMap.progress, this.__elementMap.content);
+            this.__elementMap.content.appendChild(this.__elementMap.progress);
           }
           this.__elementMap.progress.$$widget.setValue(attributes.progress);
         } else {
@@ -183,7 +183,7 @@ qx.Class.define('cv.ui.Popup', {
       if (attributes.actions && Object.getOwnPropertyNames(attributes.actions).length > 0) {
         if (!this.__elementMap.actions) {
           this.__elementMap.actions = qx.dom.Element.create("div", {"class": "actions"});
-          qx.dom.Element.insertEnd(this.__elementMap.actions, ret_val);
+          ret_val.appendChild(this.__elementMap.actions);
         } else {
           // clear content
           this.__elementMap.actions.innerHTML = "";
@@ -199,7 +199,7 @@ qx.Class.define('cv.ui.Popup', {
           } else {
             wrapper = qx.dom.Element.create('div', (actionTypes > index + 1) ? {style: "margin-bottom: 20px"} : {});
           }
-          qx.dom.Element.insertEnd(wrapper, target);
+          target.appendChild(wrapper);
           target = wrapper;
           typeActions.forEach(function (action) {
             var actionButton = cv.core.notifications.ActionRegistry.createActionElement(type, action);
@@ -207,7 +207,7 @@ qx.Class.define('cv.ui.Popup', {
               actionButton.$$handler && actionButton.$$handler.addListener('close', function () {
                 this.close();
               }, this);
-              qx.dom.Element.insertEnd(actionButton, target);
+              target.appendChild(actionButton);
             }
           }, this);
         }, this);
@@ -288,7 +288,7 @@ qx.Class.define('cv.ui.Popup', {
 
     destroyElement: function(name) {
       if (this.__elementMap[name]) {
-        qx.dom.Element.remove(this.__elementMap[name]);
+        this.__elementMap[name].parentNode.removeChild(this.__elementMap[name]);
         delete this.__elementMap[name];
       }
     },
@@ -299,7 +299,7 @@ qx.Class.define('cv.ui.Popup', {
     close: function () {
       if (this.__domElement) {
         cv.ui.BodyBlocker.getInstance().unblock(this.__domElement.$$topic);
-        qx.dom.Element.remove(this.__domElement);
+        this.__domElement.parentNode.removeChild(this.__domElement);
         this.__domElement = null;
         this.__elementMap = {};
       } else {

--- a/source/class/cv/ui/Popup.js
+++ b/source/class/cv/ui/Popup.js
@@ -262,8 +262,8 @@ qx.Class.define('cv.ui.Popup', {
         align
       );
 
-      ret_val.style['left'] = placement.x;
-      ret_val.style['top'] = placement.y;
+      ret_val.style.left = placement.x;
+      ret_val.style.top  = placement.y;
 
       if (closable && addCloseListeners) {
         this.addListener('close', this.close, this);
@@ -280,7 +280,7 @@ qx.Class.define('cv.ui.Popup', {
 
       attributes.id = this.__counter;
       if (isNew) {
-        ret_val.style['display'] = 'block';
+        ret_val.style.display = 'block';
         this.__counter++;
       }
       return ret_val;

--- a/source/class/cv/ui/Popup.js
+++ b/source/class/cv/ui/Popup.js
@@ -216,11 +216,11 @@ qx.Class.define('cv.ui.Popup', {
       }
 
       if (attributes.width) {
-        qx.bom.element.Style.add(ret_val, "width", attributes.width);
+        ret_val.style.width = attributes.width;
       }
 
       if (attributes.height) {
-        qx.bom.element.Style.add(ret_val, "height", attributes.height);
+        ret_val.style.height = attributes.height;
       }
 
       var anchor = {x: -1, y: -1, w: 0, h: 0};

--- a/source/class/cv/ui/PopupHandler.js
+++ b/source/class/cv/ui/PopupHandler.js
@@ -120,7 +120,7 @@ qx.Class.define('cv.ui.PopupHandler', {
       if (popup instanceof cv.ui.Popup) {
         popup.close();
       } else {
-        qx.dom.Element.remove(popup);
+        popup.parentNode.removeChild(popup);
       }
     },
 

--- a/source/class/cv/ui/ToastManager.js
+++ b/source/class/cv/ui/ToastManager.js
@@ -95,7 +95,7 @@ qx.Class.define("cv.ui.ToastManager", {
     _init: function() {
       if (!this.__domElement) {
         // check if there is one (might be restored from cache)
-        this.__domElement = qx.bom.Selector.query(this.getRootElementId())[0];
+        this.__domElement = document.querySelector(this.getRootElementId());
         if (!this.__domElement) {
           this.__domElement = qx.dom.Element.create("div", {"id": this.getRootElementId()});
         }

--- a/source/class/cv/ui/ToastManager.js
+++ b/source/class/cv/ui/ToastManager.js
@@ -101,7 +101,7 @@ qx.Class.define("cv.ui.ToastManager", {
         }
       }
       if (document.querySelectorAll(this.getRootElementId()).length === 0) {
-        qx.dom.Element.insertEnd(this.__domElement, document.body);
+        document.body.appendChild(this.__domElement);
       }
       if (document.querySelectorAll("#ToastTemplate").length === 0) {
         var template = qx.dom.Element.create("script", {
@@ -109,7 +109,7 @@ qx.Class.define("cv.ui.ToastManager", {
           type: "text/template",
           html: '<div class="toast {{severity}}{{#actions}} selectable{{/actions}}" title="{{tooltip}}" id="'+this.getMessageElementId()+'{{ id }}"><div class="content">{{&message}}</div></div>'
         });
-        qx.dom.Element.insertEnd(template, document.body);
+        document.body.appendChild(template);
       }
       this._list = new qx.data.controller.website.List(this._messages, this.__domElement, "ToastTemplate");
       qx.event.Registration.addListener(this.__domElement, "tap", this._onListTap, this);
@@ -135,7 +135,7 @@ qx.Class.define("cv.ui.ToastManager", {
       this.__timer = null;
     }
     if (this.__domElement) {
-      qx.dom.Element.remove(this.__domElement);
+      this.__domElement.parentNode.removeChild(this.__domElement);
       this.__domElement = null;
     }
   }

--- a/source/class/cv/ui/ToastManager.js
+++ b/source/class/cv/ui/ToastManager.js
@@ -100,10 +100,10 @@ qx.Class.define("cv.ui.ToastManager", {
           this.__domElement = qx.dom.Element.create("div", {"id": this.getRootElementId()});
         }
       }
-      if (qx.bom.Selector.query(this.getRootElementId()).length === 0) {
+      if (document.querySelectorAll(this.getRootElementId()).length === 0) {
         qx.dom.Element.insertEnd(this.__domElement, document.body);
       }
-      if (qx.bom.Selector.query("#ToastTemplate").length === 0) {
+      if (document.querySelectorAll("#ToastTemplate").length === 0) {
         var template = qx.dom.Element.create("script", {
           id: "ToastTemplate",
           type: "text/template",

--- a/source/class/cv/ui/TrickOMatic.js
+++ b/source/class/cv/ui/TrickOMatic.js
@@ -148,7 +148,7 @@ qx.Class.define('cv.ui.TrickOMatic', {
         'style');
       s.setAttribute('type', 'text/css');
       s.textContent = keyframes;
-      qx.dom.Element.insertBegin(s, qx.bom.Selector.query('svg', svg)[0]);
+      qx.dom.Element.insertBegin(s, svg.querySelector('svg'));
     },
 
     updateActive: function (pipe_group, data) {

--- a/source/class/cv/ui/TrickOMatic.js
+++ b/source/class/cv/ui/TrickOMatic.js
@@ -38,9 +38,9 @@ qx.Class.define('cv.ui.TrickOMatic', {
       if (!svg) { return; }
 
       // Pipe-O-Matic:
-      var pipes = qx.bom.Selector.query(".pipe_group", svg);
+      var pipes = svg.querySelectorAll(".pipe_group");
       pipes.forEach(function (pipe_group) {
-        qx.bom.Selector.query('path', pipe_group).forEach(function(path) {
+        pipe_group.querySelectorAll('path').forEach(function(path) {
           var halfsize = parseInt(parseFloat(path.style.strokeWidth) / 2);
           var opacity = 0.15;
           for (var width = halfsize - 1; width > 0; width--) {
@@ -60,10 +60,10 @@ qx.Class.define('cv.ui.TrickOMatic', {
 
       // Flow-O-Matic: add Paths
       var segmentLength = 40;
-      pipes = qx.bom.Selector.query(".show_flow", svg);
+      pipes = svg.querySelectorAll(".show_flow");
       pipes.forEach(function (pipe_group) {
         var length = 0.0;
-        qx.bom.Selector.query('path', pipe_group).forEach(function(path) {
+        pipe_group.querySelectorAll('path').forEach(function(path) {
           if (path.className.animVal.split(' ').indexOf('pipe-o-matic_clone') > 0) {
             return;
           }

--- a/source/class/cv/ui/TrickOMatic.js
+++ b/source/class/cv/ui/TrickOMatic.js
@@ -105,7 +105,7 @@ qx.Class.define('cv.ui.TrickOMatic', {
             pipe_group.insertBefore(n, path.nextElementSibling);
           }
           length += path.getTotalLength();
-          var activeValues = qx.bom.element.Attribute.get(pipe_group, 'data-cometvisu-active');
+          var activeValues = pipe_group.getAttribute('data-cometvisu-active');
           if (activeValues) {
             activeValues.split(' ').forEach(function (address) {
               var id = "flow_"+cv.ui.TrickOMatic.id++;

--- a/source/class/cv/ui/TrickOMatic.js
+++ b/source/class/cv/ui/TrickOMatic.js
@@ -153,9 +153,9 @@ qx.Class.define('cv.ui.TrickOMatic', {
 
     updateActive: function (pipe_group, data) {
       if (parseInt(data) === 1 || data === 'ON') {
-        qx.bom.element.Class.toggle(pipe_group, "flow_active", true);
+        pipe_group.classList.toggle("flow_active",true);
       } else {
-        qx.bom.element.Class.toggle(pipe_group, "flow_active", false);
+        pipe_group.classList.toggle("flow_active",false);
       }
     }
   }

--- a/source/class/cv/ui/common/BasicUpdate.js
+++ b/source/class/cv/ui/common/BasicUpdate.js
@@ -319,7 +319,7 @@ qx.Mixin.define("cv.ui.common.BasicUpdate", {
      * @param e {var} value to add to the element
      */
     _applyValueToDom: function(valueElement, e) {
-      if (qx.lang.Type.isNumber(e)) {
+      if (typeof e === 'number') {
         valueElement.innerText = e;
       } else {
         valueElement.innerHTML += e;

--- a/source/class/cv/ui/common/BasicUpdate.js
+++ b/source/class/cv/ui/common/BasicUpdate.js
@@ -320,7 +320,7 @@ qx.Mixin.define("cv.ui.common.BasicUpdate", {
      */
     _applyValueToDom: function(valueElement, e) {
       if (qx.lang.Type.isNumber(e)) {
-        valueElement.setAttribute("text", e);
+        valueElement.innerText = e;
       } else {
         qx.bom.Html.clean([e]).forEach(function (newElem) {
           qx.dom.Element.insertEnd(newElem, valueElement);

--- a/source/class/cv/ui/common/BasicUpdate.js
+++ b/source/class/cv/ui/common/BasicUpdate.js
@@ -300,7 +300,7 @@ qx.Mixin.define("cv.ui.common.BasicUpdate", {
       // TODO: check if this is the right place for this
       // might be if the styling removes the align class
       if (this.getAlign()) {
-        qx.bom.element.Class.add(element, this.getAlign());
+        element.classList.add(this.getAlign());
       }
       var valueElement = this.getValueElement ? this.getValueElement() : element.querySelector('.value');
       qx.dom.Element.empty(valueElement);

--- a/source/class/cv/ui/common/BasicUpdate.js
+++ b/source/class/cv/ui/common/BasicUpdate.js
@@ -320,7 +320,7 @@ qx.Mixin.define("cv.ui.common.BasicUpdate", {
      */
     _applyValueToDom: function(valueElement, e) {
       if (qx.lang.Type.isNumber(e)) {
-        qx.bom.element.Attribute.set(valueElement, "text", e);
+        valueElement.setAttribute("text", e);
       } else {
         qx.bom.Html.clean([e]).forEach(function (newElem) {
           qx.dom.Element.insertEnd(newElem, valueElement);

--- a/source/class/cv/ui/common/BasicUpdate.js
+++ b/source/class/cv/ui/common/BasicUpdate.js
@@ -302,7 +302,7 @@ qx.Mixin.define("cv.ui.common.BasicUpdate", {
       if (this.getAlign()) {
         qx.bom.element.Class.add(element, this.getAlign());
       }
-      var valueElement = this.getValueElement ? this.getValueElement() : qx.bom.Selector.query('.value', element)[0];
+      var valueElement = this.getValueElement ? this.getValueElement() : element.querySelector('.value');
       qx.dom.Element.empty(valueElement);
       if (undefined !== value) {
         this.defaultValue2DOM(value, qx.lang.Function.curry(this._applyValueToDom, valueElement));

--- a/source/class/cv/ui/common/BasicUpdate.js
+++ b/source/class/cv/ui/common/BasicUpdate.js
@@ -303,12 +303,12 @@ qx.Mixin.define("cv.ui.common.BasicUpdate", {
         element.classList.add(this.getAlign());
       }
       var valueElement = this.getValueElement ? this.getValueElement() : element.querySelector('.value');
-      qx.dom.Element.empty(valueElement);
+      valueElement.innerHTML = '';
       if (undefined !== value) {
         this.defaultValue2DOM(value, qx.lang.Function.curry(this._applyValueToDom, valueElement));
       }
       else {
-        qx.dom.Element.insertEnd(document.createTextNode('-'), valueElement);
+        valueElement.appendChild(document.createTextNode('-'));
       }
       return value;
     },
@@ -323,7 +323,7 @@ qx.Mixin.define("cv.ui.common.BasicUpdate", {
         valueElement.innerText = e;
       } else {
         qx.bom.Html.clean([e]).forEach(function (newElem) {
-          qx.dom.Element.insertEnd(newElem, valueElement);
+          valueElement.appendChild(newElem);
         }, this);
       }
     }

--- a/source/class/cv/ui/common/BasicUpdate.js
+++ b/source/class/cv/ui/common/BasicUpdate.js
@@ -305,7 +305,8 @@ qx.Mixin.define("cv.ui.common.BasicUpdate", {
       var valueElement = this.getValueElement ? this.getValueElement() : element.querySelector('.value');
       valueElement.innerHTML = '';
       if (undefined !== value) {
-        this.defaultValue2DOM(value, qx.lang.Function.curry(this._applyValueToDom, valueElement));
+        var self = this;
+        this.defaultValue2DOM(value, function(e){self._applyValueToDom(valueElement, e);});
       }
       else {
         valueElement.appendChild(document.createTextNode('-'));

--- a/source/class/cv/ui/common/BasicUpdate.js
+++ b/source/class/cv/ui/common/BasicUpdate.js
@@ -322,9 +322,7 @@ qx.Mixin.define("cv.ui.common.BasicUpdate", {
       if (qx.lang.Type.isNumber(e)) {
         valueElement.innerText = e;
       } else {
-        qx.bom.Html.clean([e]).forEach(function (newElem) {
-          valueElement.appendChild(newElem);
-        }, this);
+        valueElement.innerHTML += e;
       }
     }
   }

--- a/source/class/cv/ui/common/HasAnimatedButton.js
+++ b/source/class/cv/ui/common/HasAnimatedButton.js
@@ -86,15 +86,15 @@ qx.Mixin.define("cv.ui.common.HasAnimatedButton", {
       if (pressed) {
         buttons.forEach(function(button) {
           if (button) {
-            qx.bom.element.Class.add(button, 'switchPressed');
-            qx.bom.element.Class.remove(button, 'switchUnpressed');
+            button.classList.add('switchPressed');
+            button.classList.remove('switchUnpressed');
           }
         });
       } else {
         buttons.forEach(function(button) {
           if (button) {
-            qx.bom.element.Class.add(button, 'switchUnpressed');
-            qx.bom.element.Class.remove(button, 'switchPressed');
+            button.classList.add('switchUnpressed');
+            button.classList.remove('switchPressed');
           }
         });
       }

--- a/source/class/cv/ui/common/HasStyling.js
+++ b/source/class/cv/ui/common/HasStyling.js
@@ -49,7 +49,7 @@ qx.Mixin.define("cv.ui.common.HasStyling", {
             e = element;
           }
         });
-        qx.bom.element.Class.removeClasses(e, sty.classnames.split(" ")); // remove only styling classes
+        e.classList.remove.apply( e.classList, sty.classnames.split(" ")); // remove only styling classes
         if (!this._findValue(value, false, e, sty) && sty.defaultValue !== undefined) {
           this._findValue(sty.defaultValue, true, e, sty);
         }
@@ -61,20 +61,20 @@ qx.Mixin.define("cv.ui.common.HasStyling", {
         return false;
       }
       if (styling[value]) { // fixed value
-        qx.bom.element.Class.addClasses(element, styling[value].split(' '));
+        element.classList.add.apply( element.classList, styling[value].split(' ') );
         return true;
       }
       else {
         var range = styling.range;
         if (findExact && range[value]) {
-          qx.bom.element.Class.addClasses(element, range[value][1].split(' '));
+          element.classList.add.apply( element.classList, range[value][1].split(' '));
           return true;
         }
         var valueFloat = parseFloat(value);
         for (var min in range) {
           if (min > valueFloat) { continue; }
           if (range[min][0] < valueFloat) { continue; }// check max
-          qx.bom.element.Class.addClasses(element, range[min][1].split(' '));
+          element.classList.add.apply( element.classList, range[min][1].split(' '));
           return true;
         }
       }

--- a/source/class/cv/ui/common/HasStyling.js
+++ b/source/class/cv/ui/common/HasStyling.js
@@ -43,7 +43,12 @@ qx.Mixin.define("cv.ui.common.HasStyling", {
     applyStyling: function (value) {
       var sty = cv.Config.getStyling(this.getStyling());
       if (sty) {
-        var e = qx.bom.Selector.query('.actor:has(".value")', this.getDomElement())[0];
+        var e;
+        this.getDomElement().querySelectorAll('.actor').forEach( function(element){
+          if( element.querySelector('.value') && e === undefined ) {
+            e = element;
+          }
+        });
         qx.bom.element.Class.removeClasses(e, sty.classnames.split(" ")); // remove only styling classes
         if (!this._findValue(value, false, e, sty) && sty.defaultValue !== undefined) {
           this._findValue(sty.defaultValue, true, e, sty);

--- a/source/class/cv/ui/common/Refresh.js
+++ b/source/class/cv/ui/common/Refresh.js
@@ -218,7 +218,7 @@ qx.Mixin.define("cv.ui.common.Refresh", {
     // based on https://stackoverflow.com/questions/1077041/refresh-image-with-a-new-one-at-the-same-url
     __forceImgReload: function(src, twostage) {
       var step = 0,                                       // step: 0 - started initial load, 1 - wait before proceeding (twostage mode only), 2 - started forced reload, 3 - cancelled
-        elements = qx.bom.Selector.query('img[src="'+src+'"]'),
+        elements = document.querySelectorAll('img[src="'+src+'"]'),
         canvases = [],
         imgReloadBlank = function(){
           elements.forEach(function(elem){

--- a/source/class/cv/ui/common/Refresh.js
+++ b/source/class/cv/ui/common/Refresh.js
@@ -233,7 +233,7 @@ qx.Mixin.define("cv.ui.common.Refresh", {
             elem.width = elem.width;
             elem.height = elem.height;
             elem.parentNode.insertBefore( canvas, elem );
-            qx.bom.element.Attribute.reset(elem, "src"); 
+            elem.removeAttribute("src");
           });
         },
         imgReloadRestore = function(){

--- a/source/class/cv/ui/common/Refresh.js
+++ b/source/class/cv/ui/common/Refresh.js
@@ -132,7 +132,7 @@ qx.Mixin.define("cv.ui.common.Refresh", {
           }
         } else if (!this._timer || !this._timer.isEnabled()) {
           var element = this.getDomElement();
-          var target = qx.bom.Selector.query('img', element)[0] || qx.bom.Selector.query('iframe', element)[0];
+          var target = element.querySelector('img') || element.querySelector('iframe');
           var src = target.getAttribute("src");
           if (src.indexOf('?') < 0 && ((target.nodeName === 'IMG' && this.getCachecontrol() === 'full') || target.nodeName !== 'IMG')) {
             src += '?';

--- a/source/class/cv/ui/common/Refresh.js
+++ b/source/class/cv/ui/common/Refresh.js
@@ -133,7 +133,7 @@ qx.Mixin.define("cv.ui.common.Refresh", {
         } else if (!this._timer || !this._timer.isEnabled()) {
           var element = this.getDomElement();
           var target = qx.bom.Selector.query('img', element)[0] || qx.bom.Selector.query('iframe', element)[0];
-          var src = qx.bom.element.Attribute.get(target, "src");
+          var src = target.getAttribute("src");
           if (src.indexOf('?') < 0 && ((target.nodeName === 'IMG' && this.getCachecontrol() === 'full') || target.nodeName !== 'IMG')) {
             src += '?';
           }

--- a/source/class/cv/ui/common/Refresh.js
+++ b/source/class/cv/ui/common/Refresh.js
@@ -163,9 +163,9 @@ qx.Mixin.define("cv.ui.common.Refresh", {
          */
         var parenthost = window.location.protocol + "//" + window.location.host;
         if (target.nodeName === "IFRAME" && src.indexOf(parenthost) !== 0) {
-          qx.bom.element.Attribute.set(target, "src", "");
+          target.setAttribute("src", "");
           qx.event.Timer.once(function () {
-            qx.bom.element.Attribute.set(target, "src", src);
+            target.setAttribute("src", src);
           }, this, 0);
         } else {
           var cachecontrol = this.getCachecontrol();
@@ -178,11 +178,11 @@ qx.Mixin.define("cv.ui.common.Refresh", {
           
           switch( cachecontrol ) {
             case 'full':
-              qx.bom.element.Attribute.set(target, "src", qx.util.Uri.appendParamsToUrl(src, ""+new Date().getTime()));
+              target.setAttribute("src", qx.util.Uri.appendParamsToUrl(src, ""+new Date().getTime()));
               break;
               
             case 'weak':
-              qx.bom.element.Attribute.set(target, "src", src + '#' + new Date().getTime());
+              target.setAttribute("src", src + '#' + new Date().getTime());
               break;
               
             case 'force':
@@ -238,7 +238,7 @@ qx.Mixin.define("cv.ui.common.Refresh", {
         },
         imgReloadRestore = function(){
           elements.forEach(function(elem){
-            qx.bom.element.Attribute.set(elem, "src", src); 
+            elem.setAttribute("src", src);
             elem.removeAttribute('width');
             elem.removeAttribute('height');
           });

--- a/source/class/cv/ui/layout/Manager.js
+++ b/source/class/cv/ui/layout/Manager.js
@@ -263,7 +263,7 @@ qx.Class.define('cv.ui.layout.Manager', {
 
     __applyWidthClass: function (elem, widthClassSuffix) {
       if (widthClassSuffix === 'auto') {
-        elem.style['width'] = widthClassSuffix;
+        elem.style.width = widthClassSuffix;
       } else {
         switch (this.LAYOUT_MODE) {
           case 'GRID':
@@ -277,7 +277,7 @@ qx.Class.define('cv.ui.layout.Manager', {
             break;
 
           default:
-            elem.style['width'] = widthClassSuffix;
+            elem.style.width = widthClassSuffix;
             break;
         }
       }

--- a/source/class/cv/ui/layout/Manager.js
+++ b/source/class/cv/ui/layout/Manager.js
@@ -196,7 +196,7 @@ qx.Class.define('cv.ui.layout.Manager', {
      */
     applyColumnWidths: function (selector, includeNavbars) {
       var width = this.getAvailableWidth();
-      var mainAreaColumns = qx.bom.element.Dataset.get(document.querySelector('#main'), 'columns');
+      var mainAreaColumns = document.querySelector('#main').dataset['columns'];
       var mainAreaColspan = parseInt(mainAreaColumns || cv.Config.defaultColumns);
 
       var pageSelector = selector ? selector : '#main .activePage';
@@ -211,7 +211,7 @@ qx.Class.define('cv.ui.layout.Manager', {
       selectors.forEach(function (area) {
         var allContainer = document.querySelectorAll(area + ' .widget_container');
         if (allContainer.length > 0) {
-          var areaColumns = qx.bom.element.Dataset.get(document.querySelector(area), 'columns');
+          var areaColumns = document.querySelector(area).dataset['columns'];
           var areaColspan = areaColumns || cv.Config.defaultColumns;
           allContainer.forEach(function(child) {
             var widget = cv.ui.structure.WidgetFactory.getInstanceByElement(child);

--- a/source/class/cv/ui/layout/Manager.js
+++ b/source/class/cv/ui/layout/Manager.js
@@ -209,7 +209,7 @@ qx.Class.define('cv.ui.layout.Manager', {
       }
 
       selectors.forEach(function (area) {
-        var allContainer = qx.bom.Selector.query(area + ' .widget_container');
+        var allContainer = document.querySelectorAll(area + ' .widget_container');
         if (allContainer.length > 0) {
           var areaColumns = qx.bom.element.Dataset.get(document.querySelector(area), 'columns');
           var areaColspan = areaColumns || cv.Config.defaultColumns;
@@ -227,7 +227,7 @@ qx.Class.define('cv.ui.layout.Manager', {
         }
 
         // and elements inside groups
-        var adjustableElements = qx.bom.Selector.query(area + ' .group .widget_container');
+        var adjustableElements = document.querySelectorAll(area + ' .group .widget_container');
         adjustableElements.forEach(function (e) {
           var
             widget = cv.ui.structure.WidgetFactory.getInstanceByElement(e),

--- a/source/class/cv/ui/layout/Manager.js
+++ b/source/class/cv/ui/layout/Manager.js
@@ -92,15 +92,17 @@ qx.Class.define('cv.ui.layout.Manager', {
         this.currentPageUnavailableWidth = 0;
         var navbarVisibility = this.getCurrentPageNavbarVisibility();
 
-        var left = document.querySelector('#navbarLeft');
-        var widthNavbarLeft = navbarVisibility.left === true && window.getComputedStyle(left)['display'] !== "none" ? Math.ceil(qx.bom.element.Dimension.getWidth(left)) : 0;
+        var left = document.querySelector('#navbarLeft'),
+          leftRect = left.getBoundingClientRect(),
+          widthNavbarLeft = navbarVisibility.left === true && window.getComputedStyle(left)['display'] !== "none" ? Math.round(leftRect.right - leftRect.left) : 0;
         if (widthNavbarLeft >= bodyWidth) {
           // Left-Navbar has the same size as the complete body, this can happen, when the navbar has no content
           // maybe there is a better solution to solve this problem
           widthNavbarLeft = 0;
         }
-        var right = document.querySelector('#navbarRight');
-        var widthNavbarRight = navbarVisibility.right === true && window.getComputedStyle(right)['display'] !== "none" ? Math.ceil(qx.bom.element.Dimension.getWidth(right)) : 0;
+        var right = document.querySelector('#navbarRight'),
+          rightRect = right.getBoundingClientRect(),
+          widthNavbarRight = navbarVisibility.right === true && window.getComputedStyle(right)['display'] !== "none" ? Math.round(rightRect.right - rightRect.left) : 0;
         if (widthNavbarRight >= bodyWidth) {
           // Right-Navbar has the same size as the complete body, this can happen, when the navbar has no content
           // maybe there is a better solution to solve this problem
@@ -136,11 +138,16 @@ qx.Class.define('cv.ui.layout.Manager', {
       var topDisplay = window.getComputedStyle(top)['display'];
       var bottomNavDisplay = window.getComputedStyle(bottomNav)['display'];
       var bottomDisplay = window.getComputedStyle(bottom)['display'];
-      var topHeight = qx.bom.element.Dimension.getHeight(top);
-      var topNavHeight = qx.bom.element.Dimension.getHeight(topNav);
-      var bottomNavHeight = qx.bom.element.Dimension.getHeight(bottomNav);
-      var bottomHeight = qx.bom.element.Dimension.getHeight(bottom);
-      var navPathHeight = qx.bom.element.Dimension.getHeight(document.querySelector('.nav_path'));
+      var topRect = top.getBoundingClientRect();
+      var topHeight = Math.round(topRect.bottom - topRect.top);
+      var topNavRect = topNav.getBoundingClientRect();
+      var topNavHeight = Math.round(topNavRect.bottom - topNavRect.top);
+      var bottomNavRect = bottomNav.getBoundingClientRect();
+      var bottomNavHeight = Math.round(bottomNavRect.bottom - bottomNavRect.top);
+      var bottomRect = bottom.getBoundingClientRect();
+      var bottomHeight = Math.round(bottomRect.bottom - bottomRect.top);
+      var nav_pathRect = document.querySelector('.nav_path').getBoundingClientRect();
+      var navPathHeight = Math.round(nav_pathRect.bottom - nav_pathRect.top);
 
       if (topDisplay  !== 'none' && topHeight > 0) {
         this.currentPageUnavailableHeight += Math.max(topHeight, navPathHeight);

--- a/source/class/cv/ui/layout/Manager.js
+++ b/source/class/cv/ui/layout/Manager.js
@@ -93,14 +93,14 @@ qx.Class.define('cv.ui.layout.Manager', {
         var navbarVisibility = this.getCurrentPageNavbarVisibility();
 
         var left = document.querySelector('#navbarLeft');
-        var widthNavbarLeft = navbarVisibility.left === true && qx.bom.element.Style.get(left, 'display') !== "none" ? Math.ceil(qx.bom.element.Dimension.getWidth(left)) : 0;
+        var widthNavbarLeft = navbarVisibility.left === true && window.getComputedStyle(left)['display'] !== "none" ? Math.ceil(qx.bom.element.Dimension.getWidth(left)) : 0;
         if (widthNavbarLeft >= bodyWidth) {
           // Left-Navbar has the same size as the complete body, this can happen, when the navbar has no content
           // maybe there is a better solution to solve this problem
           widthNavbarLeft = 0;
         }
         var right = document.querySelector('#navbarRight');
-        var widthNavbarRight = navbarVisibility.right === true && qx.bom.element.Style.get(right, 'display') !== "none" ? Math.ceil(qx.bom.element.Dimension.getWidth(right)) : 0;
+        var widthNavbarRight = navbarVisibility.right === true && window.getComputedStyle(right)['display'] !== "none" ? Math.ceil(qx.bom.element.Dimension.getWidth(right)) : 0;
         if (widthNavbarRight >= bodyWidth) {
           // Right-Navbar has the same size as the complete body, this can happen, when the navbar has no content
           // maybe there is a better solution to solve this problem
@@ -132,10 +132,10 @@ qx.Class.define('cv.ui.layout.Manager', {
       var top = document.querySelector('#top');
       var bottomNav = document.querySelector('#navbarBottom');
       var bottom = document.querySelector('#bottom');
-      var topNavDisplay = qx.bom.element.Style.get(topNav, 'display');
-      var topDisplay = qx.bom.element.Style.get(top, 'display');
-      var bottomNavDisplay = qx.bom.element.Style.get(bottomNav, 'display');
-      var bottomDisplay = qx.bom.element.Style.get(bottom, 'display');
+      var topNavDisplay = window.getComputedStyle(topNav)['display'];
+      var topDisplay = window.getComputedStyle(top)['display'];
+      var bottomNavDisplay = window.getComputedStyle(bottomNav)['display'];
+      var bottomDisplay = window.getComputedStyle(bottom)['display'];
       var topHeight = qx.bom.element.Dimension.getHeight(top);
       var topNavHeight = qx.bom.element.Dimension.getHeight(topNav);
       var bottomNavHeight = qx.bom.element.Dimension.getHeight(bottomNav);
@@ -256,7 +256,7 @@ qx.Class.define('cv.ui.layout.Manager', {
 
     __applyWidthClass: function (elem, widthClassSuffix) {
       if (widthClassSuffix === 'auto') {
-        qx.bom.element.Style.set(elem, 'width', widthClassSuffix);
+        elem.style['width'] = widthClassSuffix;
       } else {
         switch (this.LAYOUT_MODE) {
           case 'GRID':
@@ -270,7 +270,7 @@ qx.Class.define('cv.ui.layout.Manager', {
             break;
 
           default:
-            qx.bom.element.Style.set(elem, 'width', widthClassSuffix);
+            elem.style['width'] = widthClassSuffix;
             break;
         }
       }

--- a/source/class/cv/ui/layout/Manager.js
+++ b/source/class/cv/ui/layout/Manager.js
@@ -92,14 +92,14 @@ qx.Class.define('cv.ui.layout.Manager', {
         this.currentPageUnavailableWidth = 0;
         var navbarVisibility = this.getCurrentPageNavbarVisibility();
 
-        var left = qx.bom.Selector.query('#navbarLeft')[0];
+        var left = document.querySelector('#navbarLeft');
         var widthNavbarLeft = navbarVisibility.left === true && qx.bom.element.Style.get(left, 'display') !== "none" ? Math.ceil(qx.bom.element.Dimension.getWidth(left)) : 0;
         if (widthNavbarLeft >= bodyWidth) {
           // Left-Navbar has the same size as the complete body, this can happen, when the navbar has no content
           // maybe there is a better solution to solve this problem
           widthNavbarLeft = 0;
         }
-        var right = qx.bom.Selector.query('#navbarRight')[0];
+        var right = document.querySelector('#navbarRight');
         var widthNavbarRight = navbarVisibility.right === true && qx.bom.element.Style.get(right, 'display') !== "none" ? Math.ceil(qx.bom.element.Dimension.getWidth(right)) : 0;
         if (widthNavbarRight >= bodyWidth) {
           // Right-Navbar has the same size as the complete body, this can happen, when the navbar has no content
@@ -128,10 +128,10 @@ qx.Class.define('cv.ui.layout.Manager', {
       var windowHeight = qx.bom.Viewport.getHeight();
       this.currentPageUnavailableHeight = 0;
       var navbarVisibility = this.getCurrentPageNavbarVisibility();
-      var topNav = qx.bom.Selector.query('#navbarTop')[0];
-      var top = qx.bom.Selector.query('#top')[0];
-      var bottomNav = qx.bom.Selector.query('#navbarBottom')[0];
-      var bottom = qx.bom.Selector.query('#bottom')[0];
+      var topNav = document.querySelector('#navbarTop');
+      var top = document.querySelector('#top');
+      var bottomNav = document.querySelector('#navbarBottom');
+      var bottom = document.querySelector('#bottom');
       var topNavDisplay = qx.bom.element.Style.get(topNav, 'display');
       var topDisplay = qx.bom.element.Style.get(top, 'display');
       var bottomNavDisplay = qx.bom.element.Style.get(bottomNav, 'display');
@@ -140,7 +140,7 @@ qx.Class.define('cv.ui.layout.Manager', {
       var topNavHeight = qx.bom.element.Dimension.getHeight(topNav);
       var bottomNavHeight = qx.bom.element.Dimension.getHeight(bottomNav);
       var bottomHeight = qx.bom.element.Dimension.getHeight(bottom);
-      var navPathHeight = qx.bom.element.Dimension.getHeight(qx.bom.Selector.query('.nav_path')[0]);
+      var navPathHeight = qx.bom.element.Dimension.getHeight(document.querySelector('.nav_path'));
 
       if (topDisplay  !== 'none' && topHeight > 0) {
         this.currentPageUnavailableHeight += Math.max(topHeight, navPathHeight);
@@ -196,7 +196,7 @@ qx.Class.define('cv.ui.layout.Manager', {
      */
     applyColumnWidths: function (selector, includeNavbars) {
       var width = this.getAvailableWidth();
-      var mainAreaColumns = qx.bom.element.Dataset.get(qx.bom.Selector.query('#main')[0], 'columns');
+      var mainAreaColumns = qx.bom.element.Dataset.get(document.querySelector('#main'), 'columns');
       var mainAreaColspan = parseInt(mainAreaColumns || cv.Config.defaultColumns);
 
       var pageSelector = selector ? selector : '#main .activePage';
@@ -211,7 +211,7 @@ qx.Class.define('cv.ui.layout.Manager', {
       selectors.forEach(function (area) {
         var allContainer = qx.bom.Selector.query(area + ' .widget_container');
         if (allContainer.length > 0) {
-          var areaColumns = qx.bom.element.Dataset.get(qx.bom.Selector.query(area)[0], 'columns');
+          var areaColumns = qx.bom.element.Dataset.get(document.querySelector(area), 'columns');
           var areaColspan = areaColumns || cv.Config.defaultColumns;
           allContainer.forEach(function(child) {
             var widget = cv.ui.structure.WidgetFactory.getInstanceByElement(child);

--- a/source/class/cv/ui/layout/Manager.js
+++ b/source/class/cv/ui/layout/Manager.js
@@ -266,7 +266,7 @@ qx.Class.define('cv.ui.layout.Manager', {
                 elem.classList.remove(cssClass);
               }
             }, this);
-            qx.bom.element.Class.add(elem, 'width-' + parseInt(widthClassSuffix));
+            elem.classList.add('width-' + parseInt(widthClassSuffix));
             break;
 
           default:

--- a/source/class/cv/ui/layout/Manager.js
+++ b/source/class/cv/ui/layout/Manager.js
@@ -85,7 +85,7 @@ qx.Class.define('cv.ui.layout.Manager', {
       // currently this calculation is done once after every page scroll (where cv.TemplateEngine.getInstance()currentPageUnavailableWidth is reseted)
       // if the screen width falls below the threshold which activates/deactivates the mobile.css
       // the calculation has to be done again, even if the page hasn´t changed (e.g. switching between portrait and landscape mode on a mobile can cause that)
-      var bodyWidth = qx.bom.Viewport.getWidth();
+      var bodyWidth = document.documentElement.clientWidth;
       var mobileUseChanged = (this.lastBodyWidth < cv.Config.maxMobileScreenWidth) !== (bodyWidth < cv.Config.maxMobileScreenWidth);
       if (this.currentPageUnavailableWidth < 0 || mobileUseChanged || true) {
         //      console.log("Mobile.css use changed "+mobileUseChanged);
@@ -127,7 +127,7 @@ qx.Class.define('cv.ui.layout.Manager', {
      *         because the value of main.position().top is not reliable all the time
      */
     getAvailableHeight: function () {
-      var windowHeight = qx.bom.Viewport.getHeight();
+      var windowHeight = document.documentElement.clientHeight;
       this.currentPageUnavailableHeight = 0;
       var navbarVisibility = this.getCurrentPageNavbarVisibility();
       var topNav = document.querySelector('#navbarTop');

--- a/source/class/cv/ui/layout/Manager.js
+++ b/source/class/cv/ui/layout/Manager.js
@@ -249,7 +249,7 @@ qx.Class.define('cv.ui.layout.Manager', {
             var groupColspan = mainAreaColspan;
             var parentGroupElement = cv.util.Tree.getParent(e, '.widget_container', '.group', 1)[0];
             if (parentGroupElement) {
-              var parentGroupWidget = cv.ui.structure.WidgetFactory.getInstanceByElement(qx.dom.Element.getParentElement(parentGroupElement));
+              var parentGroupWidget = cv.ui.structure.WidgetFactory.getInstanceByElement(parentGroupElement.parentNode);
               if (parentGroupWidget) {
                 groupColspan = Math.min(mainAreaColspan, this.getWidgetColspan(parentGroupWidget, width));
               }

--- a/source/class/cv/ui/layout/ResizeHandler.js
+++ b/source/class/cv/ui/layout/ResizeHandler.js
@@ -231,8 +231,8 @@ qx.Class.define('cv.ui.layout.ResizeHandler', {
         var navbarTop = this.getNavbarTop();
         var navbarBottom = this.getNavbarBottom();
         if (
-          (qx.bom.element.Style.get(navbarTop, 'display') !== 'none' && qx.bom.element.Dimension.getHeight(navbarTop) <= 2) ||
-          (qx.bom.element.Style.get(navbarBottom, 'display') !== 'none' && qx.bom.element.Dimension.getHeight(navbarBottom) <= 2)
+          (window.getComputedStyle(navbarTop)['display'] !== 'none' && qx.bom.element.Dimension.getHeight(navbarTop) <= 2) ||
+          (window.getComputedStyle(navbarBottom)['display'] !== 'none' && qx.bom.element.Dimension.getHeight(navbarBottom) <= 2)
         ) {
           // Top/Bottom-Navbar is not initialized yet, re-queue the job
           new qx.util.DeferredCall(function() {

--- a/source/class/cv/ui/layout/ResizeHandler.js
+++ b/source/class/cv/ui/layout/ResizeHandler.js
@@ -162,7 +162,7 @@ qx.Class.define('cv.ui.layout.ResizeHandler', {
               height: backdropHeight + 'px',
               left: backdropLeft + 'px',
               top: backdropTop + 'px'
-            }).forEach(function(key,value){backdrop.style[key]=value;});
+            }).forEach(function([key,value]){backdrop.style[key]=value;});
           }
 
           page.getDomElement().querySelectorAll('.widget_container').forEach(function (widgetContainer) {

--- a/source/class/cv/ui/layout/ResizeHandler.js
+++ b/source/class/cv/ui/layout/ResizeHandler.js
@@ -306,7 +306,8 @@ qx.Class.define('cv.ui.layout.ResizeHandler', {
         height = Math.round(rect.bottom - rect.top);
       if (height === 0) {
         // not ready try again
-        qx.bom.AnimationFrame.request(qx.lang.Function.curry(this.__updateRowHeight, elem), this);
+        var self = this;
+        qx.bom.AnimationFrame.request(function(){self.__updateRowHeight(elem);}, this);
         return;
       }
       var styles = '';

--- a/source/class/cv/ui/layout/ResizeHandler.js
+++ b/source/class/cv/ui/layout/ResizeHandler.js
@@ -165,7 +165,7 @@ qx.Class.define('cv.ui.layout.ResizeHandler', {
             });
           }
 
-          qx.bom.Selector.query('.widget_container', page.getDomElement()).forEach(function (widgetContainer) {
+          page.getDomElement().querySelectorAll('.widget_container').forEach(function (widgetContainer) {
             var widget = cv.ui.structure.WidgetFactory.getInstanceById(widgetContainer.id);
             var value;
             var layout = widget.getResponsiveLayout();
@@ -309,7 +309,7 @@ qx.Class.define('cv.ui.layout.ResizeHandler', {
       for (var rowspan in cv.Config.configSettings.usedRowspans) {
         styles += '.rowspan.rowspan' + rowspan + ' { height: ' + Math.round(rowspan * height) + "px;}\n";
       }
-      qx.bom.Selector.query("#calcrowspan").forEach(qx.dom.Element.remove, qx.dom.Element);
+      document.querySelectorAll("#calcrowspan").forEach(qx.dom.Element.remove, qx.dom.Element);
 
       // set css style
       var rowSpanStyle = document.querySelector('#rowspanStyle');

--- a/source/class/cv/ui/layout/ResizeHandler.js
+++ b/source/class/cv/ui/layout/ResizeHandler.js
@@ -294,7 +294,7 @@ qx.Class.define('cv.ui.layout.ResizeHandler', {
           "id": "calcrowspan",
           "html": '<div id="containerDiv" class="widget_container"><div class="widget clearfix text" id="innerDiv"></div>'
         });
-        qx.dom.Element.insertEnd(elem, document.body);
+        document.body.appendChild(elem);
       }
       // use the internal div for height as in mobile view the elem uses the full screen height
       this.__updateRowHeight(elem.querySelector("#containerDiv"));
@@ -314,7 +314,10 @@ qx.Class.define('cv.ui.layout.ResizeHandler', {
       for (var rowspan in cv.Config.configSettings.usedRowspans) {
         styles += '.rowspan.rowspan' + rowspan + ' { height: ' + Math.round(rowspan * height) + "px;}\n";
       }
-      document.querySelectorAll("#calcrowspan").forEach(qx.dom.Element.remove, qx.dom.Element);
+      var calcrowspan = document.querySelector("#calcrowspan");
+      if( calcrowspan ) {
+        calcrowspan.parentNode.removeChild(calcrowspan);
+      }
 
       // set css style
       var rowSpanStyle = document.querySelector('#rowspanStyle');

--- a/source/class/cv/ui/layout/ResizeHandler.js
+++ b/source/class/cv/ui/layout/ResizeHandler.js
@@ -162,7 +162,7 @@ qx.Class.define('cv.ui.layout.ResizeHandler', {
               height: backdropHeight + 'px',
               left: backdropLeft + 'px',
               top: backdropTop + 'px'
-            }).forEach(function([key,value]){backdrop.style[key]=value;});
+            }).forEach(function(key_value){backdrop.style[key_value[0]]=key_value[1];});
           }
 
           page.getDomElement().querySelectorAll('.widget_container').forEach(function (widgetContainer) {

--- a/source/class/cv/ui/layout/ResizeHandler.js
+++ b/source/class/cv/ui/layout/ResizeHandler.js
@@ -62,21 +62,21 @@ qx.Class.define('cv.ui.layout.ResizeHandler', {
 
     getPageSize: function (noCache) {
       if (!this.$pageSize || noCache === true) {
-        this.$pageSize = qx.bom.Selector.query('#pageSize')[0];
+        this.$pageSize = document.querySelector('#pageSize');
       }
       return this.$pageSize;
     },
 
     getNavbarTop: function (noCache) {
       if (!this.$navbarTop || noCache === true) {
-        this.$navbarTop = qx.bom.Selector.query('#navbarTop')[0];
+        this.$navbarTop = document.querySelector('#navbarTop');
       }
       return this.$navbarTop;
     },
 
     getNavbarBottom: function (noCache) {
       if (!this.$navbarBottom || noCache === true) {
-        this.$navbarBottom = qx.bom.Selector.query('#navbarBottom')[0];
+        this.$navbarBottom = document.querySelector('#navbarBottom');
       }
       return this.$navbarBottom;
     },
@@ -122,7 +122,7 @@ qx.Class.define('cv.ui.layout.ResizeHandler', {
       if ('2d' === page.getPageType()) {
         var
           cssPosRegEx = /(\d*)(.*)/,
-          backdrop = qx.bom.Selector.query("div > "+page.getBackdropType(), page.getDomElement())[0];
+          backdrop = page.getDomElement().querySelector("div > "+page.getBackdropType());
         try {
           var backdropSVG = page.getBackdropType() === 'embed' ? backdrop.getSVGDocument() : null;
           var backdropBBox = backdropSVG ? backdropSVG.children[0].getBBox() : {},
@@ -284,7 +284,7 @@ qx.Class.define('cv.ui.layout.ResizeHandler', {
 
     __makeRowspanValid: function () {
       qx.log.Logger.debug(this, "makeRowspanValid");
-      var elem = qx.bom.Selector.query("#calcrowspan")[0];
+      var elem = document.querySelector("#calcrowspan");
       if (!elem) {
         elem = qx.dom.Element.create("div", {
           "class": "clearfix",
@@ -294,7 +294,7 @@ qx.Class.define('cv.ui.layout.ResizeHandler', {
         qx.dom.Element.insertEnd(elem, document.body);
       }
       // use the internal div for height as in mobile view the elem uses the full screen height
-      this.__updateRowHeight(qx.bom.Selector.query("#containerDiv", elem)[0]);
+      this.__updateRowHeight(elem.querySelector("#containerDiv"));
     },
 
     __updateRowHeight: function(elem) {
@@ -312,7 +312,7 @@ qx.Class.define('cv.ui.layout.ResizeHandler', {
       qx.bom.Selector.query("#calcrowspan").forEach(qx.dom.Element.remove, qx.dom.Element);
 
       // set css style
-      var rowSpanStyle = qx.bom.Selector.query('#rowspanStyle')[0];
+      var rowSpanStyle = document.querySelector('#rowspanStyle');
       if (rowSpanStyle) {
         rowSpanStyle.innerHTML = styles;
       }

--- a/source/class/cv/ui/layout/ResizeHandler.js
+++ b/source/class/cv/ui/layout/ResizeHandler.js
@@ -228,11 +228,14 @@ qx.Class.define('cv.ui.layout.ResizeHandler', {
       if (cv.Config.mobileDevice) {
         //do nothing
       } else {
-        var navbarTop = this.getNavbarTop();
-        var navbarBottom = this.getNavbarBottom();
+        var
+          navbarTop = this.getNavbarTop(),
+          navbarTopRect = navbarTop.getBoundingClientRect(),
+          navbarBottom = this.getNavbarBottom(),
+          navbarBottomRect = navbarBottom.getBoundingClientRect();
         if (
-          (window.getComputedStyle(navbarTop)['display'] !== 'none' && qx.bom.element.Dimension.getHeight(navbarTop) <= 2) ||
-          (window.getComputedStyle(navbarBottom)['display'] !== 'none' && qx.bom.element.Dimension.getHeight(navbarBottom) <= 2)
+          (window.getComputedStyle(navbarTop)['display'] !== 'none' && Math.round(navbarTopRect.bottom - navbarTopRect.top) <= 2) ||
+          (window.getComputedStyle(navbarBottom)['display'] !== 'none' && Math.round(navbarBottomRect.bottom - navbarBottomRect.top) <= 2)
         ) {
           // Top/Bottom-Navbar is not initialized yet, re-queue the job
           new qx.util.DeferredCall(function() {
@@ -298,7 +301,9 @@ qx.Class.define('cv.ui.layout.ResizeHandler', {
     },
 
     __updateRowHeight: function(elem) {
-      var height = qx.bom.element.Dimension.getHeight(elem);
+      var
+        rect = elem.getBoundingClientRect(),
+        height = Math.round(rect.bottom - rect.top);
       if (height === 0) {
         // not ready try again
         qx.bom.AnimationFrame.request(qx.lang.Function.curry(this.__updateRowHeight, elem), this);

--- a/source/class/cv/ui/layout/ResizeHandler.js
+++ b/source/class/cv/ui/layout/ResizeHandler.js
@@ -157,12 +157,12 @@ qx.Class.define('cv.ui.layout.ResizeHandler', {
             page.getBackdropType() === 'embed' ||
             ( uagent.indexOf('safari') !== -1 && uagent.indexOf('chrome') === -1 )
           ) {
-            qx.bom.element.Style.setStyles(backdrop, {
+            Object.entries({
               width: backdropWidth + 'px',
               height: backdropHeight + 'px',
               left: backdropLeft + 'px',
               top: backdropTop + 'px'
-            });
+            }).forEach(function(key,value){backdrop.style[key]=value;});
           }
 
           page.getDomElement().querySelectorAll('.widget_container').forEach(function (widgetContainer) {

--- a/source/class/cv/ui/structure/AbstractBasicWidget.js
+++ b/source/class/cv/ui/structure/AbstractBasicWidget.js
@@ -95,7 +95,16 @@ qx.Class.define('cv.ui.structure.AbstractBasicWidget', {
      * @return {Element}
      */
     getDomElement: function() {
-      return qx.bom.Selector.query('#'+this.getPath())[0];
+      var element = document.querySelector('#'+this.getPath());
+      if( null === element ) {
+        // TODO and FIXME: no code should rely on a return of `document` here.
+        // But currently it is required as this is the behaviour that Qx had
+        // when it called getAttribute().
+        // This is only an issue for the Karma tests.
+        console.warn( 'Compatability mode used - everything should be set up, so that getDomElement() can return the element and not `document` instead.', this.get$$type(), this.getPath());
+        return document;
+      }
+      return element;
     },
 
     /**

--- a/source/class/cv/ui/structure/AbstractWidget.js
+++ b/source/class/cv/ui/structure/AbstractWidget.js
@@ -342,7 +342,7 @@ qx.Class.define('cv.ui.structure.AbstractWidget', {
       if (this.isAnonymous()) { return; }
       var widget = this.getInteractionElement();
       if (widget) {
-        qx.bom.element.Dataset.set(widget, "longtapable", type !== "longtap");
+        widget.dataset["longtapable"] = type !== "longtap";
         return qx.event.Registration.addListener(widget, type, callback, context);
       }
       return null;

--- a/source/class/cv/ui/structure/AbstractWidget.js
+++ b/source/class/cv/ui/structure/AbstractWidget.js
@@ -200,7 +200,7 @@ qx.Class.define('cv.ui.structure.AbstractWidget', {
      * @return {Element}
      */
     getActor: function() {
-      return qx.bom.Selector.query('.actor', this.getDomElement())[0];
+      return this.getDomElement().querySelector('.actor');
     },
 
     /**
@@ -208,7 +208,7 @@ qx.Class.define('cv.ui.structure.AbstractWidget', {
      * @return {Element}
      */
     getValueElement: function() {
-      return qx.bom.Selector.query(".value", this.getDomElement())[0];
+      return this.getDomElement().querySelector(".value");
     },
 
     /**
@@ -216,7 +216,7 @@ qx.Class.define('cv.ui.structure.AbstractWidget', {
      * @return {Element}
      */
     getWidgetElement: function() {
-      return qx.bom.Selector.query('.widget', this.getDomElement())[0];
+      return this.getDomElement().querySelector('.widget');
     },
 
     /**

--- a/source/class/cv/ui/structure/WidgetFactory.js
+++ b/source/class/cv/ui/structure/WidgetFactory.js
@@ -67,7 +67,7 @@ qx.Class.define('cv.ui.structure.WidgetFactory', {
     },
 
     getInstanceByElement: function(element) {
-      var instance = this.getInstanceById(qx.bom.element.Attribute.get(element, 'id'));
+      var instance = this.getInstanceById(element.getAttribute('id'));
       if (instance && cv.Config.lazyLoading === true && instance._onDomReady && !instance.$$domReady) {
         // apply listeners and update initial value
         instance._onDomReady();

--- a/source/class/cv/ui/structure/WidgetFactory.js
+++ b/source/class/cv/ui/structure/WidgetFactory.js
@@ -40,7 +40,7 @@ qx.Class.define('cv.ui.structure.WidgetFactory', {
 
     createInstance: function (type, data) {
       if (!this.registry[data.path]) {
-        if (!cv.ui.structure.pure[qx.lang.String.firstUp(type)]) {
+        if (!cv.ui.structure.pure[type.charAt(0).toUpperCase() + type.substr(1)]) {
           var clazz = this.__typeMapping[type];
           if (clazz) {
             this.registry[data.path] = new clazz(data); // jshint ignore:line
@@ -49,8 +49,8 @@ qx.Class.define('cv.ui.structure.WidgetFactory', {
             return null;
           }
         } else {
-          // console.log(data.path+" cv.ui.structure.pure."+qx.lang.String.firstUp(type));
-          this.registry[data.path] = new cv.ui.structure.pure[qx.lang.String.firstUp(type)](data);
+          // console.log(data.path+" cv.ui.structure.pure."+type.charAt(0).toUpperCase() + type.substr(1));
+          this.registry[data.path] = new cv.ui.structure.pure[type.charAt(0).toUpperCase() + type.substr(1)](data);
         }
         this.c++;
       }

--- a/source/class/cv/ui/structure/pure/Audio.js
+++ b/source/class/cv/ui/structure/pure/Audio.js
@@ -79,7 +79,7 @@
 
       // overridden
       getActor: function() {
-        return qx.bom.Selector.query(".actor audio", this.getDomElement())[0];
+        return this.getDomElement().querySelector(".actor audio");
       },
 
       /**

--- a/source/class/cv/ui/structure/pure/DesignToggle.js
+++ b/source/class/cv/ui/structure/pure/DesignToggle.js
@@ -80,7 +80,7 @@ qx.Class.define('cv.ui.structure.pure.DesignToggle', {
 
       var designs = this.getAvailableDesigns();
 
-      var oldDesign = qx.bom.Selector.query('.value',this.getDomElement())[0].textContent;
+      var oldDesign = this.getDomElement().querySelector('.value').textContent;
       var newDesign = designs.getItem((designs.indexOf(oldDesign) + 1) % designs.length);
 
       var URL = cv.util.Location.getHref();

--- a/source/class/cv/ui/structure/pure/Group.js
+++ b/source/class/cv/ui/structure/pure/Group.js
@@ -123,7 +123,7 @@ qx.Class.define('cv.ui.structure.pure.Group', {
     // overridden
     _onDomReady: function() {
       this.base(arguments);
-      qx.bom.element.Style.set(this.getDomElement(), "z-index", 1);
+      this.getDomElement().style["z-index"] = 1;
     },
 
     // overridden

--- a/source/class/cv/ui/structure/pure/Image.js
+++ b/source/class/cv/ui/structure/pure/Image.js
@@ -99,9 +99,9 @@ qx.Class.define('cv.ui.structure.pure.Image', {
         return;
       }
       if (value === true) {
-        qx.bom.element.Attribute.set(valueElem, "src", this.__getSrc());
+        valueElem.setAttribute("src", this.__getSrc());
       } else {
-        qx.bom.element.Attribute.set(valueElem, "src", "");
+        valueElem.setAttribute("src", "");
       }
     }
   },

--- a/source/class/cv/ui/structure/pure/Image.js
+++ b/source/class/cv/ui/structure/pure/Image.js
@@ -89,7 +89,7 @@ qx.Class.define('cv.ui.structure.pure.Image', {
 
     // overridden
     getValueElement: function() {
-      return qx.bom.Selector.query("img", this.getDomElement())[0];
+      return this.getDomElement().querySelector("img");
     },
 
     // overridden

--- a/source/class/cv/ui/structure/pure/ImageTrigger.js
+++ b/source/class/cv/ui/structure/pure/ImageTrigger.js
@@ -124,7 +124,7 @@ qx.Class.define('cv.ui.structure.pure.ImageTrigger', {
     },
 
     _update: function(address, value) {
-      var imageChild = qx.bom.Selector.query("img", this.getDomElement())[0];
+      var imageChild = this.getDomElement().querySelector("img");
       if (this.getUpdateType() === "show") {
         if (value === 0) {
           qx.bom.element.Style.set(imageChild, "display", "none");

--- a/source/class/cv/ui/structure/pure/ImageTrigger.js
+++ b/source/class/cv/ui/structure/pure/ImageTrigger.js
@@ -101,7 +101,7 @@ qx.Class.define('cv.ui.structure.pure.ImageTrigger', {
     _getInnerDomString: function () {
 
       var style = "";
-      if (qx.lang.Object.isEmpty(this.getLayout())) {
+      if (Object.keys(this.getLayout()).length === 0) {
         style += cv.parser.WidgetParser.extractLayout(this.getLayout(), this.getPageType());
       }
       if (this.getHeight()) {

--- a/source/class/cv/ui/structure/pure/ImageTrigger.js
+++ b/source/class/cv/ui/structure/pure/ImageTrigger.js
@@ -130,7 +130,7 @@ qx.Class.define('cv.ui.structure.pure.ImageTrigger', {
           qx.bom.element.Style.set(imageChild, "display", "none");
         }
         else {
-          qx.bom.element.Attribute.set(imageChild, "src", this.__getUrl(this.getSrc() + '.' + this.getSuffix()));
+          imageChild.setAttribute("src", this.__getUrl(this.getSrc() + '.' + this.getSuffix()));
           qx.bom.element.Style.set(imageChild, "display", "block");
         }
       }
@@ -139,7 +139,7 @@ qx.Class.define('cv.ui.structure.pure.ImageTrigger', {
           qx.bom.element.Style.set(imageChild, "display", "none");
         }
         else {
-          qx.bom.element.Attribute.set(imageChild, "src", this.__getUrl(this.getSrc() + value + '.' + this.getSuffix()));
+          imageChild.setAttribute("src", this.__getUrl(this.getSrc() + value + '.' + this.getSuffix()));
           qx.bom.element.Style.set(imageChild, "display", "block");
         }
       }

--- a/source/class/cv/ui/structure/pure/ImageTrigger.js
+++ b/source/class/cv/ui/structure/pure/ImageTrigger.js
@@ -127,20 +127,20 @@ qx.Class.define('cv.ui.structure.pure.ImageTrigger', {
       var imageChild = this.getDomElement().querySelector("img");
       if (this.getUpdateType() === "show") {
         if (value === 0) {
-          qx.bom.element.Style.set(imageChild, "display", "none");
+          imageChild.style["display"] = "none";
         }
         else {
           imageChild.setAttribute("src", this.__getUrl(this.getSrc() + '.' + this.getSuffix()));
-          qx.bom.element.Style.set(imageChild, "display", "block");
+          imageChild.style["display"] = "block";
         }
       }
       else if (this.getUpdateType() === "select") {
         if (value === 0) {
-          qx.bom.element.Style.set(imageChild, "display", "none");
+          imageChild.style["display"] = "none";
         }
         else {
           imageChild.setAttribute("src", this.__getUrl(this.getSrc() + value + '.' + this.getSuffix()));
-          qx.bom.element.Style.set(imageChild, "display", "block");
+          imageChild.style["display"] = "block";
         }
       }
 

--- a/source/class/cv/ui/structure/pure/ImageTrigger.js
+++ b/source/class/cv/ui/structure/pure/ImageTrigger.js
@@ -127,20 +127,20 @@ qx.Class.define('cv.ui.structure.pure.ImageTrigger', {
       var imageChild = this.getDomElement().querySelector("img");
       if (this.getUpdateType() === "show") {
         if (value === 0) {
-          imageChild.style["display"] = "none";
+          imageChild.style.display = "none";
         }
         else {
           imageChild.setAttribute("src", this.__getUrl(this.getSrc() + '.' + this.getSuffix()));
-          imageChild.style["display"] = "block";
+          imageChild.style.display = "block";
         }
       }
       else if (this.getUpdateType() === "select") {
         if (value === 0) {
-          imageChild.style["display"] = "none";
+          imageChild.style.display = "none";
         }
         else {
           imageChild.setAttribute("src", this.__getUrl(this.getSrc() + value + '.' + this.getSuffix()));
-          imageChild.style["display"] = "block";
+          imageChild.style.display = "block";
         }
       }
 

--- a/source/class/cv/ui/structure/pure/InfoTrigger.js
+++ b/source/class/cv/ui/structure/pure/InfoTrigger.js
@@ -149,9 +149,9 @@ qx.Class.define('cv.ui.structure.pure.InfoTrigger', {
     },
 
     __findActor: function (element) {
-      while (!qx.bom.element.Class.has(element, 'actor')) {
+      while (!element.classList.contains('actor')) {
         element = element.parentNode;
-        if (qx.bom.element.Class.has(element, 'widget')) {
+        if (element.classList.contains('widget')) {
           // thats too far
           return null;
         }
@@ -160,11 +160,11 @@ qx.Class.define('cv.ui.structure.pure.InfoTrigger', {
     },
 
     _onLongTap: function(event) {
-      this.__action(false, qx.bom.element.Class.has(this.__findActor(event.getCurrentTarget()), 'downlabel'));
+      this.__action(false, this.__findActor(event.getCurrentTarget()).classList.contains('downlabel'));
     },
 
     _action: function(event) {
-      this.__action(true, qx.bom.element.Class.has(this.__findActor(event.getCurrentTarget()), 'downlabel'));
+      this.__action(true, this.__findActor(event.getCurrentTarget()).classList.contains('downlabel'));
     },
 
     __action: function (isShort, isDown) {

--- a/source/class/cv/ui/structure/pure/InfoTrigger.js
+++ b/source/class/cv/ui/structure/pure/InfoTrigger.js
@@ -192,15 +192,15 @@ qx.Class.define('cv.ui.structure.pure.InfoTrigger', {
     },
 
     getDownActor: function() {
-      return qx.bom.Selector.query(".actor.downlabel", this.getDomElement())[0];
+      return this.getDomElement().querySelector(".actor.downlabel");
     },
 
     getUpActor: function() {
-      return qx.bom.Selector.query(".actor.uplabel", this.getDomElement())[0];
+      return this.getDomElement().querySelector(".actor.uplabel");
     },
 
     getInfoActor: function() {
-      return qx.bom.Selector.query(".actor.switchInvisible", this.getDomElement())[0];
+      return this.getDomElement().querySelector(".actor.switchInvisible");
     }
   },
 

--- a/source/class/cv/ui/structure/pure/InfoTrigger.js
+++ b/source/class/cv/ui/structure/pure/InfoTrigger.js
@@ -137,7 +137,7 @@ qx.Class.define('cv.ui.structure.pure.InfoTrigger', {
     },
 
     getActors: function(){
-      return qx.bom.Selector.query(".actor.uplabel, .actor.downlabel", this.getDomElement());
+      return this.getDomElement().querySelectorAll(".actor.uplabel, .actor.downlabel");
     },
 
     // overridden

--- a/source/class/cv/ui/structure/pure/MultiTrigger.js
+++ b/source/class/cv/ui/structure/pure/MultiTrigger.js
@@ -124,7 +124,8 @@ qx.Class.define('cv.ui.structure.pure.MultiTrigger', {
         children.forEach(function (element, i) {
           value = this.defaultValueHandling(undefined, this['getButton' + (i + 1) + 'value']());
           element.innerHTML = '';
-          this.defaultValue2DOM(value, qx.lang.Function.curry(this._applyValueToDom, element));
+          var self = this;
+          this.defaultValue2DOM(value, function(e){self._applyValueToDom(element,e);});
         }, this);
       }
     },

--- a/source/class/cv/ui/structure/pure/MultiTrigger.js
+++ b/source/class/cv/ui/structure/pure/MultiTrigger.js
@@ -150,8 +150,8 @@ qx.Class.define('cv.ui.structure.pure.MultiTrigger', {
         // delay this a little bit to give the HasAnimatedButton stuff time to finish
         // otherwise it might override the settings here
         new qx.util.DeferredCall(function() {
-          qx.bom.element.Class.remove(actor, isPressed ? 'switchUnpressed' : 'switchPressed');
-          qx.bom.element.Class.add(actor, isPressed ? 'switchPressed' : 'switchUnpressed');
+          actor.classList.remove(isPressed ? 'switchUnpressed' : 'switchPressed');
+          actor.classList.add(isPressed ? 'switchPressed' : 'switchUnpressed');
         }, this).schedule();
       }, this);
     },

--- a/source/class/cv/ui/structure/pure/MultiTrigger.js
+++ b/source/class/cv/ui/structure/pure/MultiTrigger.js
@@ -117,7 +117,7 @@ qx.Class.define('cv.ui.structure.pure.MultiTrigger', {
     _onDomReady: function() {
       this.base(arguments);
       var actor = this.getActor();
-      var children = qx.dom.Hierarchy.getChildElements(actor);
+      var children = actor.childNodes;
       var value;
 
       if (this.getMapping()) {

--- a/source/class/cv/ui/structure/pure/MultiTrigger.js
+++ b/source/class/cv/ui/structure/pure/MultiTrigger.js
@@ -130,7 +130,7 @@ qx.Class.define('cv.ui.structure.pure.MultiTrigger', {
     },
 
     getActors: function(){
-      return qx.bom.Selector.query('.actor_container .actor', this.getDomElement());
+      return this.getDomElement().querySelectorAll('.actor_container .actor');
     },
 
     // overridden, only transform the value, do not apply it to DOM
@@ -144,7 +144,7 @@ qx.Class.define('cv.ui.structure.pure.MultiTrigger', {
     handleUpdate: function () {
       var children = this.getActors();
       children.forEach(function(actor) {
-        var index = children.indexOf(actor)+1;
+        var index = Array.prototype.indexOf.call( children, actor )+1;
         var isPressed = (''+this.getBasicValue()) === (''+this['getButton' + index + 'value']()); // compare as string
 
         // delay this a little bit to give the HasAnimatedButton stuff time to finish
@@ -161,7 +161,7 @@ qx.Class.define('cv.ui.structure.pure.MultiTrigger', {
      *
      */
     getActionValue: function (event) {
-      var index = qx.bom.Selector.query('.actor_container .actor', this.getDomElement()).indexOf(event.getCurrentTarget())+1;
+      var index = Array.prototype.indexOf.call( this.getDomElement().querySelectorAll('.actor_container .actor'), event.getCurrentTarget() )+1;
       return this['getButton' + index + 'value']();
     },
 

--- a/source/class/cv/ui/structure/pure/MultiTrigger.js
+++ b/source/class/cv/ui/structure/pure/MultiTrigger.js
@@ -123,7 +123,7 @@ qx.Class.define('cv.ui.structure.pure.MultiTrigger', {
       if (this.getMapping()) {
         children.forEach(function (element, i) {
           value = this.defaultValueHandling(undefined, this['getButton' + (i + 1) + 'value']());
-          qx.dom.Element.empty(element);
+          element.innerHTML = '';
           this.defaultValue2DOM(value, qx.lang.Function.curry(this._applyValueToDom, element));
         }, this);
       }

--- a/source/class/cv/ui/structure/pure/NavBar.js
+++ b/source/class/cv/ui/structure/pure/NavBar.js
@@ -83,7 +83,7 @@ qx.Class.define('cv.ui.structure.pure.NavBar', {
     initializeNavbars: function() {
       ['Top', 'Left', 'Right', 'Bottom'].forEach(function(pos) {
         if (this['_navbar'+pos]) {
-          var elem = qx.bom.Selector.query('#navbar'+pos)[0];
+          var elem = document.querySelector('#navbar'+pos);
           if (elem) {
             elem.innerHTML += this['_navbar' + pos];
           }
@@ -103,8 +103,8 @@ qx.Class.define('cv.ui.structure.pure.NavBar', {
 
     // overridden
     _onDomReady: function() {
-      var left = qx.bom.Selector.query('#navbarLeft')[0];
-      var right = qx.bom.Selector.query('#navbarRight')[0];
+      var left = document.querySelector('#navbarLeft');
+      var right = document.querySelector('#navbarRight');
       this.__navbarLeftSize = left ? qx.bom.element.Dataset.get(left, 'size') : 0;
       this.__navbarRightSize = right ? qx.bom.element.Dataset.get(right, 'size') : 0;
     },

--- a/source/class/cv/ui/structure/pure/NavBar.js
+++ b/source/class/cv/ui/structure/pure/NavBar.js
@@ -105,8 +105,8 @@ qx.Class.define('cv.ui.structure.pure.NavBar', {
     _onDomReady: function() {
       var left = document.querySelector('#navbarLeft');
       var right = document.querySelector('#navbarRight');
-      this.__navbarLeftSize = left ? qx.bom.element.Dataset.get(left, 'size') : 0;
-      this.__navbarRightSize = right ? qx.bom.element.Dataset.get(right, 'size') : 0;
+      this.__navbarLeftSize = left ? left.dataset['size'] : 0;
+      this.__navbarRightSize = right ? right.dataset['size'] : 0;
     },
     
     getGlobalPath: function () {

--- a/source/class/cv/ui/structure/pure/NotificationCenterBadge.js
+++ b/source/class/cv/ui/structure/pure/NotificationCenterBadge.js
@@ -118,7 +118,7 @@ qx.Class.define('cv.ui.structure.pure.NotificationCenterBadge', {
       var messages = cv.ui.NotificationCenter.getInstance().getMessages().length;
       this.__getBadgeElement().innerHTML = ""+messages;
       if (this.isHideWhenEmpty()) {
-        qx.bom.element.Style.set(this.__getBadgeElement(), "display", messages === 0 ? "none" : "block");
+        this.__getBadgeElement().style["display"] = messages === 0 ? "none" : "block";
       }
     },
 

--- a/source/class/cv/ui/structure/pure/NotificationCenterBadge.js
+++ b/source/class/cv/ui/structure/pure/NotificationCenterBadge.js
@@ -42,11 +42,13 @@ qx.Class.define('cv.ui.structure.pure.NotificationCenterBadge', {
   ******************************************************
   */
   construct: function(props) {
-    var classes = props.classes.trim().split(" ");
-    if (classes.indexOf("right")) {
+    var classes = props.classes.trim().split(" "),
+        i_right = classes.indexOf("right");
+
+    if (i_right !== -1) {
       // do not align, but float the container instead
       this.setContainerClass("float-right");
-      qx.lang.Array.remove(classes, "right");
+      classes.splice(i_right, 1);
       props.classes = classes.join(" ");
     }
     this.base(arguments, props);

--- a/source/class/cv/ui/structure/pure/NotificationCenterBadge.js
+++ b/source/class/cv/ui/structure/pure/NotificationCenterBadge.js
@@ -101,7 +101,7 @@ qx.Class.define('cv.ui.structure.pure.NotificationCenterBadge', {
 
     __getBadgeElement: function() {
       if (!this.__badgeElement) {
-        this.__badgeElement = qx.bom.Selector.query(".badge", this.getDomElement())[0];
+        this.__badgeElement = this.getDomElement().querySelector(".badge");
       }
       return this.__badgeElement;
     },

--- a/source/class/cv/ui/structure/pure/NotificationCenterBadge.js
+++ b/source/class/cv/ui/structure/pure/NotificationCenterBadge.js
@@ -115,7 +115,7 @@ qx.Class.define('cv.ui.structure.pure.NotificationCenterBadge', {
 
     _onChangeCounter: function() {
       var messages = cv.ui.NotificationCenter.getInstance().getMessages().length;
-      qx.bom.element.Attribute.set(this.__getBadgeElement(), "html", ""+messages);
+      this.__getBadgeElement().setAttribute("html", ""+messages);
       if (this.isHideWhenEmpty()) {
         qx.bom.element.Style.set(this.__getBadgeElement(), "display", messages === 0 ? "none" : "block");
       }

--- a/source/class/cv/ui/structure/pure/NotificationCenterBadge.js
+++ b/source/class/cv/ui/structure/pure/NotificationCenterBadge.js
@@ -107,9 +107,10 @@ qx.Class.define('cv.ui.structure.pure.NotificationCenterBadge', {
     },
 
     _onChangeGlobalSeverity: function(ev) {
-      qx.bom.element.Class.removeClasses(this.__getBadgeElement(), cv.ui.NotificationCenter.getInstance().getSeverities());
+      var classList = this.__getBadgeElement().classList;
+      classList.remove.apply( classList, cv.ui.NotificationCenter.getInstance().getSeverities() );
       if (ev.getData()) {
-        qx.bom.element.Class.add(this.__getBadgeElement(), ev.getData());
+        classList.add(ev.getData());
       }
     },
 

--- a/source/class/cv/ui/structure/pure/NotificationCenterBadge.js
+++ b/source/class/cv/ui/structure/pure/NotificationCenterBadge.js
@@ -118,7 +118,7 @@ qx.Class.define('cv.ui.structure.pure.NotificationCenterBadge', {
       var messages = cv.ui.NotificationCenter.getInstance().getMessages().length;
       this.__getBadgeElement().innerHTML = ""+messages;
       if (this.isHideWhenEmpty()) {
-        this.__getBadgeElement().style["display"] = messages === 0 ? "none" : "block";
+        this.__getBadgeElement().style.display = messages === 0 ? "none" : "block";
       }
     },
 

--- a/source/class/cv/ui/structure/pure/NotificationCenterBadge.js
+++ b/source/class/cv/ui/structure/pure/NotificationCenterBadge.js
@@ -115,7 +115,7 @@ qx.Class.define('cv.ui.structure.pure.NotificationCenterBadge', {
 
     _onChangeCounter: function() {
       var messages = cv.ui.NotificationCenter.getInstance().getMessages().length;
-      this.__getBadgeElement().setAttribute("html", ""+messages);
+      this.__getBadgeElement().innerHTML = ""+messages;
       if (this.isHideWhenEmpty()) {
         qx.bom.element.Style.set(this.__getBadgeElement(), "display", messages === 0 ? "none" : "block");
       }

--- a/source/class/cv/ui/structure/pure/Page.js
+++ b/source/class/cv/ui/structure/pure/Page.js
@@ -252,17 +252,17 @@ qx.Class.define('cv.ui.structure.pure.Page', {
          });
          }}, floorplan.translateMouseEvent );
          $(window).bind( 'resize', function(){ floorplan.resize($('.page').width(), $('.page').height(), true);} );
-         if (qx.bom.element.Attribute.get(page, 'azimut')) {
-         cv.TemplateEngine.getInstance().addAddress( qx.bom.element.Attribute.get(page, 'azimut'), path + '_' );
-         address[ qx.bom.element.Attribute.get(page, 'azimut') ] = [ 'DPT:9.001', 0, 'azimut' ];
+         if (page.getAttribute('azimut')) {
+         cv.TemplateEngine.getInstance().addAddress( page.getAttribute('azimut'), path + '_' );
+         address[ page.getAttribute('azimut') ] = [ 'DPT:9.001', 0, 'azimut' ];
          }
-         if (qx.bom.element.Attribute.get(page, 'elevation')) {
-         cv.TemplateEngine.getInstance().addAddress( qx.bom.element.Attribute.get(page, 'elevation'), path + '_' );
-         address[ qx.bom.element.Attribute.get(page, 'elevation') ] = [ 'DPT:9.001', 0, 'elevation' ];
+         if (page.getAttribute('elevation')) {
+         cv.TemplateEngine.getInstance().addAddress( page.getAttribute('elevation'), path + '_' );
+         address[ page.getAttribute('elevation') ] = [ 'DPT:9.001', 0, 'elevation' ];
          };
-         if (qx.bom.element.Attribute.get(page, 'floor')) {
-         cv.TemplateEngine.getInstance().addAddress( qx.bom.element.Attribute.get(page, 'floor'), path + '_' );
-         address[ qx.bom.element.Attribute.get(page, 'floor') ] = [ 'DPT:5.004', 0, 'floor' ];
+         if (page.getAttribute('floor')) {
+         cv.TemplateEngine.getInstance().addAddress( page.getAttribute('floor'), path + '_' );
+         address[ page.getAttribute('floor') ] = [ 'DPT:5.004', 0, 'floor' ];
          };
 
          $( childs ).each( function(i,a){

--- a/source/class/cv/ui/structure/pure/Page.js
+++ b/source/class/cv/ui/structure/pure/Page.js
@@ -94,7 +94,7 @@ qx.Class.define('cv.ui.structure.pure.Page', {
      * Append the complete generated HTML code to the DOM tree at the end of the generation process
      */
     createFinal: function() { // special function - only for pages!
-      qx.bom.Selector.query("#pages")[0].innerHTML = this.allPages;
+      document.querySelector("#pages").innerHTML = this.allPages;
       qx.event.message.Bus.unsubscribe("setup.dom.append", this.createFinal, this);
     }
 

--- a/source/class/cv/ui/structure/pure/Page.js
+++ b/source/class/cv/ui/structure/pure/Page.js
@@ -62,13 +62,13 @@ qx.Class.define('cv.ui.structure.pure.Page', {
       ].forEach(function (tuple) {
         var property = tuple[0];
         var defaultValue = tuple[1];
-        if (this['get' + qx.lang.String.firstUp(property)]() === null) {
+        if (this['get' + property.charAt(0).toUpperCase() + property.substr(1)]() === null) {
           // inherit from parent
           if (parentPage) {
             parentPage.bind(property, this, property);
           } else {
             // we have not parent page, because we are the root page, use the default value
-            this['set' + qx.lang.String.firstUp(property)](defaultValue);
+            this['set' + property.charAt(0).toUpperCase() + property.substr(1)](defaultValue);
           }
         }
         if (!parentPage) {
@@ -177,7 +177,10 @@ qx.Class.define('cv.ui.structure.pure.Page', {
 
     _applyNavbarVisibility: function(value, old, name) {
       if (value !== null) {
-        qx.lang.Array.remove(this.__waitForProperties, name);
+        var i_name = this.__waitForProperties.indexOf(name);
+        if( i_name !== -1 ) {
+          this.__waitForProperties.splice(i_name,1);
+        }
         if (this.__waitForProperties.length === 0) {
           this.setInitialized(true);
         }

--- a/source/class/cv/ui/structure/pure/PageJump.js
+++ b/source/class/cv/ui/structure/pure/PageJump.js
@@ -120,7 +120,7 @@ qx.Class.define('cv.ui.structure.pure.PageJump', {
       };
 
       while (parentPage && cv.util.Tree.getParentWidget(parentPage, "page")) {
-        pageJumps.forEach(qx.lang.Function.curry(markPageJumps, parentPage.getName()));
+        pageJumps.forEach(function(elem){markPageJumps(parentPage.getName(), elem);});
         // recursively find pagejumps for parent pages
         parentPage = cv.util.Tree.getParentWidget(parentPage, "page");
       }

--- a/source/class/cv/ui/structure/pure/PageJump.js
+++ b/source/class/cv/ui/structure/pure/PageJump.js
@@ -90,17 +90,17 @@ qx.Class.define('cv.ui.structure.pure.PageJump', {
 
       // remove old active classes
       document.querySelectorAll('.pagejump.active').forEach(function(elem) {
-        qx.bom.element.Class.remove(elem, 'active');
+        elem.classList.remove('active');
       }, this);
       document.querySelectorAll('.pagejump.active_ancestor').forEach(function(elem) {
-        qx.bom.element.Class.remove(elem, 'active_ancestor');
+        elem.classList.remove('active_ancestor');
       }, this);
 
       // and set the new active ones
       document.querySelectorAll('.pagejump').forEach(function(elem) {
         var data = model.getWidgetDataByElement(elem);
         if (name === data.target) {
-          qx.bom.element.Class.add(elem, 'active');
+          elem.classList.add('active');
         }
       }, this);
 
@@ -115,7 +115,7 @@ qx.Class.define('cv.ui.structure.pure.PageJump', {
             qx.lang.Type.isString(data.path) && data.path.match(parentName + "$") ||
             qx.lang.Type.isString(data.targetPath) && data.targetPath.match(parentName + "$"))
         )) {
-          qx.bom.element.Class.add(elem, 'active_ancestor');
+          elem.classList.add('active_ancestor');
         }
       };
 

--- a/source/class/cv/ui/structure/pure/PageJump.js
+++ b/source/class/cv/ui/structure/pure/PageJump.js
@@ -112,8 +112,8 @@ qx.Class.define('cv.ui.structure.pure.PageJump', {
       var markPageJumps = function(parentName, elem) {
         var data = model.getWidgetDataByElement(elem);
         if (parentName === data.target || (data.activeScope === "path" && (
-            qx.lang.Type.isString(data.path) && data.path.match(parentName + "$") ||
-            qx.lang.Type.isString(data.targetPath) && data.targetPath.match(parentName + "$"))
+            (typeof data.path === 'string') && data.path.match(parentName + "$") ||
+            (typeof data.targetPath === 'string') && data.targetPath.match(parentName + "$"))
         )) {
           elem.classList.add('active_ancestor');
         }

--- a/source/class/cv/ui/structure/pure/PageJump.js
+++ b/source/class/cv/ui/structure/pure/PageJump.js
@@ -89,15 +89,15 @@ qx.Class.define('cv.ui.structure.pure.PageJump', {
       var name = page.getName();
 
       // remove old active classes
-      qx.bom.Selector.query('.pagejump.active').forEach(function(elem) {
+      document.querySelectorAll('.pagejump.active').forEach(function(elem) {
         qx.bom.element.Class.remove(elem, 'active');
       }, this);
-      qx.bom.Selector.query('.pagejump.active_ancestor').forEach(function(elem) {
+      document.querySelectorAll('.pagejump.active_ancestor').forEach(function(elem) {
         qx.bom.element.Class.remove(elem, 'active_ancestor');
       }, this);
 
       // and set the new active ones
-      qx.bom.Selector.query('.pagejump').forEach(function(elem) {
+      document.querySelectorAll('.pagejump').forEach(function(elem) {
         var data = model.getWidgetDataByElement(elem);
         if (name === data.target) {
           qx.bom.element.Class.add(elem, 'active');
@@ -108,7 +108,7 @@ qx.Class.define('cv.ui.structure.pure.PageJump', {
       var parentPage = cv.util.Tree.getParentWidget(page, "page");
       // set for all parent pages apart from the root page
 
-      var pageJumps = qx.bom.Selector.query('.pagejump');
+      var pageJumps = document.querySelectorAll('.pagejump');
       var markPageJumps = function(parentName, elem) {
         var data = model.getWidgetDataByElement(elem);
         if (parentName === data.target || (data.activeScope === "path" && (

--- a/source/class/cv/ui/structure/pure/PageLink.js
+++ b/source/class/cv/ui/structure/pure/PageLink.js
@@ -63,7 +63,7 @@ qx.Class.define('cv.ui.structure.pure.PageLink', {
     getDomString: function() {
       var layout = this.getLayout();
 
-      var style = qx.lang.Type.isObject(layout) ? '' : 'style="' + cv.parser.WidgetParser.extractLayout(layout, this.getPageType()) + '"';
+      var style = typeof layout === 'object' ? '' : 'style="' + cv.parser.WidgetParser.extractLayout(layout, this.getPageType()) + '"';
 
       var ret_val = '<div class="widget clearfix link pagelink ' + this.getClasses() + '" ' + style + '>';
       ret_val += '<div class="actor" ' + this.getWstyle() + '><a href="javascript:void(0)">' + this.getName() + '</a></div>';

--- a/source/class/cv/ui/structure/pure/PushButton.js
+++ b/source/class/cv/ui/structure/pure/PushButton.js
@@ -67,8 +67,8 @@ qx.Class.define('cv.ui.structure.pure.PushButton', {
       // compare against the unmapped value
       value = "" + this.getBasicValue();
       var off = this.getUpValue();
-      qx.bom.element.Class.remove(actor, value === off ? 'switchPressed' : 'switchUnpressed');
-      qx.bom.element.Class.add(actor, value === off ? 'switchUnpressed' : 'switchPressed');
+      actor.classList.remove(value === off ? 'switchPressed' : 'switchUnpressed');
+      actor.classList.add(value === off ? 'switchUnpressed' : 'switchPressed');
     },
 
     /**

--- a/source/class/cv/ui/structure/pure/Rgb.js
+++ b/source/class/cv/ui/structure/pure/Rgb.js
@@ -52,7 +52,7 @@ qx.Class.define('cv.ui.structure.pure.Rgb', {
 
       var value = cv.Transform.decode( this.getAddress()[ address ][0], data );
 
-      var bg = qx.bom.element.Style.get(valElem, 'background-color').replace(/[a-zA-Z()\s]/g, '').split(/,/);
+      var bg = window.getComputedStyle(valElem)['background-color'].replace(/[a-zA-Z()\s]/g, '').split(/,/);
       if( 3 !== bg.length ) {
         bg = [0, 0, 0];
       }
@@ -62,7 +62,7 @@ qx.Class.define('cv.ui.structure.pure.Rgb', {
         case 'b' :  bg[2] = value; break;
       }
       var bgs = "rgb(" + bg[0] + ", " + bg[1] + ", " + bg[2] + ")";
-      qx.bom.element.Style.set(valElem, 'background-color', bgs);
+      valElem.style['background-color'] = bgs;
     }
   },
 

--- a/source/class/cv/ui/structure/pure/Switch.js
+++ b/source/class/cv/ui/structure/pure/Switch.js
@@ -99,8 +99,8 @@ qx.Class.define('cv.ui.structure.pure.Switch', {
       value = this.getBasicValue();
       var off = this.getOffValue();
       // using == comparisons to make sure that e.g. 1 equals "1"
-      qx.bom.element.Class.remove(actor, value == off ? 'switchPressed' : 'switchUnpressed'); // jshint ignore:line
-      qx.bom.element.Class.add(actor, value == off ? 'switchUnpressed' : 'switchPressed'); // jshint ignore:line
+      actor.classList.remove(value == off ? 'switchPressed' : 'switchUnpressed'); // jshint ignore:line
+      actor.classList.add(value == off ? 'switchUnpressed' : 'switchPressed'); // jshint ignore:line
     },
 
     /**

--- a/source/class/cv/ui/structure/pure/Unknown.js
+++ b/source/class/cv/ui/structure/pure/Unknown.js
@@ -77,7 +77,7 @@ qx.Class.define('cv.ui.structure.pure.Unknown', {
      * @return {Element} the DOM element
      */
     getDomElement: function () {
-      return qx.bom.Selector.query('#' + this.getPath())[0];
+      return document.querySelector('#' + this.getPath());
     },
 
     /**

--- a/source/class/cv/ui/structure/pure/Video.js
+++ b/source/class/cv/ui/structure/pure/Video.js
@@ -62,7 +62,7 @@ qx.Class.define('cv.ui.structure.pure.Video', {
 
     // overridden
     getValueElement: function() {
-      return qx.bom.Selector.query("video", this.getDomElement())[0];
+      return this.getDomElement().querySelector("video");
     },
 
     // overridden

--- a/source/class/cv/ui/structure/pure/Web.js
+++ b/source/class/cv/ui/structure/pure/Web.js
@@ -100,7 +100,7 @@ qx.Class.define('cv.ui.structure.pure.Web', {
       if (!addr) { return; }
       if (data === 1) {
         var iframe = qx.bom.Selector.query('iframe', this.getDomElement())[0];
-        this.refreshAction(iframe, qx.bom.element.Attribute.get(iframe, 'src'));
+        this.refreshAction(iframe, iframe.getAttribute('src'));
         // reset the value
         cv.TemplateEngine.getInstance().visu.write( address, cv.Transform.encode(addr[0], 0));
       }

--- a/source/class/cv/ui/structure/pure/Web.js
+++ b/source/class/cv/ui/structure/pure/Web.js
@@ -99,7 +99,7 @@ qx.Class.define('cv.ui.structure.pure.Web', {
       var addr = this.getAddress()[ address ];
       if (!addr) { return; }
       if (data === 1) {
-        var iframe = qx.bom.Selector.query('iframe', this.getDomElement())[0];
+        var iframe = this.getDomElement().querySelector('iframe');
         this.refreshAction(iframe, iframe.getAttribute('src'));
         // reset the value
         cv.TemplateEngine.getInstance().visu.write( address, cv.Transform.encode(addr[0], 0));

--- a/source/class/cv/ui/util/ProgressBar.js
+++ b/source/class/cv/ui/util/ProgressBar.js
@@ -75,7 +75,7 @@ qx.Class.define("cv.ui.util.ProgressBar", {
       var container = this.__domElement = qx.dom.Element.create("div", { "class": "progressbar" });
       this.__domElement.$$widget = this;
       var progress = this.__progressElement = qx.dom.Element.create("div", { "class": "completed" });
-      qx.dom.Element.insertEnd(progress, container);
+      container.appendChild(progress);
       return container;
     }
   }

--- a/source/class/cv/ui/util/ProgressBar.js
+++ b/source/class/cv/ui/util/ProgressBar.js
@@ -62,7 +62,7 @@ qx.Class.define("cv.ui.util.ProgressBar", {
     _applyValue: function(value) {
       var totalWidth = qx.bom.element.Dimension.getContentWidth(this.__domElement);
       var progressWidth = Math.round(totalWidth*value/100)+"px";
-      qx.bom.element.Style.set(this.__progressElement, "width", progressWidth);
+      this.__progressElement.style["width"] = progressWidth;
     },
 
     getDomElement: function() {

--- a/source/class/cv/ui/util/ProgressBar.js
+++ b/source/class/cv/ui/util/ProgressBar.js
@@ -60,9 +60,11 @@ qx.Class.define("cv.ui.util.ProgressBar", {
     __progressElement: null,
 
     _applyValue: function(value) {
-      var totalWidth = qx.bom.element.Dimension.getContentWidth(this.__domElement);
-      var progressWidth = Math.round(totalWidth*value/100)+"px";
-      this.__progressElement.style["width"] = progressWidth;
+      var
+        rect = this.__domElement.getBoundingClientRect(),
+        totalWidth = Math.round(rect.right - rect.left),
+        progressWidth = Math.round(totalWidth*value/100)+"px";
+      this.__progressElement.style.width = progressWidth;
     },
 
     getDomElement: function() {

--- a/source/class/cv/util/ConfigLoader.js
+++ b/source/class/cv/util/ConfigLoader.js
@@ -71,7 +71,7 @@ qx.Class.define('cv.util.ConfigLoader', {
         }
         else {
           // check the library version
-          var xmlLibVersion = qx.bom.element.Attribute.get(qx.bom.Selector.query('pages', xml)[0], "lib_version");
+          var xmlLibVersion = qx.bom.Selector.query('pages', xml)[0].getAttribute("lib_version");
           if (xmlLibVersion === undefined) {
             xmlLibVersion = -1;
           }
@@ -116,7 +116,7 @@ qx.Class.define('cv.util.ConfigLoader', {
      * @param includeElem {Element}
      */
     loadInclude: function (includeElem) {
-      var url = qx.bom.element.Attribute.get(includeElem, 'src');
+      var url = includeElem.getAttribute('src');
       if (!url.startsWith('/')) {
         url = qx.util.LibraryManager.getInstance().get('cv', 'resourceUri') + '/' + url;
       }

--- a/source/class/cv/util/ConfigLoader.js
+++ b/source/class/cv/util/ConfigLoader.js
@@ -131,7 +131,7 @@ qx.Class.define('cv.util.ConfigLoader', {
         var xml = qx.xml.Document.fromString('<root>' + req.getResponseText() + '</root>');
         var parent = includeElem.parentElement;
         parent.removeChild(includeElem);
-        qx.dom.Hierarchy.getChildElements(xml.firstChild).forEach(function (child) {
+        xml.firstChild.childNodes.forEach(function (child) {
           parent.appendChild(child);
         });
         this.__loadQueue.remove(url);

--- a/source/class/cv/util/ConfigLoader.js
+++ b/source/class/cv/util/ConfigLoader.js
@@ -59,7 +59,7 @@ qx.Class.define('cv.util.ConfigLoader', {
         cv.Config.configServer = req.getResponseHeader("Server");
         // Response parsed according to the server's response content type
         var xml = req.getResponse();
-        if (xml && qx.lang.Type.isString(xml)) {
+        if (xml && (typeof xml === 'string')) {
           xml = qx.xml.Document.fromString(xml);
         }
         this.__xml = xml;

--- a/source/class/cv/util/ConfigLoader.js
+++ b/source/class/cv/util/ConfigLoader.js
@@ -63,7 +63,7 @@ qx.Class.define('cv.util.ConfigLoader', {
           xml = qx.xml.Document.fromString(xml);
         }
         this.__xml = xml;
-        qx.bom.Selector.query('include', xml).forEach(this.loadInclude, this);
+        xml.querySelectorAll('include').forEach(this.loadInclude, this);
         this.__loadQueue.remove(ajaxRequest.getUrl());
 
         if (!xml || !xml.documentElement || xml.getElementsByTagName("parsererror").length) {

--- a/source/class/cv/util/ConfigLoader.js
+++ b/source/class/cv/util/ConfigLoader.js
@@ -71,7 +71,7 @@ qx.Class.define('cv.util.ConfigLoader', {
         }
         else {
           // check the library version
-          var xmlLibVersion = qx.bom.Selector.query('pages', xml)[0].getAttribute("lib_version");
+          var xmlLibVersion = xml.querySelector('pages').getAttribute("lib_version");
           if (xmlLibVersion === undefined) {
             xmlLibVersion = -1;
           }

--- a/source/class/cv/util/IconTools.js
+++ b/source/class/cv/util/IconTools.js
@@ -257,7 +257,7 @@ qx.Class.define('cv.util.IconTools', {
   },
 
   defer: function() {
-    var canvas = qx.dom.Element.create('canvas');
+    var canvas = document.createElement('canvas');
     this.defer.self.tmpCanvas = canvas;
     this.defer.self.tmpCtx = canvas.getContext('2d');
   }

--- a/source/class/cv/util/IconTools.js
+++ b/source/class/cv/util/IconTools.js
@@ -207,7 +207,7 @@ qx.Class.define('cv.util.IconTools', {
         if (asText) {
           return newCanvas;
         }
-        var newElement = qx.bom.Selector.query(newCanvas)[0];
+        var newElement = document.querySelector(newCanvas);
         if (cv.util.IconTools.iconCache[url].icon.complete) {
           cv.util.IconTools.fillCanvas(newElement, cv.util.IconTools.iconCache[url].colors[color]);
         }

--- a/source/class/cv/util/ScriptLoader.js
+++ b/source/class/cv/util/ScriptLoader.js
@@ -69,7 +69,7 @@ qx.Class.define('cv.util.ScriptLoader', {
     __listener : null,
 
     addStyles: function(styleArr) {
-      var queue = (typeof styleArr === 'string' ? [ styleArr ] : qx.lang.Array.clone(styleArr));
+      var queue = (typeof styleArr === 'string' ? [ styleArr ] : styleArr.concat());
       var suffix = (cv.Config.forceReload === true) ? '?'+Date.now() : '';
       queue.forEach(function(style) {
         qx.bom.Stylesheet.includeFile(qx.util.ResourceManager.getInstance().toUri(style) + suffix);
@@ -102,7 +102,7 @@ qx.Class.define('cv.util.ScriptLoader', {
         var processQueue = function () {
           if (order.length > 0) {
             var loadIndex = order.shift();
-            var script = qx.lang.Array.removeAt(realQueue, loadIndex);
+            var script = realQueue.splice(loadIndex, 1)[0];
             var loader = this.__loadSingleScript(script);
             loader.addListener("ready", processQueue, this);
           } else {

--- a/source/class/cv/util/ScriptLoader.js
+++ b/source/class/cv/util/ScriptLoader.js
@@ -69,7 +69,7 @@ qx.Class.define('cv.util.ScriptLoader', {
     __listener : null,
 
     addStyles: function(styleArr) {
-      var queue = (qx.lang.Type.isString(styleArr) ? [ styleArr ] : qx.lang.Array.clone(styleArr));
+      var queue = (typeof styleArr === 'string' ? [ styleArr ] : qx.lang.Array.clone(styleArr));
       var suffix = (cv.Config.forceReload === true) ? '?'+Date.now() : '';
       queue.forEach(function(style) {
         qx.bom.Stylesheet.includeFile(qx.util.ResourceManager.getInstance().toUri(style) + suffix);
@@ -77,7 +77,7 @@ qx.Class.define('cv.util.ScriptLoader', {
     },
 
     addScripts: function(scriptArr, order) {
-      var queue = (qx.lang.Type.isString(scriptArr) ? [ scriptArr ] : scriptArr);
+      var queue = (typeof scriptArr === 'string' ? [ scriptArr ] : scriptArr);
       // make sure that no cached scripts are loaded
       var suffix = (cv.Config.forceReload === true) ? '?'+Date.now() : '';
       var realQueue = [];

--- a/source/class/cv/util/String.js
+++ b/source/class/cv/util/String.js
@@ -41,7 +41,20 @@ qx.Class.define('cv.util.String', {
       this.__elem.innerHTML = str;
       return this.__elem.innerText;
     },
-    
+
+    /**
+     * Clean the string that contains HTML code and convert it to a DOM element
+     * @param str {String} string to decode
+     * @return {String}
+     */
+    htmlStringToDomElement: function (str) {
+      //var widget = qx.bom.Html.clean([res[1]])[0];
+      //var widget = (function(){var div=document.createElement('div');div.innerHTML=res[1];return div.childNodes[0];})();
+      var div = document.createElement('div');
+      div.innerHTML = str;
+      return div.childNodes[0];
+    },
+
     /**
      * Insert in string values as the well known sprint() function of other
      * programming languages does.

--- a/source/class/cv/util/String.js
+++ b/source/class/cv/util/String.js
@@ -50,7 +50,7 @@ qx.Class.define('cv.util.String', {
      * @return {String}
      */
     sprintf: function() {
-      var args = qx.lang.Array.fromArguments(arguments);
+      var args = Array.prototype.slice.call(arguments);
       var string = '-';
       try {
         string = sprintf.apply(this, args);

--- a/source/class/cv/util/String.js
+++ b/source/class/cv/util/String.js
@@ -36,7 +36,7 @@ qx.Class.define('cv.util.String', {
      */
     decodeHtmlEntities: function (str) {
       if (!this.__elem) {
-        this.__elem = qx.dom.Element.create("span");
+        this.__elem = document.createElement("span");
       }
       this.__elem.innerHTML = str;
       return this.__elem.innerText;

--- a/source/class/cv/util/Tree.js
+++ b/source/class/cv/util/Tree.js
@@ -134,7 +134,7 @@ qx.Class.define('cv.util.Tree', {
     * ********************************************************
     */
     getChildElements: function(element, selector) {
-      return qx.dom.Hierarchy.getChildElements(element).filter(function(child) {
+      return Array.from(element.childNodes).filter(function(child) {
         if (selector) {
           return Array.prototype.filter.call(child,function(m){return m.matches(selector);});
         } else {

--- a/source/class/cv/util/Tree.js
+++ b/source/class/cv/util/Tree.js
@@ -153,7 +153,7 @@ qx.Class.define('cv.util.Tree', {
 
     getParent: function(element, until, selector, limit) {
       var parents = [];
-      var parent = qx.dom.Element.getParentElement(element);
+      var parent = element.parentNode;
       while (parent && parent.getAttribute('id') !== "pages") {
         var found = [parent];
         if (selector) {
@@ -166,7 +166,7 @@ qx.Class.define('cv.util.Tree', {
         if (until && Array.prototype.filter.call([parent],function(m){return m.matches(until);}).length > 0) {
           break;
         }
-        parent = qx.dom.Element.getParentElement(parent);
+        parent = parent.parentNode;
       }
       return parents;
     },

--- a/source/class/cv/util/Tree.js
+++ b/source/class/cv/util/Tree.js
@@ -82,7 +82,7 @@ qx.Class.define('cv.util.Tree', {
         return null;
       }
       var model = cv.data.Model.getInstance();
-      while (qx.lang.Object.isEmpty(data) && parentPath.length > 2) {
+      while (Object.keys(data).length === 0 && parentPath.length > 2) {
         data = model.getWidgetData(parentPath);
         if (parentPath === "id_") {
           break;

--- a/source/class/cv/util/Tree.js
+++ b/source/class/cv/util/Tree.js
@@ -154,7 +154,7 @@ qx.Class.define('cv.util.Tree', {
     getParent: function(element, until, selector, limit) {
       var parents = [];
       var parent = qx.dom.Element.getParentElement(element);
-      while (parent && qx.bom.element.Attribute.get(parent, 'id') !== "pages") {
+      while (parent && parent.getAttribute('id') !== "pages") {
         var found = [parent];
         if (selector) {
           found = qx.bom.Selector.matches(selector, found);

--- a/source/class/cv/util/Tree.js
+++ b/source/class/cv/util/Tree.js
@@ -136,7 +136,7 @@ qx.Class.define('cv.util.Tree', {
     getChildElements: function(element, selector) {
       return qx.dom.Hierarchy.getChildElements(element).filter(function(child) {
         if (selector) {
-          return qx.bom.Selector.matches(selector, child);
+          return Array.prototype.filter.call(child,function(m){return m.matches(selector);});
         } else {
           return true;
         }
@@ -157,13 +157,13 @@ qx.Class.define('cv.util.Tree', {
       while (parent && parent.getAttribute('id') !== "pages") {
         var found = [parent];
         if (selector) {
-          found = qx.bom.Selector.matches(selector, found);
+          found = Array.prototype.filter.call(found,function(m){return m.matches(selector);});
         }
         parents = parents.concat(found);
         if (limit && parents.length >= limit) {
           break;
         }
-        if (until && qx.bom.Selector.matches(until, [parent]).length > 0) {
+        if (until && Array.prototype.filter.call([parent],function(m){return m.matches(until);}).length > 0) {
           break;
         }
         parent = qx.dom.Element.getParentElement(parent);
@@ -174,7 +174,7 @@ qx.Class.define('cv.util.Tree', {
     getClosest: function(elem, selector) {
 
       var findClosest = function (current) {
-        var found = qx.bom.Selector.matches(selector, [current]);
+        var found = Array.prototype.filter.call([current],function(m){return m.matches(selector);});
         if (found.length) {
           return found[0];
         } else {

--- a/source/resource/config/hidden.php
+++ b/source/resource/config/hidden.php
@@ -1,5 +1,9 @@
 <?php
 // File for configurations that shouldn't be shared with the user
 $hidden = array(
+  'fritzbox' => array( 'uri' => 'https://192.168.0.1:49443/', 'user' => 'CometVisuTestUser', 'pass' => 'cvtu4here' ),
+  //'fritzbox' => array( 'uri' => 'http://192.168.0.1:49000/', 'user' => 'CometVisuTestUser', 'pass' => 'cvtu4here' ),
+  //'fritzbox' => array( 'uri' => 'https://fritz.box:49443/', 'user' => 'CometVisuTestUser', 'pass' => 'cvtu4here' , 'selfsigned' => 'true'),
+  'influx' => array('uri' => 'https://172.17.0.1/proxy/ts/query', 'user' => 'docker', 'pass' => 'cwkvJPQeFlGlRKc402CA', 'selfsigned' => 'true')
 );
 ?>

--- a/source/resource/demo/media/demo_2d_backdrop_red_pot.js
+++ b/source/resource/demo/media/demo_2d_backdrop_red_pot.js
@@ -16,7 +16,7 @@ client.update = function(json ) // overload the handler
   var filling = qx.bom.Selector.query('#rect3855', document)[0];
   filling.y.baseVal.value=200.57388 + (100-h)*2;
   filling.height.baseVal.value = h*2;
-  qx.bom.element.Attribute.set(qx.bom.Selector.query('#path3029-4', document)[0], 'd', 'm 524.85653,'+(200.57388+ (100-h)*2)+' a 100,37.795274 0 0 1 -200,0 100,37.795274 0 1 1 200,0 z');
+  qx.bom.Selector.query('#path3029-4', document)[0].setAttribute('d', 'm 524.85653,'+(200.57388+ (100-h)*2)+' a 100,37.795274 0 0 1 -200,0 100,37.795274 0 1 1 200,0 z');
 };
   
 client.user = 'demo_user'; // example for setting a user

--- a/source/resource/demo/media/demo_2d_backdrop_red_pot.js
+++ b/source/resource/demo/media/demo_2d_backdrop_red_pot.js
@@ -13,10 +13,10 @@ client.update = function(json ) // overload the handler
   if (h === undefined) {
     return;
   }
-  var filling = qx.bom.Selector.query('#rect3855', document)[0];
+  var filling = document.querySelector('#rect3855');
   filling.y.baseVal.value=200.57388 + (100-h)*2;
   filling.height.baseVal.value = h*2;
-  qx.bom.Selector.query('#path3029-4', document)[0].setAttribute('d', 'm 524.85653,'+(200.57388+ (100-h)*2)+' a 100,37.795274 0 0 1 -200,0 100,37.795274 0 1 1 200,0 z');
+  document.querySelector('#path3029-4').setAttribute('d', 'm 524.85653,'+(200.57388+ (100-h)*2)+' a 100,37.795274 0 0 1 -200,0 100,37.795274 0 1 1 200,0 z');
 };
   
 client.user = 'demo_user'; // example for setting a user

--- a/source/resource/designs/alaska/design_setup.js
+++ b/source/resource/designs/alaska/design_setup.js
@@ -25,7 +25,7 @@
  * @since 2012
  */
 qx.event.message.Bus.subscribe("setup.dom.finished.before", function() {
-  qx.bom.element.Dataset.set(document.querySelector('#navbarLeft'), 'columns', 6);
-  qx.bom.element.Dataset.set(document.querySelector('#main'), 'columns', 12);
-  qx.bom.element.Dataset.set(document.querySelector('#navbarRight'), 'columns', 6);
+  document.querySelector('#navbarLeft').dataset['columns'] = 6;
+  document.querySelector('#main').dataset['columns'] = 12;
+  document.querySelector('#navbarRight').dataset['columns'] = 6;
 });

--- a/source/resource/designs/alaska/design_setup.js
+++ b/source/resource/designs/alaska/design_setup.js
@@ -25,7 +25,7 @@
  * @since 2012
  */
 qx.event.message.Bus.subscribe("setup.dom.finished.before", function() {
-  qx.bom.element.Dataset.set(qx.bom.Selector.query('#navbarLeft')[0], 'columns', 6);
-  qx.bom.element.Dataset.set(qx.bom.Selector.query('#main')[0], 'columns', 12);
-  qx.bom.element.Dataset.set(qx.bom.Selector.query('#navbarRight')[0], 'columns', 6);
+  qx.bom.element.Dataset.set(document.querySelector('#navbarLeft'), 'columns', 6);
+  qx.bom.element.Dataset.set(document.querySelector('#main'), 'columns', 12);
+  qx.bom.element.Dataset.set(document.querySelector('#navbarRight'), 'columns', 6);
 });

--- a/source/resource/designs/alaska_slim/design_setup.js
+++ b/source/resource/designs/alaska_slim/design_setup.js
@@ -25,7 +25,7 @@
  * @since 2012
  */
 qx.event.message.Bus.subscribe("setup.dom.finished.before", function() {
-  qx.bom.element.Dataset.set(document.querySelector('#navbarLeft'), 'columns', 6);
-  qx.bom.element.Dataset.set(document.querySelector('#main'), 'columns', 12);
-  qx.bom.element.Dataset.set(document.querySelector('#navbarRight'), 'columns', 6);
+  document.querySelector('#navbarLeft').dataset['columns'] = 6;
+  document.querySelector('#main').dataset['columns'] = 12;
+  document.querySelector('#navbarRight').dataset['columns'] = 6;
 });

--- a/source/resource/designs/alaska_slim/design_setup.js
+++ b/source/resource/designs/alaska_slim/design_setup.js
@@ -25,7 +25,7 @@
  * @since 2012
  */
 qx.event.message.Bus.subscribe("setup.dom.finished.before", function() {
-  qx.bom.element.Dataset.set(qx.bom.Selector.query('#navbarLeft')[0], 'columns', 6);
-  qx.bom.element.Dataset.set(qx.bom.Selector.query('#main')[0], 'columns', 12);
-  qx.bom.element.Dataset.set(qx.bom.Selector.query('#navbarRight')[0], 'columns', 6);
+  qx.bom.element.Dataset.set(document.querySelector('#navbarLeft'), 'columns', 6);
+  qx.bom.element.Dataset.set(document.querySelector('#main'), 'columns', 12);
+  qx.bom.element.Dataset.set(document.querySelector('#navbarRight'), 'columns', 6);
 });

--- a/source/resource/designs/discreet/design_setup.js
+++ b/source/resource/designs/discreet/design_setup.js
@@ -25,7 +25,7 @@
  * @since 2012
  */
 qx.event.message.Bus.subscribe("setup.dom.finished.before", function() {
-  qx.bom.element.Dataset.set(qx.bom.Selector.query('#navbarLeft')[0], 'columns', 6);
-  qx.bom.element.Dataset.set(qx.bom.Selector.query('#main')[0], 'columns', 12);
-  qx.bom.element.Dataset.set(qx.bom.Selector.query('#navbarRight')[0], 'columns', 6);
+  qx.bom.element.Dataset.set(document.querySelector('#navbarLeft'), 'columns', 6);
+  qx.bom.element.Dataset.set(document.querySelector('#main'), 'columns', 12);
+  qx.bom.element.Dataset.set(document.querySelector('#navbarRight'), 'columns', 6);
 })

--- a/source/resource/designs/discreet/design_setup.js
+++ b/source/resource/designs/discreet/design_setup.js
@@ -25,7 +25,7 @@
  * @since 2012
  */
 qx.event.message.Bus.subscribe("setup.dom.finished.before", function() {
-  qx.bom.element.Dataset.set(document.querySelector('#navbarLeft'), 'columns', 6);
-  qx.bom.element.Dataset.set(document.querySelector('#main'), 'columns', 12);
-  qx.bom.element.Dataset.set(document.querySelector('#navbarRight'), 'columns', 6);
+  document.querySelector('#navbarLeft').dataset['columns'] = 6;
+  document.querySelector('#main').dataset['columns'] = 12;
+  document.querySelector('#navbarRight').dataset['columns'] = 6;
 })

--- a/source/resource/designs/discreet_sand/design_setup.js
+++ b/source/resource/designs/discreet_sand/design_setup.js
@@ -25,7 +25,7 @@
  * @since 2012
  */
 qx.event.message.Bus.subscribe("setup.dom.finished.before", function() {
-  qx.bom.element.Dataset.set(qx.bom.Selector.query('#navbarLeft')[0], 'columns', 6);
-  qx.bom.element.Dataset.set(qx.bom.Selector.query('#main')[0], 'columns', 12);
-  qx.bom.element.Dataset.set(qx.bom.Selector.query('#navbarRight')[0], 'columns', 6);
+  qx.bom.element.Dataset.set(document.querySelector('#navbarLeft'), 'columns', 6);
+  qx.bom.element.Dataset.set(document.querySelector('#main'), 'columns', 12);
+  qx.bom.element.Dataset.set(document.querySelector('#navbarRight'), 'columns', 6);
 })

--- a/source/resource/designs/discreet_sand/design_setup.js
+++ b/source/resource/designs/discreet_sand/design_setup.js
@@ -25,7 +25,7 @@
  * @since 2012
  */
 qx.event.message.Bus.subscribe("setup.dom.finished.before", function() {
-  qx.bom.element.Dataset.set(document.querySelector('#navbarLeft'), 'columns', 6);
-  qx.bom.element.Dataset.set(document.querySelector('#main'), 'columns', 12);
-  qx.bom.element.Dataset.set(document.querySelector('#navbarRight'), 'columns', 6);
+  document.querySelector('#navbarLeft').dataset['columns'] = 6;
+  document.querySelector('#main').dataset['columns'] = 12;
+  document.querySelector('#navbarRight').dataset['columns'] = 6;
 })

--- a/source/resource/designs/discreet_slim/design_setup.js
+++ b/source/resource/designs/discreet_slim/design_setup.js
@@ -25,7 +25,7 @@
  * @since 2012
  */
 qx.event.message.Bus.subscribe("setup.dom.finished.before", function() {
-  qx.bom.element.Dataset.set(document.querySelector('#navbarLeft'), 'columns', 6);
-  qx.bom.element.Dataset.set(document.querySelector('#main'), 'columns', 12);
-  qx.bom.element.Dataset.set(document.querySelector('#navbarRight'), 'columns', 6);
+  document.querySelector('#navbarLeft').dataset['columns'] = 6;
+  document.querySelector('#main').dataset['columns'] = 12;
+  document.querySelector('#navbarRight').dataset['columns'] = 6;
 });

--- a/source/resource/designs/discreet_slim/design_setup.js
+++ b/source/resource/designs/discreet_slim/design_setup.js
@@ -25,7 +25,7 @@
  * @since 2012
  */
 qx.event.message.Bus.subscribe("setup.dom.finished.before", function() {
-  qx.bom.element.Dataset.set(qx.bom.Selector.query('#navbarLeft')[0], 'columns', 6);
-  qx.bom.element.Dataset.set(qx.bom.Selector.query('#main')[0], 'columns', 12);
-  qx.bom.element.Dataset.set(qx.bom.Selector.query('#navbarRight')[0], 'columns', 6);
+  qx.bom.element.Dataset.set(document.querySelector('#navbarLeft'), 'columns', 6);
+  qx.bom.element.Dataset.set(document.querySelector('#main'), 'columns', 12);
+  qx.bom.element.Dataset.set(document.querySelector('#navbarRight'), 'columns', 6);
 });

--- a/source/resource/designs/metal/design_setup.js
+++ b/source/resource/designs/metal/design_setup.js
@@ -108,7 +108,7 @@ qx.event.message.Bus.subscribe("setup.dom.finished", function() {
   // Disable borders for groups that contain widget-group as children
   document.querySelectorAll('.page > div > .widget_container > .group:not(.widget)').forEach(function(elem) {
     if (elem.querySelectorAll('.clearfix > .widget_container > .group.widget').length > 0) {
-      qx.bom.element.Style.setStyles(elem, {'border': 'none', 'margin': 0});
+      Object.entries({'border': 'none', 'margin': 0}).forEach(function(key,value){elem.style[key]=value;});
     }
   });
 });

--- a/source/resource/designs/metal/design_setup.js
+++ b/source/resource/designs/metal/design_setup.js
@@ -49,7 +49,7 @@ function setRadius(elem, type, value) {
 
 function roundCorners() {
   // find elements in each groups corners
-  qx.bom.Selector.query('.page.activePage .group').forEach(function(group) {
+  document.querySelectorAll('.page.activePage .group').forEach(function(group) {
     var bounds = group.getBoundingClientRect();
     // skip invisible groups
     if (bounds.width === 0 || bounds.height === 0) {
@@ -62,9 +62,9 @@ function roundCorners() {
     var topRight = qx.bom.element.Style.get(group, 'border-top-right-radius');
     var bottomRight = qx.bom.element.Style.get(group, 'border-bottom-right-radius');
     var bottomLeft = qx.bom.element.Style.get(group, 'border-bottom-left-radius');
-    var roundUpperCorners = (qx.bom.Selector.query('.widget_container:first-child', group).length>0) && topRight !== "0px";
+    var roundUpperCorners = (group.querySelectorAll('.widget_container:first-child').length>0) && topRight !== "0px";
     var threshold=5;
-    qx.bom.Selector.query('.widget_container', group).forEach(function (elem) {
+    group.querySelectorAll('.widget_container').forEach(function (elem) {
       var elemCorners = getOffsetCorners(elem);
       if (roundUpperCorners) {
         // upper left corner is done by regular  css-rule  upper right corner
@@ -93,7 +93,7 @@ if (/(opera|chrome|safari)/i.test(navigator.userAgent.toLowerCase())) {
 }
 
 qx.event.message.Bus.subscribe("setup.dom.finished", function() {
-  qx.bom.Selector.query('#navbarLeft .navbar .widget .label,#navbarRight .navbar .widget .label').forEach(function(label) {
+  document.querySelectorAll('#navbarLeft .navbar .widget .label,#navbarRight .navbar .widget .label').forEach(function(label) {
 
     if (label.textContent.trim()!=="") {
       var actor = qx.bom.Selector.matches('.actor', qx.dom.Hierarchy.getSiblings(label))[0];
@@ -106,8 +106,8 @@ qx.event.message.Bus.subscribe("setup.dom.finished", function() {
     }
   });
   // Disable borders for groups that contain widget-group as children
-  qx.bom.Selector.query('.page > div > .widget_container > .group:not(.widget)').forEach(function(elem) {
-    if (qx.bom.Selector.query('.clearfix > .widget_container > .group.widget', elem).length > 0) {
+  document.querySelectorAll('.page > div > .widget_container > .group:not(.widget)').forEach(function(elem) {
+    if (elem.querySelectorAll('.clearfix > .widget_container > .group.widget').length > 0) {
       qx.bom.element.Style.setStyles(elem, {'border': 'none', 'margin': 0});
     }
   });

--- a/source/resource/designs/metal/design_setup.js
+++ b/source/resource/designs/metal/design_setup.js
@@ -41,9 +41,9 @@ function getOffsetCorners(elem) {
 }
 
 function setRadius(elem, type, value) {
-  qx.bom.element.Style.set(elem, type, value);
+  elem.style[type] = value;
   qx.dom.Hierarchy.getChildElements(elem).forEach(function(subElem) {
-    qx.bom.element.Style.set(subElem, type, value);
+    subElem.style[type] = value;
   }, this);
 }
 
@@ -59,9 +59,9 @@ function roundCorners() {
     if (qx.bom.Selector.matches('.navbar', qx.dom.Hierarchy.getAncestors(group)).length > 0) { return; }
     var groupCorners = getOffsetCorners(group);
     // if the group has a headline (=name) we must not round the upper corners
-    var topRight = qx.bom.element.Style.get(group, 'border-top-right-radius');
-    var bottomRight = qx.bom.element.Style.get(group, 'border-bottom-right-radius');
-    var bottomLeft = qx.bom.element.Style.get(group, 'border-bottom-left-radius');
+    var topRight = window.getComputedStyle(group)['border-top-right-radius'];
+    var bottomRight = window.getComputedStyle(group)['border-bottom-right-radius'];
+    var bottomLeft = window.getComputedStyle(group)['border-bottom-left-radius'];
     var roundUpperCorners = (group.querySelectorAll('.widget_container:first-child').length>0) && topRight !== "0px";
     var threshold=5;
     group.querySelectorAll('.widget_container').forEach(function (elem) {
@@ -100,7 +100,7 @@ qx.event.message.Bus.subscribe("setup.dom.finished", function() {
       if (actor && qx.bom.Selector.matches('img', qx.dom.Hierarchy.getChildElements(label)).length === 0) {
         var value = qx.bom.Selector.matches('.value', qx.dom.Hierarchy.getChildElements(actor))[0];
         if (value && value.textContent.trim() !== "") {
-          qx.bom.element.Style.set(actor, 'padding-top', '0.5em');
+          actor.style['padding-top'] = '0.5em';
         }
       }
     }

--- a/source/resource/designs/metal/design_setup.js
+++ b/source/resource/designs/metal/design_setup.js
@@ -56,7 +56,7 @@ function roundCorners() {
       return;
     }
     // do not use this in navbars
-    if (qx.bom.Selector.matches('.navbar', qx.dom.Hierarchy.getAncestors(group)).length > 0) { return; }
+    if (Array.prototype.filter.call(qx.dom.Hierarchy.getAncestors(group),function(m){return m.matches('.navbar');}).length > 0) { return; }
     var groupCorners = getOffsetCorners(group);
     // if the group has a headline (=name) we must not round the upper corners
     var topRight = window.getComputedStyle(group)['border-top-right-radius'];
@@ -96,9 +96,9 @@ qx.event.message.Bus.subscribe("setup.dom.finished", function() {
   document.querySelectorAll('#navbarLeft .navbar .widget .label,#navbarRight .navbar .widget .label').forEach(function(label) {
 
     if (label.textContent.trim()!=="") {
-      var actor = qx.bom.Selector.matches('.actor', qx.dom.Hierarchy.getSiblings(label))[0];
-      if (actor && qx.bom.Selector.matches('img', qx.dom.Hierarchy.getChildElements(label)).length === 0) {
-        var value = qx.bom.Selector.matches('.value', qx.dom.Hierarchy.getChildElements(actor))[0];
+      var actor = Array.prototype.filter.call(qx.dom.Hierarchy.getSiblings(label),function(m){return m.matches('.actor');})[0];
+      if (actor && Array.prototype.filter.call(qx.dom.Hierarchy.getChildElements(label),function(m){return m.matches('img');}).length === 0) {
+        var value = Array.prototype.filter.call(qx.dom.Hierarchy.getChildElements(actor),function(m){return m.matches('.value');})[0];
         if (value && value.textContent.trim() !== "") {
           actor.style['padding-top'] = '0.5em';
         }

--- a/source/resource/designs/metal/design_setup.js
+++ b/source/resource/designs/metal/design_setup.js
@@ -25,9 +25,9 @@
  * @since 2012
  */
 qx.event.message.Bus.subscribe("setup.dom.finished.before", function() {
-  qx.bom.element.Dataset.set(qx.bom.Selector.query('#navbarLeft')[0], 'columns', 6);
-  qx.bom.element.Dataset.set(qx.bom.Selector.query('#main')[0], 'columns', 12);
-  qx.bom.element.Dataset.set(qx.bom.Selector.query('#navbarRight')[0], 'columns', 6);
+  qx.bom.element.Dataset.set(document.querySelector('#navbarLeft'), 'columns', 6);
+  qx.bom.element.Dataset.set(document.querySelector('#main'), 'columns', 12);
+  qx.bom.element.Dataset.set(document.querySelector('#navbarRight'), 'columns', 6);
 });
 
 function getOffsetCorners(elem) {

--- a/source/resource/designs/metal/design_setup.js
+++ b/source/resource/designs/metal/design_setup.js
@@ -25,9 +25,9 @@
  * @since 2012
  */
 qx.event.message.Bus.subscribe("setup.dom.finished.before", function() {
-  qx.bom.element.Dataset.set(document.querySelector('#navbarLeft'), 'columns', 6);
-  qx.bom.element.Dataset.set(document.querySelector('#main'), 'columns', 12);
-  qx.bom.element.Dataset.set(document.querySelector('#navbarRight'), 'columns', 6);
+  document.querySelector('#navbarLeft').dataset['columns'] = 6;
+  document.querySelector('#main').dataset['columns'] = 12;
+  document.querySelector('#navbarRight').dataset['columns'] = 6;
 });
 
 function getOffsetCorners(elem) {

--- a/source/resource/designs/metal/design_setup.js
+++ b/source/resource/designs/metal/design_setup.js
@@ -42,7 +42,7 @@ function getOffsetCorners(elem) {
 
 function setRadius(elem, type, value) {
   elem.style[type] = value;
-  qx.dom.Hierarchy.getChildElements(elem).forEach(function(subElem) {
+  Array.from(elem.children).forEach(function(subElem) {
     subElem.style[type] = value;
   }, this);
 }
@@ -97,8 +97,8 @@ qx.event.message.Bus.subscribe("setup.dom.finished", function() {
 
     if (label.textContent.trim()!=="") {
       var actor = Array.prototype.filter.call(qx.dom.Hierarchy.getSiblings(label),function(m){return m.matches('.actor');})[0];
-      if (actor && Array.prototype.filter.call(qx.dom.Hierarchy.getChildElements(label),function(m){return m.matches('img');}).length === 0) {
-        var value = Array.prototype.filter.call(qx.dom.Hierarchy.getChildElements(actor),function(m){return m.matches('.value');})[0];
+      if (actor && Array.from(label.children).filter(function(m){return m.matches('img');}).length === 0) {
+        var value = Array.from(actor.children).filter(function(m){return m.matches('.value');})[0];
         if (value && value.textContent.trim() !== "") {
           actor.style['padding-top'] = '0.5em';
         }

--- a/source/resource/designs/metal/design_setup.js
+++ b/source/resource/designs/metal/design_setup.js
@@ -108,7 +108,7 @@ qx.event.message.Bus.subscribe("setup.dom.finished", function() {
   // Disable borders for groups that contain widget-group as children
   document.querySelectorAll('.page > div > .widget_container > .group:not(.widget)').forEach(function(elem) {
     if (elem.querySelectorAll('.clearfix > .widget_container > .group.widget').length > 0) {
-      Object.entries({'border': 'none', 'margin': 0}).forEach(function(key,value){elem.style[key]=value;});
+      Object.entries({'border': 'none', 'margin': 0}).forEach(function([key,value]){elem.style[key]=value;});
     }
   });
 });

--- a/source/resource/designs/metal/design_setup.js
+++ b/source/resource/designs/metal/design_setup.js
@@ -108,7 +108,7 @@ qx.event.message.Bus.subscribe("setup.dom.finished", function() {
   // Disable borders for groups that contain widget-group as children
   document.querySelectorAll('.page > div > .widget_container > .group:not(.widget)').forEach(function(elem) {
     if (elem.querySelectorAll('.clearfix > .widget_container > .group.widget').length > 0) {
-      Object.entries({'border': 'none', 'margin': 0}).forEach(function([key,value]){elem.style[key]=value;});
+      Object.entries({'border': 'none', 'margin': 0}).forEach(function(key_value){elem.style[key_value[0]]=key_value[1];});
     }
   });
 });

--- a/source/resource/designs/pitchblack/design_setup.js
+++ b/source/resource/designs/pitchblack/design_setup.js
@@ -25,7 +25,7 @@
  * @since 2012
  */
 qx.event.message.Bus.subscribe("setup.dom.finished.before", function() {
-  qx.bom.element.Dataset.set(qx.bom.Selector.query('head')[0], 'colspanDefault', 1);
-  qx.bom.element.Dataset.set(qx.bom.Selector.query('#navbarLeft')[0], 'columns', 6);
-  qx.bom.element.Dataset.set(qx.bom.Selector.query('#navbarRight')[0], 'columns', 6);
+  qx.bom.element.Dataset.set(document.querySelector('head'), 'colspanDefault', 1);
+  qx.bom.element.Dataset.set(document.querySelector('#navbarLeft'), 'columns', 6);
+  qx.bom.element.Dataset.set(document.querySelector('#navbarRight'), 'columns', 6);
 });

--- a/source/resource/designs/pitchblack/design_setup.js
+++ b/source/resource/designs/pitchblack/design_setup.js
@@ -25,7 +25,7 @@
  * @since 2012
  */
 qx.event.message.Bus.subscribe("setup.dom.finished.before", function() {
-  qx.bom.element.Dataset.set(document.querySelector('head'), 'colspanDefault', 1);
-  qx.bom.element.Dataset.set(document.querySelector('#navbarLeft'), 'columns', 6);
-  qx.bom.element.Dataset.set(document.querySelector('#navbarRight'), 'columns', 6);
+  document.querySelector('head').dataset['colspanDefault'] = 1;
+  document.querySelector('#navbarLeft').dataset['columns'] = 6;
+  document.querySelector('#navbarRight').dataset['columns'] = 6;
 });

--- a/source/resource/designs/planet/design_setup.js
+++ b/source/resource/designs/planet/design_setup.js
@@ -25,9 +25,9 @@
  * @since 2012
  */
 qx.event.message.Bus.subscribe("setup.dom.finished.before", function() {
-  qx.bom.element.Dataset.set(document.querySelector('#navbarLeft'), 'columns', 6);
-  qx.bom.element.Dataset.set(document.querySelector('#navbarLeft'), 'size', '12rem');
-  qx.bom.element.Dataset.set(document.querySelector('#main'), 'columns', 12);
-  qx.bom.element.Dataset.set(document.querySelector('#main'), 'disableSliderTransform', true);
-  qx.bom.element.Dataset.set(document.querySelector('#navbarRight'), 'columns', 6);
+  document.querySelector('#navbarLeft').dataset['columns'] = 6;
+  document.querySelector('#navbarLeft').dataset['size'] = '12rem';
+  document.querySelector('#main').dataset['columns'] = 12;
+  document.querySelector('#main').dataset['disableSliderTransform'] = true;
+  document.querySelector('#navbarRight').dataset['columns'] = 6;
 });

--- a/source/resource/designs/planet/design_setup.js
+++ b/source/resource/designs/planet/design_setup.js
@@ -25,9 +25,9 @@
  * @since 2012
  */
 qx.event.message.Bus.subscribe("setup.dom.finished.before", function() {
-  qx.bom.element.Dataset.set(qx.bom.Selector.query('#navbarLeft')[0], 'columns', 6);
-  qx.bom.element.Dataset.set(qx.bom.Selector.query('#navbarLeft')[0], 'size', '12rem');
-  qx.bom.element.Dataset.set(qx.bom.Selector.query('#main')[0], 'columns', 12);
-  qx.bom.element.Dataset.set(qx.bom.Selector.query('#main')[0], 'disableSliderTransform', true);
-  qx.bom.element.Dataset.set(qx.bom.Selector.query('#navbarRight')[0], 'columns', 6);
+  qx.bom.element.Dataset.set(document.querySelector('#navbarLeft'), 'columns', 6);
+  qx.bom.element.Dataset.set(document.querySelector('#navbarLeft'), 'size', '12rem');
+  qx.bom.element.Dataset.set(document.querySelector('#main'), 'columns', 12);
+  qx.bom.element.Dataset.set(document.querySelector('#main'), 'disableSliderTransform', true);
+  qx.bom.element.Dataset.set(document.querySelector('#navbarRight'), 'columns', 6);
 });

--- a/source/resource/designs/pure/design_setup.js
+++ b/source/resource/designs/pure/design_setup.js
@@ -25,8 +25,8 @@
  * @since 2012
  */
 qx.event.message.Bus.subscribe("setup.dom.finished.before", function() {
-  qx.bom.element.Dataset.set(document.querySelector('#navbarLeft'), 'columns', 6);
-  qx.bom.element.Dataset.set(document.querySelector('#main'), 'columns', 12);
-  qx.bom.element.Dataset.set(document.querySelector('#navbarRight'), 'columns', 6);
+  document.querySelector('#navbarLeft').dataset['columns'] = 6;
+  document.querySelector('#main').dataset['columns'] = 12;
+  document.querySelector('#navbarRight').dataset['columns'] = 6;
 });
 

--- a/source/resource/designs/pure/design_setup.js
+++ b/source/resource/designs/pure/design_setup.js
@@ -25,8 +25,8 @@
  * @since 2012
  */
 qx.event.message.Bus.subscribe("setup.dom.finished.before", function() {
-  qx.bom.element.Dataset.set(qx.bom.Selector.query('#navbarLeft')[0], 'columns', 6);
-  qx.bom.element.Dataset.set(qx.bom.Selector.query('#main')[0], 'columns', 12);
-  qx.bom.element.Dataset.set(qx.bom.Selector.query('#navbarRight')[0], 'columns', 6);
+  qx.bom.element.Dataset.set(document.querySelector('#navbarLeft'), 'columns', 6);
+  qx.bom.element.Dataset.set(document.querySelector('#main'), 'columns', 12);
+  qx.bom.element.Dataset.set(document.querySelector('#navbarRight'), 'columns', 6);
 });
 

--- a/source/resource/plugins/openweathermap/owm_core.js
+++ b/source/resource/plugins/openweathermap/owm_core.js
@@ -382,7 +382,7 @@ var jOWM = jOWM || {};
        req.addListener("success", function (ev) {
            var req = ev.getTarget();
            var data = req.getResponse();
-           if (qx.lang.Type.isString(data)) {
+           if (typeof data === 'string') {
                data = qx.lang.Json.parse(data);
            }
            callback(data);

--- a/source/resource/plugins/openweathermap/owm_core.js
+++ b/source/resource/plugins/openweathermap/owm_core.js
@@ -383,7 +383,7 @@ var jOWM = jOWM || {};
            var req = ev.getTarget();
            var data = req.getResponse();
            if (typeof data === 'string') {
-               data = qx.lang.Json.parse(data);
+               data = JSON.parse(data);
            }
            callback(data);
        }, this);

--- a/source/test/karma/core/notifications/Router-spec.js
+++ b/source/test/karma/core/notifications/Router-spec.js
@@ -113,24 +113,24 @@ describe('test the notification router', function () {
     var model = cv.data.Model.getInstance();
     model.onUpdate("0/0/1", 1);
 
-    var popup = qx.bom.Selector.query("#popup_0")[0];
+    var popup = document.querySelector("#popup_0");
 
     // initial state should trigger no popup
-    expect(popup).toBeUndefined();
+    expect(popup).toBeNull();
 
     model.onUpdate("0/0/1", 0);
-    popup = qx.bom.Selector.query("#popup_0")[0];
+    popup = document.querySelector("#popup_0");
     // still no popup cause value is 0
-    expect(popup).toBeUndefined();
+    expect(popup).toBeNull();
 
     model.onUpdate("0/0/1", 1);
-    popup = qx.bom.Selector.query("#popup_0")[0];
-    expect(popup).not.toBeUndefined();
+    popup = document.querySelector("#popup_0");
+    expect(popup).not.toBeNull();
 
     model.onUpdate("0/0/1", 0);
-    popup = qx.bom.Selector.query("#popup_0")[0];
+    popup = document.querySelector("#popup_0");
     // as the condition isn't met anymore the popup must be gone
-    expect(popup).toBeUndefined();
+    expect(popup).toBeNull();
 
     router.unregisterStateUpdatehandler(["0/0/1"]);
   });

--- a/source/test/karma/core/notifications/actions/Link-spec.js
+++ b/source/test/karma/core/notifications/actions/Link-spec.js
@@ -10,7 +10,7 @@ describe("testing the Link action", function() {
     });
 
     var actionButton = action.getDomElement();
-    expect(actionButton.getAttribute("text")).toBe("Title");
+    expect(actionButton.innerText).toBe("Title");
     expect(actionButton).toHaveClass("action");
 
     var spy = spyOn(cv.util.Location, "open");

--- a/source/test/karma/core/notifications/actions/Link-spec.js
+++ b/source/test/karma/core/notifications/actions/Link-spec.js
@@ -28,7 +28,7 @@ describe("testing the Link action", function() {
       action: "reload",
       needsConfirmation: false
     });
-    expect(qx.lang.Type.isFunction(action.getAction())).toBeTruthy();
+    expect(typeof action.getAction() === 'function').toBeTruthy();
 
     action = new cv.core.notifications.actions.Link({
       title: "Title",
@@ -42,7 +42,7 @@ describe("testing the Link action", function() {
       action: function() {},
       needsConfirmation: false
     });
-    expect(qx.lang.Type.isFunction(action.getAction())).toBeTruthy();
+    expect(typeof action.getAction() === 'function').toBeTruthy();
   });
 
   it("should execute the actions", function() {

--- a/source/test/karma/core/notifications/actions/Link-spec.js
+++ b/source/test/karma/core/notifications/actions/Link-spec.js
@@ -10,7 +10,7 @@ describe("testing the Link action", function() {
     });
 
     var actionButton = action.getDomElement();
-    expect(qx.bom.element.Attribute.get(actionButton, "text")).toBe("Title");
+    expect(actionButton.getAttribute("text")).toBe("Title");
     expect(actionButton).toHaveClass("action");
 
     var spy = spyOn(cv.util.Location, "open");

--- a/source/test/karma/helper-spec.js
+++ b/source/test/karma/helper-spec.js
@@ -40,7 +40,7 @@ var createTestWidgetString = function (name, attributes, content) {
     content = "";
   }
   var elem = qx.dom.Element.create(name, attributes);
-  elem.setAttribute("html", content);
+  elem.innerHTML = content;
 
   var data = null;
   if (name !== "page") {

--- a/source/test/karma/helper-spec.js
+++ b/source/test/karma/helper-spec.js
@@ -194,7 +194,7 @@ var customMatchers = {
     return  {
       compare: function(actual, expected) {
         var result = {};
-        var label = Array.prototype.filter.call(qx.dom.Hierarchy.getChildElements(actual),function(m){return m.matches("div.label");})[0];
+        var label = Array.from(actual.children).filter(function(m){return m.matches("div.label");})[0];
         result.pass = label && label.innerText === expected;
         if (result.pass) {
           result.message = "Expected " + actual.tagName + " not to have value "+expected;

--- a/source/test/karma/helper-spec.js
+++ b/source/test/karma/helper-spec.js
@@ -162,7 +162,7 @@ var customMatchers = {
       compare: function(actual, expected) {
         var result = {};
 
-        result.pass = qx.bom.element.Class.has(actual, 'flavour_'+expected);
+        result.pass = actual.classList.contains('flavour_'+expected);
         if (result.pass) {
           result.message = "Expected " + actual.tagName + " not to be flavoured with "+expected;
         }
@@ -178,7 +178,7 @@ var customMatchers = {
     return  {
       compare: function(actual, expected) {
         var result = {};
-        result.pass = qx.bom.element.Class.has(actual, expected);
+        result.pass = actual.classList.contains(expected);
         if (result.pass) {
           result.message = "Expected " + actual.tagName + " not to have class "+expected;
         }

--- a/source/test/karma/helper-spec.js
+++ b/source/test/karma/helper-spec.js
@@ -135,7 +135,7 @@ resetApplication = function() {
     delete subs[topic];
   });
 
-  var body = qx.bom.Selector.query("body")[0];
+  var body = document.querySelector("body");
   // load empty HTML structure
   qx.dom.Element.empty(body);
   qx.bom.Html.clean([cv.Application.HTML_STRUCT], null, body);
@@ -350,7 +350,7 @@ afterEach(function () {
     this.creator = null;
   }
 
-  var body = qx.bom.Selector.query("body")[0];
+  var body = document.querySelector("body");
   // load empty HTML structure
   qx.dom.Element.empty(body);
   qx.bom.Html.clean([cv.Application.HTML_STRUCT], null, body);

--- a/source/test/karma/helper-spec.js
+++ b/source/test/karma/helper-spec.js
@@ -137,8 +137,7 @@ resetApplication = function() {
 
   var body = document.querySelector("body");
   // load empty HTML structure
-  body.innerHTML = '';
-  qx.bom.Html.clean([cv.Application.HTML_STRUCT], null, body);
+  body.innerHTML = cv.Application.HTML_STRUCT;
 
   cv.Config.cacheUsed = false;
   // reset templateEngine's init values
@@ -352,8 +351,7 @@ afterEach(function () {
 
   var body = document.querySelector("body");
   // load empty HTML structure
-  body.innerHTML = '';
-  qx.bom.Html.clean([cv.Application.HTML_STRUCT], null, body);
+  body.innerHTML = cv.Application.HTML_STRUCT;
   cv.TemplateEngine.getInstance().resetDomFinished();
   // resetApplication();
 });

--- a/source/test/karma/helper-spec.js
+++ b/source/test/karma/helper-spec.js
@@ -278,9 +278,9 @@ var customMatchers = {
     return  {
       compare: function(actual) {
         var result = {};
-        result.pass = qx.bom.element.Style.get(actual, 'display') !== 'none';
+        result.pass = window.getComputedStyle(actual)['display'] !== 'none';
         if (result.pass) {
-          result.message = "Expected " + actual.tagName + " not to be visible, but it is "+qx.bom.element.Style.get(actual, 'display');
+          result.message = "Expected " + actual.tagName + " not to be visible, but it is "+window.getComputedStyle(actual)['display'];
         }
         else{
           result.message = "Expected " + actual.tagName + " to be visible";

--- a/source/test/karma/helper-spec.js
+++ b/source/test/karma/helper-spec.js
@@ -46,7 +46,7 @@ var createTestWidgetString = function (name, attributes, content) {
   if (name !== "page") {
     // create surrounding root page
     var page = qx.dom.Element.create("page", {visible: "false"});
-    qx.dom.Element.insertEnd(elem, page);
+    page.appendChild(elem);
     data = cv.parser.WidgetParser.parse(page, 'id', null, "text");
     cv.ui.structure.WidgetFactory.createInstance(data.$$type, data);
     data = cv.data.Model.getInstance().getWidgetData(data.children[0]);
@@ -137,7 +137,7 @@ resetApplication = function() {
 
   var body = document.querySelector("body");
   // load empty HTML structure
-  qx.dom.Element.empty(body);
+  body.innerHTML = '';
   qx.bom.Html.clean([cv.Application.HTML_STRUCT], null, body);
 
   cv.Config.cacheUsed = false;
@@ -153,7 +153,7 @@ resetApplication = function() {
 // DOM Helpers
 
 var findChild = function(elem, selector) {
-  return Array.prototype.filter.call(qx.dom.Hierarchy.getDescendants(elem),function(m){return m.matches(selector);})[0];
+  return Array.from(elem.getElementsByTagName("*")).filter(function(m){return m.matches(selector);})[0];
 };
 
 var customMatchers = {
@@ -195,12 +195,12 @@ var customMatchers = {
       compare: function(actual, expected) {
         var result = {};
         var label = Array.prototype.filter.call(qx.dom.Hierarchy.getChildElements(actual),function(m){return m.matches("div.label");})[0];
-        result.pass = label && qx.dom.Node.getText(label) === expected;
+        result.pass = label && label.innerText === expected;
         if (result.pass) {
           result.message = "Expected " + actual.tagName + " not to have value "+expected;
         }
         else{
-          result.message = "Expected " + actual.tagName + " to have value "+expected+", but it has "+qx.dom.Node.getText(label);
+          result.message = "Expected " + actual.tagName + " to have value "+expected+", but it has "+label.innerText;
         }
         return result;
       }
@@ -211,13 +211,13 @@ var customMatchers = {
     return  {
       compare: function(actual, expected) {
         var result = {};
-        var label = Array.prototype.filter.call(qx.dom.Hierarchy.getDescendants(actual),function(m){return m.matches(".value");})[0];
-        result.pass = label && qx.dom.Node.getText(label) === expected;
+        var label = Array.from(actual.getElementsByTagName("*")).filter(function(m){return m.matches(".value");})[0];
+        result.pass = label && label.innerText === expected;
         if (result.pass) {
           result.message = "Expected " + actual.tagName + " not to have label "+expected;
         }
         else{
-          result.message = "Expected " + actual.tagName + " to have label "+expected+", but it has "+qx.dom.Node.getText(label);
+          result.message = "Expected " + actual.tagName + " to have label "+expected+", but it has "+label.innerText;
         }
         return result;
       }
@@ -352,7 +352,7 @@ afterEach(function () {
 
   var body = document.querySelector("body");
   // load empty HTML structure
-  qx.dom.Element.empty(body);
+  body.innerHTML = '';
   qx.bom.Html.clean([cv.Application.HTML_STRUCT], null, body);
   cv.TemplateEngine.getInstance().resetDomFinished();
   // resetApplication();

--- a/source/test/karma/helper-spec.js
+++ b/source/test/karma/helper-spec.js
@@ -153,7 +153,7 @@ resetApplication = function() {
 // DOM Helpers
 
 var findChild = function(elem, selector) {
-  return qx.bom.Selector.matches(selector, qx.dom.Hierarchy.getDescendants(elem))[0];
+  return Array.prototype.filter.call(qx.dom.Hierarchy.getDescendants(elem),function(m){return m.matches(selector);})[0];
 };
 
 var customMatchers = {
@@ -194,7 +194,7 @@ var customMatchers = {
     return  {
       compare: function(actual, expected) {
         var result = {};
-        var label = qx.bom.Selector.matches("div.label", qx.dom.Hierarchy.getChildElements(actual))[0];
+        var label = Array.prototype.filter.call(qx.dom.Hierarchy.getChildElements(actual),function(m){return m.matches("div.label");})[0];
         result.pass = label && qx.dom.Node.getText(label) === expected;
         if (result.pass) {
           result.message = "Expected " + actual.tagName + " not to have value "+expected;
@@ -211,7 +211,7 @@ var customMatchers = {
     return  {
       compare: function(actual, expected) {
         var result = {};
-        var label = qx.bom.Selector.matches(".value", qx.dom.Hierarchy.getDescendants(actual))[0];
+        var label = Array.prototype.filter.call(qx.dom.Hierarchy.getDescendants(actual),function(m){return m.matches(".value");})[0];
         result.pass = label && qx.dom.Node.getText(label) === expected;
         if (result.pass) {
           result.message = "Expected " + actual.tagName + " not to have label "+expected;

--- a/source/test/karma/helper-spec.js
+++ b/source/test/karma/helper-spec.js
@@ -40,7 +40,7 @@ var createTestWidgetString = function (name, attributes, content) {
     content = "";
   }
   var elem = qx.dom.Element.create(name, attributes);
-  qx.bom.element.Attribute.set(elem, "html", content);
+  elem.setAttribute("html", content);
 
   var data = null;
   if (name !== "page") {

--- a/source/test/karma/plugins/ColorChooser-spec.js
+++ b/source/test/karma/plugins/ColorChooser-spec.js
@@ -41,7 +41,7 @@ describe("testing a colorchooser plugin", function() {
 
   it("should test the colorchooser creator", function() {
     var res = this.createTestWidgetString("colorchooser", {id: 'test'}, '<label>Test</label>');
-    var widget = qx.bom.Html.clean([res[1]])[0];
+    var widget = (function(){var div=document.createElement('div');div.innerHTML=res[1];return div.childNodes[0];})();
     var widgetInstance = res[0];
 
     expect(widget).toHaveClass('colorchooser');

--- a/source/test/karma/plugins/ColorChooser-spec.js
+++ b/source/test/karma/plugins/ColorChooser-spec.js
@@ -41,7 +41,7 @@ describe("testing a colorchooser plugin", function() {
 
   it("should test the colorchooser creator", function() {
     var res = this.createTestWidgetString("colorchooser", {id: 'test'}, '<label>Test</label>');
-    var widget = (function(){var div=document.createElement('div');div.innerHTML=res[1];return div.childNodes[0];})();
+    var widget = cv.util.String.htmlStringToDomElement(res[1]);
     var widgetInstance = res[0];
 
     expect(widget).toHaveClass('colorchooser');

--- a/source/test/karma/plugins/tr064-spec.js
+++ b/source/test/karma/plugins/tr064-spec.js
@@ -47,7 +47,7 @@ describe("testing a TR-064 plugin", function() {
 
   it("should test the TR-064:calllist creator", function() {
     var res = this.createTestWidgetString("calllist", {id: 'test', device: 'testdevice'}, '<label>Test</label>');
-    var widget = qx.bom.Html.clean([res[1]])[0];
+    var widget = (function(){var div=document.createElement('div');div.innerHTML=res[1];return div.childNodes[0];})();
     var widgetInstance = res[0];
 
     expect(widget).toHaveClass('calllist');

--- a/source/test/karma/plugins/tr064-spec.js
+++ b/source/test/karma/plugins/tr064-spec.js
@@ -47,7 +47,7 @@ describe("testing a TR-064 plugin", function() {
 
   it("should test the TR-064:calllist creator", function() {
     var res = this.createTestWidgetString("calllist", {id: 'test', device: 'testdevice'}, '<label>Test</label>');
-    var widget = (function(){var div=document.createElement('div');div.innerHTML=res[1];return div.childNodes[0];})();
+    var widget = cv.util.String.htmlStringToDomElement(res[1]);
     var widgetInstance = res[0];
 
     expect(widget).toHaveClass('calllist');

--- a/source/test/karma/ui/NotificationCenter-spec.js
+++ b/source/test/karma/ui/NotificationCenter-spec.js
@@ -108,7 +108,7 @@ describe('test the NotificationCenter', function () {
     // as we had 2 messages with same topic both should be gone now
     expect(center.getMessages().getLength()).toBe(0);
 
-    expect(badge.innerHTML).toBeNull();
+    expect(badge.innerHTML).toBe('');
     expect(qx.bom.element.Class.has(badge, "urgent")).toBeFalsy();
   });
 

--- a/source/test/karma/ui/NotificationCenter-spec.js
+++ b/source/test/karma/ui/NotificationCenter-spec.js
@@ -74,7 +74,7 @@ describe('test the NotificationCenter', function () {
     center.handleMessage(qx.lang.Object.clone(message));
     expect(center.getMessages().getLength()).toBe(1);
 
-    expect(qx.bom.element.Attribute.get(badge, "html")).toEqual("1");
+    expect(badge.getAttribute("html")).toEqual("1");
     expect(qx.bom.element.Class.has(badge, "normal")).toBeTruthy();
 
     // add message with higher severity
@@ -85,7 +85,7 @@ describe('test the NotificationCenter', function () {
     // as the message was unique it replaces the old one
     expect(center.getMessages().getLength()).toBe(1);
 
-    expect(qx.bom.element.Attribute.get(badge, "html")).toEqual("1");
+    expect(badge.getAttribute("html")).toEqual("1");
     expect(qx.bom.element.Class.has(badge, "high")).toBeTruthy();
 
     // add message with higher severity
@@ -96,7 +96,7 @@ describe('test the NotificationCenter', function () {
     // as the message was unique it replaces the old one
     expect(center.getMessages().getLength()).toBe(2);
 
-    expect(qx.bom.element.Attribute.get(badge, "html")).toEqual("2");
+    expect(badge.getAttribute("html")).toEqual("2");
     expect(qx.bom.element.Class.has(badge, "urgent")).toBeTruthy();
 
     // remove unique messages
@@ -108,7 +108,7 @@ describe('test the NotificationCenter', function () {
     // as we had 2 messages with same topic both should be gone now
     expect(center.getMessages().getLength()).toBe(0);
 
-    expect(qx.bom.element.Attribute.get(badge, "html")).toBeNull();
+    expect(badge.getAttribute("html")).toBeNull();
     expect(qx.bom.element.Class.has(badge, "urgent")).toBeFalsy();
   });
 

--- a/source/test/karma/ui/NotificationCenter-spec.js
+++ b/source/test/karma/ui/NotificationCenter-spec.js
@@ -71,7 +71,7 @@ describe('test the NotificationCenter', function () {
     var badge = document.querySelector("#notification-center .badge");
     expect(badge).not.toBeUndefined();
 
-    center.handleMessage(qx.lang.Object.clone(message));
+    center.handleMessage(Object.assign({}, message));
     expect(center.getMessages().getLength()).toBe(1);
 
     expect(badge.innerHTML).toEqual("1");
@@ -81,7 +81,7 @@ describe('test the NotificationCenter', function () {
     message.severity = "high";
     message.unique = true;
 
-    center.handleMessage(qx.lang.Object.clone(message));
+    center.handleMessage(Object.assign({}, message));
     // as the message was unique it replaces the old one
     expect(center.getMessages().getLength()).toBe(1);
 
@@ -92,7 +92,7 @@ describe('test the NotificationCenter', function () {
     message.severity = "urgent";
     message.unique = false;
 
-    center.handleMessage(qx.lang.Object.clone(message));
+    center.handleMessage(Object.assign({}, message));
     // as the message was unique it replaces the old one
     expect(center.getMessages().getLength()).toBe(2);
 
@@ -103,8 +103,8 @@ describe('test the NotificationCenter', function () {
     message.condition = false;
     message.unique = true;
 
-    center.handleMessage(qx.lang.Object.clone(message));
-    center.handleMessage(qx.lang.Object.clone(message));
+    center.handleMessage(Object.assign({}, message));
+    center.handleMessage(Object.assign({}, message));
     // as we had 2 messages with same topic both should be gone now
     expect(center.getMessages().getLength()).toBe(0);
 
@@ -122,7 +122,7 @@ describe('test the NotificationCenter', function () {
     };
 
     for(var i=0; i< 10; i++) {
-      var msg = qx.lang.Object.clone(message);
+      var msg = Object.assign({}, message);
       msg.title = i;
       center.handleMessage(msg);
     }

--- a/source/test/karma/ui/NotificationCenter-spec.js
+++ b/source/test/karma/ui/NotificationCenter-spec.js
@@ -48,13 +48,13 @@ describe('test the NotificationCenter', function () {
 
     expect(element).not.toBeUndefined();
 
-    expect(qx.bom.element.Class.has(element, "hidden")).toBeFalsy();
+    expect(element.classList.contains("hidden")).toBeFalsy();
     center.disableBadge(true);
     setTimeout(function() {
-      expect(qx.bom.element.Class.has(element, "hidden")).toBeTruthy();
+      expect(element.classList.contains("hidden")).toBeTruthy();
       center.disableBadge(false);
       setTimeout(function() {
-        expect(qx.bom.element.Class.has(element, "hidden")).toBeFalsy();
+        expect(element.classList.contains("hidden")).toBeFalsy();
         done();
       }, 10);
     }, 10);
@@ -75,7 +75,7 @@ describe('test the NotificationCenter', function () {
     expect(center.getMessages().getLength()).toBe(1);
 
     expect(badge.innerHTML).toEqual("1");
-    expect(qx.bom.element.Class.has(badge, "normal")).toBeTruthy();
+    expect(badge.classList.contains("normal")).toBeTruthy();
 
     // add message with higher severity
     message.severity = "high";
@@ -86,7 +86,7 @@ describe('test the NotificationCenter', function () {
     expect(center.getMessages().getLength()).toBe(1);
 
     expect(badge.innerHTML).toEqual("1");
-    expect(qx.bom.element.Class.has(badge, "high")).toBeTruthy();
+    expect(badge.classList.contains("high")).toBeTruthy();
 
     // add message with higher severity
     message.severity = "urgent";
@@ -97,7 +97,7 @@ describe('test the NotificationCenter', function () {
     expect(center.getMessages().getLength()).toBe(2);
 
     expect(badge.innerHTML).toEqual("2");
-    expect(qx.bom.element.Class.has(badge, "urgent")).toBeTruthy();
+    expect(badge.classList.contains("urgent")).toBeTruthy();
 
     // remove unique messages
     message.condition = false;
@@ -109,7 +109,7 @@ describe('test the NotificationCenter', function () {
     expect(center.getMessages().getLength()).toBe(0);
 
     expect(badge.innerHTML).toBe('');
-    expect(qx.bom.element.Class.has(badge, "urgent")).toBeFalsy();
+    expect(badge.classList.contains("urgent")).toBeFalsy();
   });
 
   it("should test the maxEntries limit", function() {

--- a/source/test/karma/ui/NotificationCenter-spec.js
+++ b/source/test/karma/ui/NotificationCenter-spec.js
@@ -27,7 +27,7 @@ describe('test the NotificationCenter', function () {
   });
 
   it('should toggle the visibility', function(done) {
-    var element = qx.bom.Selector.query("#notification-center")[0];
+    var element = document.querySelector("#notification-center");
 
     expect(element).not.toBeUndefined();
 
@@ -44,7 +44,7 @@ describe('test the NotificationCenter', function () {
   });
 
   it('should toggle the badge visibility', function(done) {
-    var element = qx.bom.Selector.query("#notification-center .badge")[0];
+    var element = document.querySelector("#notification-center .badge");
 
     expect(element).not.toBeUndefined();
 
@@ -68,7 +68,7 @@ describe('test the NotificationCenter', function () {
       message: "Test message",
       severity: "normal"
     };
-    var badge = qx.bom.Selector.query("#notification-center .badge")[0];
+    var badge = document.querySelector("#notification-center .badge");
     expect(badge).not.toBeUndefined();
 
     center.handleMessage(qx.lang.Object.clone(message));
@@ -216,7 +216,7 @@ describe('test the NotificationCenter', function () {
       };
       center.handleMessage(message);
 
-      var messageElement = qx.bom.Selector.query("#notification_0")[0];
+      var messageElement = document.querySelector("#notification_0");
       spyOn(center, "deleteMessage");
       spyOn(center, "performAction");
 
@@ -232,13 +232,13 @@ describe('test the NotificationCenter', function () {
         cancelable: true,
         view: window
       });
-      var element = qx.bom.Selector.query(".content", messageElement)[0];
+      var element = messageElement.querySelector(".content");
       element.dispatchEvent(down);
       element.dispatchEvent(up);
       expect(center.performAction).toHaveBeenCalledWith(0, jasmine.any(qx.event.type.Event));
 
       // click on the delete button
-      element = qx.bom.Selector.query(".delete", messageElement)[0];
+      element = messageElement.querySelector(".delete");
       element.dispatchEvent(down);
       element.dispatchEvent(up);
       expect(center.deleteMessage).toHaveBeenCalledWith(0, jasmine.any(qx.event.type.Event));

--- a/source/test/karma/ui/NotificationCenter-spec.js
+++ b/source/test/karma/ui/NotificationCenter-spec.js
@@ -74,7 +74,7 @@ describe('test the NotificationCenter', function () {
     center.handleMessage(qx.lang.Object.clone(message));
     expect(center.getMessages().getLength()).toBe(1);
 
-    expect(badge.getAttribute("html")).toEqual("1");
+    expect(badge.innerHTML).toEqual("1");
     expect(qx.bom.element.Class.has(badge, "normal")).toBeTruthy();
 
     // add message with higher severity
@@ -85,7 +85,7 @@ describe('test the NotificationCenter', function () {
     // as the message was unique it replaces the old one
     expect(center.getMessages().getLength()).toBe(1);
 
-    expect(badge.getAttribute("html")).toEqual("1");
+    expect(badge.innerHTML).toEqual("1");
     expect(qx.bom.element.Class.has(badge, "high")).toBeTruthy();
 
     // add message with higher severity
@@ -96,7 +96,7 @@ describe('test the NotificationCenter', function () {
     // as the message was unique it replaces the old one
     expect(center.getMessages().getLength()).toBe(2);
 
-    expect(badge.getAttribute("html")).toEqual("2");
+    expect(badge.innerHTML).toEqual("2");
     expect(qx.bom.element.Class.has(badge, "urgent")).toBeTruthy();
 
     // remove unique messages
@@ -108,7 +108,7 @@ describe('test the NotificationCenter', function () {
     // as we had 2 messages with same topic both should be gone now
     expect(center.getMessages().getLength()).toBe(0);
 
-    expect(badge.getAttribute("html")).toBeNull();
+    expect(badge.innerHTML).toBeNull();
     expect(qx.bom.element.Class.has(badge, "urgent")).toBeFalsy();
   });
 

--- a/source/test/karma/ui/NotificationCenter-spec.js
+++ b/source/test/karma/ui/NotificationCenter-spec.js
@@ -31,13 +31,13 @@ describe('test the NotificationCenter', function () {
 
     expect(element).not.toBeUndefined();
 
-    expect(qx.bom.element.Style.get(element, "transform")).toEqual("none");
+    expect(window.getComputedStyle(element)["transform"]).toEqual("none");
     center.show();
     setTimeout(function() {
-      expect(qx.bom.element.Style.get(element, "transform")).toEqual("matrix(1, 0, 0, 1, -300, 0)");
+      expect(window.getComputedStyle(element)["transform"]).toEqual("matrix(1, 0, 0, 1, -300, 0)");
       center.hide();
       setTimeout(function() {
-        expect(qx.bom.element.Style.get(element, "transform")).toEqual("matrix(1, 0, 0, 1, 0, 0)");
+        expect(window.getComputedStyle(element)["transform"]).toEqual("matrix(1, 0, 0, 1, 0, 0)");
         done();
       }, 10);
     }, 10);

--- a/source/test/karma/ui/ToastManager-spec.js
+++ b/source/test/karma/ui/ToastManager-spec.js
@@ -41,7 +41,7 @@ describe('test the NotificationCenter', function () {
     // as the message was unique it replaces the old one
     expect(center.getMessages().getLength()).toBe(1);
 
-    var messageElement = qx.bom.Selector.query("#"+center.getMessageElementId()+messageId)[0];
+    var messageElement = document.querySelector("#"+center.getMessageElementId()+messageId);
     expect(qx.bom.element.Class.has(messageElement, "high")).toBeTruthy();
 
     // add message with higher severity
@@ -53,7 +53,7 @@ describe('test the NotificationCenter', function () {
     // as the message was unique it replaces the old one
     expect(center.getMessages().getLength()).toBe(2);
 
-    messageElement = qx.bom.Selector.query("#"+center.getMessageElementId()+messageId)[0];
+    messageElement = document.querySelector("#"+center.getMessageElementId()+messageId);
     expect(qx.bom.element.Class.has(messageElement, "urgent")).toBeTruthy();
 
     // remove unique messages
@@ -182,7 +182,7 @@ describe('test the NotificationCenter', function () {
       var messageId = center.__idCounter;
       center.handleMessage(message);
 
-      var element = qx.bom.Selector.query("#"+center.getMessageElementId()+messageId)[0];
+      var element = document.querySelector("#"+center.getMessageElementId()+messageId);
       element.dispatchEvent(down);
       element.dispatchEvent(up);
       expect(center.deleteMessage).toHaveBeenCalledWith(messageId);
@@ -203,7 +203,7 @@ describe('test the NotificationCenter', function () {
 
       center.handleMessage(message);
 
-      element = qx.bom.Selector.query("#"+center.getMessageElementId()+messageId)[0];
+      element = document.querySelector("#"+center.getMessageElementId()+messageId);
 
       spyOn(center, "performAction");
 

--- a/source/test/karma/ui/ToastManager-spec.js
+++ b/source/test/karma/ui/ToastManager-spec.js
@@ -42,7 +42,7 @@ describe('test the NotificationCenter', function () {
     expect(center.getMessages().getLength()).toBe(1);
 
     var messageElement = document.querySelector("#"+center.getMessageElementId()+messageId);
-    expect(qx.bom.element.Class.has(messageElement, "high")).toBeTruthy();
+    expect(messageElement.classList.contains("high")).toBeTruthy();
 
     // add message with higher severity
     message.severity = "urgent";
@@ -54,7 +54,7 @@ describe('test the NotificationCenter', function () {
     expect(center.getMessages().getLength()).toBe(2);
 
     messageElement = document.querySelector("#"+center.getMessageElementId()+messageId);
-    expect(qx.bom.element.Class.has(messageElement, "urgent")).toBeTruthy();
+    expect(messageElement.classList.contains("urgent")).toBeTruthy();
 
     // remove unique messages
     message.condition = false;

--- a/source/test/karma/ui/ToastManager-spec.js
+++ b/source/test/karma/ui/ToastManager-spec.js
@@ -29,7 +29,7 @@ describe('test the NotificationCenter', function () {
       target: "toast"
     };
 
-    center.handleMessage(qx.lang.Object.clone(message));
+    center.handleMessage(Object.assign({}, message));
     expect(center.getMessages().getLength()).toBe(1);
 
     // add message with higher severity
@@ -37,7 +37,7 @@ describe('test the NotificationCenter', function () {
     message.unique = true;
 
     var messageId = center.__idCounter-1;
-    center.handleMessage(qx.lang.Object.clone(message));
+    center.handleMessage(Object.assign({}, message));
     // as the message was unique it replaces the old one
     expect(center.getMessages().getLength()).toBe(1);
 
@@ -49,7 +49,7 @@ describe('test the NotificationCenter', function () {
     message.unique = false;
 
     messageId = center.__idCounter;
-    center.handleMessage(qx.lang.Object.clone(message));
+    center.handleMessage(Object.assign({}, message));
     // as the message was unique it replaces the old one
     expect(center.getMessages().getLength()).toBe(2);
 
@@ -60,8 +60,8 @@ describe('test the NotificationCenter', function () {
     message.condition = false;
     message.unique = true;
 
-    center.handleMessage(qx.lang.Object.clone(message));
-    center.handleMessage(qx.lang.Object.clone(message));
+    center.handleMessage(Object.assign({}, message));
+    center.handleMessage(Object.assign({}, message));
     // as we had 2 messages with same topic both should be gone now
     expect(center.getMessages().getLength()).toBe(0);
 
@@ -78,7 +78,7 @@ describe('test the NotificationCenter', function () {
     };
 
     for(var i=0; i< 10; i++) {
-      var msg = qx.lang.Object.clone(message);
+      var msg = Object.assign({}, message);
       msg.title = i;
       center.handleMessage(msg);
     }

--- a/source/test/karma/ui/structure/pure/Audio-spec.js
+++ b/source/test/karma/ui/structure/pure/Audio-spec.js
@@ -29,7 +29,7 @@ describe("testing a audio widget", function() {
   it("should test the audio creator", function() {
 
     var res = this.createTestWidgetString("audio", {id: 'test'}, '<label>Test</label>');
-    var widget = qx.bom.Html.clean([res[1]])[0];
+    var widget = (function(){var div=document.createElement('div');div.innerHTML=res[1];return div.childNodes[0];})();
     var widgetInstance = res[0];
 
     expect(widget).toHaveClass('audio');
@@ -55,7 +55,7 @@ describe("testing a audio widget", function() {
       loop: 'true'
     }, '<label>Test</label>');
 
-    var widget = qx.bom.Html.clean([res[1]])[0];
+    var widget = (function(){var div=document.createElement('div');div.innerHTML=res[1];return div.childNodes[0];})();
 
     expect(widget).toHaveClass('audio');
     expect(widget).toHaveLabel('Test');

--- a/source/test/karma/ui/structure/pure/Audio-spec.js
+++ b/source/test/karma/ui/structure/pure/Audio-spec.js
@@ -35,7 +35,7 @@ describe("testing a audio widget", function() {
     expect(widget).toHaveClass('audio');
     expect(widget).toHaveLabel('Test');
 
-    var audio = qx.bom.Selector.query("audio", widget)[0];
+    var audio = widget.querySelector("audio");
 
     expect(audio).not.toHaveAttribute("autoplay");
     expect(audio).not.toHaveAttribute("loop");
@@ -60,7 +60,7 @@ describe("testing a audio widget", function() {
     expect(widget).toHaveClass('audio');
     expect(widget).toHaveLabel('Test');
 
-    var audio = qx.bom.Selector.query("audio", widget)[0];
+    var audio = widget.querySelector("audio");
     expect(audio).toHaveAttribute("autoplay");
     expect(audio).toHaveAttribute("loop");
     expect(audio).toHaveAttribute("controls");

--- a/source/test/karma/ui/structure/pure/Audio-spec.js
+++ b/source/test/karma/ui/structure/pure/Audio-spec.js
@@ -64,8 +64,8 @@ describe("testing a audio widget", function() {
     expect(audio).toHaveAttribute("autoplay");
     expect(audio).toHaveAttribute("loop");
     expect(audio).toHaveAttribute("controls");
-    expect(qx.bom.element.Attribute.get(audio, 'style')).toBe('width:50%;height:50%;');
-    expect(qx.bom.element.Attribute.get(audio, 'id')).toBe('test');
+    expect(audio.getAttribute('style')).toBe('width:50%;height:50%;');
+    expect(audio.getAttribute('id')).toBe('test');
 
   });
 

--- a/source/test/karma/ui/structure/pure/Audio-spec.js
+++ b/source/test/karma/ui/structure/pure/Audio-spec.js
@@ -29,7 +29,7 @@ describe("testing a audio widget", function() {
   it("should test the audio creator", function() {
 
     var res = this.createTestWidgetString("audio", {id: 'test'}, '<label>Test</label>');
-    var widget = (function(){var div=document.createElement('div');div.innerHTML=res[1];return div.childNodes[0];})();
+    var widget = cv.util.String.htmlStringToDomElement(res[1]);
     var widgetInstance = res[0];
 
     expect(widget).toHaveClass('audio');
@@ -55,7 +55,7 @@ describe("testing a audio widget", function() {
       loop: 'true'
     }, '<label>Test</label>');
 
-    var widget = (function(){var div=document.createElement('div');div.innerHTML=res[1];return div.childNodes[0];})();
+    var widget = cv.util.String.htmlStringToDomElement(res[1]);
 
     expect(widget).toHaveClass('audio');
     expect(widget).toHaveLabel('Test');

--- a/source/test/karma/ui/structure/pure/Designtoggle-spec.js
+++ b/source/test/karma/ui/structure/pure/Designtoggle-spec.js
@@ -26,7 +26,7 @@ describe("testing a designtoggle widget", function() {
 
   it("should test the designtoggle creator", function() {
     var res = this.createTestWidgetString("designtoggle", {}, "<label>Test</label>");
-    var widget = (function(){var div=document.createElement('div');div.innerHTML=res[1];return div.childNodes[0];})();
+    var widget = cv.util.String.htmlStringToDomElement(res[1]);
 
     expect(widget).toHaveClass('toggle');
     expect(widget).toHaveLabel('Test');

--- a/source/test/karma/ui/structure/pure/Designtoggle-spec.js
+++ b/source/test/karma/ui/structure/pure/Designtoggle-spec.js
@@ -26,7 +26,7 @@ describe("testing a designtoggle widget", function() {
 
   it("should test the designtoggle creator", function() {
     var res = this.createTestWidgetString("designtoggle", {}, "<label>Test</label>");
-    var widget = qx.bom.Html.clean([res[1]])[0];
+    var widget = (function(){var div=document.createElement('div');div.innerHTML=res[1];return div.childNodes[0];})();
 
     expect(widget).toHaveClass('toggle');
     expect(widget).toHaveLabel('Test');

--- a/source/test/karma/ui/structure/pure/Group-spec.js
+++ b/source/test/karma/ui/structure/pure/Group-spec.js
@@ -28,7 +28,7 @@ describe("testing a group widget", function() {
 
     var res = this.createTestWidgetString("group");
 
-    var widget = qx.bom.Html.clean([res[1]])[0];
+    var widget = (function(){var div=document.createElement('div');div.innerHTML=res[1];return div.childNodes[0];})();
 
     expect(widget).toHaveClass('group');
     expect(widget).toHaveClass('widget');
@@ -46,7 +46,7 @@ describe("testing a group widget", function() {
       name: "Test",
       target: "target"
     }, '<text/>');
-    var widget = qx.bom.Html.clean([res[1]])[0];
+    var widget = (function(){var div=document.createElement('div');div.innerHTML=res[1];return div.childNodes[0];})();
 
     expect(widget).toHaveClass('group');
     expect(widget).toHaveClass('custom_test');
@@ -54,7 +54,7 @@ describe("testing a group widget", function() {
     expect(widget).toHaveClass('clickable');
     expect(widget).not.toHaveClass('widget');
 
-    expect(qx.dom.Node.getText(widget.querySelector("h2"))).toBe("Test")
+    expect(widget.querySelector("h2").innerText).toBe("Test")
   });
 
   it('should trigger the group action', function() {

--- a/source/test/karma/ui/structure/pure/Group-spec.js
+++ b/source/test/karma/ui/structure/pure/Group-spec.js
@@ -28,7 +28,7 @@ describe("testing a group widget", function() {
 
     var res = this.createTestWidgetString("group");
 
-    var widget = (function(){var div=document.createElement('div');div.innerHTML=res[1];return div.childNodes[0];})();
+    var widget = cv.util.String.htmlStringToDomElement(res[1]);
 
     expect(widget).toHaveClass('group');
     expect(widget).toHaveClass('widget');
@@ -46,7 +46,7 @@ describe("testing a group widget", function() {
       name: "Test",
       target: "target"
     }, '<text/>');
-    var widget = (function(){var div=document.createElement('div');div.innerHTML=res[1];return div.childNodes[0];})();
+    var widget = cv.util.String.htmlStringToDomElement(res[1]);
 
     expect(widget).toHaveClass('group');
     expect(widget).toHaveClass('custom_test');

--- a/source/test/karma/ui/structure/pure/Group-spec.js
+++ b/source/test/karma/ui/structure/pure/Group-spec.js
@@ -54,7 +54,7 @@ describe("testing a group widget", function() {
     expect(widget).toHaveClass('clickable');
     expect(widget).not.toHaveClass('widget');
 
-    expect(qx.dom.Node.getText(qx.bom.Selector.query("h2", widget)[0])).toBe("Test")
+    expect(qx.dom.Node.getText(widget.querySelector("h2"))).toBe("Test")
   });
 
   it('should trigger the group action', function() {

--- a/source/test/karma/ui/structure/pure/Image-spec.js
+++ b/source/test/karma/ui/structure/pure/Image-spec.js
@@ -51,7 +51,7 @@ describe("testing a image widget", function() {
       flavour: 'potassium'
     }, '<label>Test</label>');
 
-    var widget = (function(){var div=document.createElement('div');div.innerHTML=res[1];return div.childNodes[0];})();
+    var widget = cv.util.String.htmlStringToDomElement(res[1]);
 
     expect(widget).toHaveClass('image');
     expect(widget).toHaveLabel('Test');

--- a/source/test/karma/ui/structure/pure/Image-spec.js
+++ b/source/test/karma/ui/structure/pure/Image-spec.js
@@ -51,7 +51,7 @@ describe("testing a image widget", function() {
       flavour: 'potassium'
     }, '<label>Test</label>');
 
-    var widget = qx.bom.Html.clean([res[1]])[0];
+    var widget = (function(){var div=document.createElement('div');div.innerHTML=res[1];return div.childNodes[0];})();
 
     expect(widget).toHaveClass('image');
     expect(widget).toHaveLabel('Test');

--- a/source/test/karma/ui/structure/pure/Image-spec.js
+++ b/source/test/karma/ui/structure/pure/Image-spec.js
@@ -56,8 +56,8 @@ describe("testing a image widget", function() {
     expect(widget).toHaveClass('image');
     expect(widget).toHaveLabel('Test');
     expect(res[0].getPath()).toBe("id_0");
-    expect(qx.bom.Selector.query("img", widget)[0].getAttribute("src")).toBe('/source/resource/icon/comet_64_ff8000.png');
-    expect(qx.bom.Selector.query("img", widget)[0].getAttribute("style")).toBe('width:100%;');
+    expect(widget.querySelector("img").getAttribute("src")).toBe('/source/resource/icon/comet_64_ff8000.png');
+    expect(widget.querySelector("img").getAttribute("style")).toBe('width:100%;');
   });
 
   it("should test the image creator and refreshing", function() {
@@ -72,7 +72,7 @@ describe("testing a image widget", function() {
     qx.event.message.Bus.dispatchByName("setup.dom.finished");
 
     expect(spiedTimer.start).toHaveBeenCalled();
-    expect(qx.bom.Selector.query("img", widget)[0].getAttribute("style")).toBe('width:50%;height:51%;');
+    expect(widget.querySelector("img").getAttribute("style")).toBe('width:50%;height:51%;');
   });
 
   it("should test the image creator width size", function() {
@@ -82,7 +82,7 @@ describe("testing a image widget", function() {
       widthfit: 'true'
     });
     var widget = res.getDomElement();
-    expect(qx.bom.Selector.query("img", widget)[0].getAttribute("style")).toBe('width:100%;max-width:100%;');
+    expect(widget.querySelector("img").getAttribute("style")).toBe('width:100%;max-width:100%;');
   });
 
 });
@@ -99,10 +99,10 @@ describe("testing the refresh caching of the image widget", function() {
     });
     this.initWidget(widget);
     var domElement = widget.getDomElement();
-    expect(qx.bom.Selector.query("img", domElement)[0].getAttribute("src")).toBe('/source/resource/icon/comet_64_ff8000.png');
+    expect(domElement.querySelector("img").getAttribute("src")).toBe('/source/resource/icon/comet_64_ff8000.png');
 
     qx.event.Timer.once(function() {
-      expect(qx.bom.Selector.query("img", domElement)[0].getAttribute("src")).toMatch(/^\/source\/resource\/icon\/comet_64_ff8000.png\?/);
+      expect(domElement.querySelector("img").getAttribute("src")).toMatch(/^\/source\/resource\/icon\/comet_64_ff8000.png\?/);
 
       // cleanup
       widget.dispose();
@@ -120,11 +120,11 @@ describe("testing the refresh caching of the image widget", function() {
     });
     this.initWidget(widget);
     var domElement = widget.getDomElement();
-    expect(qx.bom.Selector.query("img", domElement)[0].getAttribute("src")).toBe('/source/resource/icon/comet_64_ff8000.png');
+    expect(domElement.querySelector("img").getAttribute("src")).toBe('/source/resource/icon/comet_64_ff8000.png');
     widget.setVisible(true);
 
     qx.event.Timer.once(function() {
-      expect(qx.bom.Selector.query("img", domElement)[0].getAttribute("src")).toMatch(/^\/source\/resource\/icon\/comet_64_ff8000.png#/);
+      expect(domElement.querySelector("img").getAttribute("src")).toMatch(/^\/source\/resource\/icon\/comet_64_ff8000.png#/);
 
       // cleanup
       widget.dispose();
@@ -142,10 +142,10 @@ describe("testing the refresh caching of the image widget", function() {
     });
     qx.event.message.Bus.dispatchByName("setup.dom.finished");
     var domElement = widget.getDomElement();
-    expect(qx.bom.Selector.query("img", domElement)[0].getAttribute("src")).toBe('/source/resource/icon/comet_64_ff8000.png');
+    expect(domElement.querySelector("img").getAttribute("src")).toBe('/source/resource/icon/comet_64_ff8000.png');
 
     qx.event.Timer.once(function() {
-      expect(qx.bom.Selector.query("img", domElement)[0].getAttribute("src")).toBe('/source/resource/icon/comet_64_ff8000.png');
+      expect(domElement.querySelector("img").getAttribute("src")).toBe('/source/resource/icon/comet_64_ff8000.png');
 
       // cleanup
       widget.dispose();
@@ -163,10 +163,10 @@ describe("testing the refresh caching of the image widget", function() {
     });
     qx.event.message.Bus.dispatchByName("setup.dom.finished");
     var domElement = widget.getDomElement();
-    expect(qx.bom.Selector.query("img", domElement)[0].getAttribute("src")).toBe('/source/resource/icon/comet_64_ff8000.png');
+    expect(domElement.querySelector("img").getAttribute("src")).toBe('/source/resource/icon/comet_64_ff8000.png');
 
     qx.event.Timer.once(function() {
-      expect(qx.bom.Selector.query("img", domElement)[0].getAttribute("src")).toBe('/source/resource/icon/comet_64_ff8000.png');
+      expect(domElement.querySelector("img").getAttribute("src")).toBe('/source/resource/icon/comet_64_ff8000.png');
 
       // cleanup
       widget.dispose();

--- a/source/test/karma/ui/structure/pure/Image-spec.js
+++ b/source/test/karma/ui/structure/pure/Image-spec.js
@@ -56,8 +56,8 @@ describe("testing a image widget", function() {
     expect(widget).toHaveClass('image');
     expect(widget).toHaveLabel('Test');
     expect(res[0].getPath()).toBe("id_0");
-    expect(qx.bom.element.Attribute.get(qx.bom.Selector.query("img", widget)[0], "src")).toBe('/source/resource/icon/comet_64_ff8000.png');
-    expect(qx.bom.element.Attribute.get(qx.bom.Selector.query("img", widget)[0], "style")).toBe('width:100%;');
+    expect(qx.bom.Selector.query("img", widget)[0].getAttribute("src")).toBe('/source/resource/icon/comet_64_ff8000.png');
+    expect(qx.bom.Selector.query("img", widget)[0].getAttribute("style")).toBe('width:100%;');
   });
 
   it("should test the image creator and refreshing", function() {
@@ -72,7 +72,7 @@ describe("testing a image widget", function() {
     qx.event.message.Bus.dispatchByName("setup.dom.finished");
 
     expect(spiedTimer.start).toHaveBeenCalled();
-    expect(qx.bom.element.Attribute.get(qx.bom.Selector.query("img", widget)[0], "style")).toBe('width:50%;height:51%;');
+    expect(qx.bom.Selector.query("img", widget)[0].getAttribute("style")).toBe('width:50%;height:51%;');
   });
 
   it("should test the image creator width size", function() {
@@ -82,7 +82,7 @@ describe("testing a image widget", function() {
       widthfit: 'true'
     });
     var widget = res.getDomElement();
-    expect(qx.bom.element.Attribute.get(qx.bom.Selector.query("img", widget)[0], "style")).toBe('width:100%;max-width:100%;');
+    expect(qx.bom.Selector.query("img", widget)[0].getAttribute("style")).toBe('width:100%;max-width:100%;');
   });
 
 });
@@ -99,10 +99,10 @@ describe("testing the refresh caching of the image widget", function() {
     });
     this.initWidget(widget);
     var domElement = widget.getDomElement();
-    expect(qx.bom.element.Attribute.get(qx.bom.Selector.query("img", domElement)[0], "src")).toBe('/source/resource/icon/comet_64_ff8000.png');
+    expect(qx.bom.Selector.query("img", domElement)[0].getAttribute("src")).toBe('/source/resource/icon/comet_64_ff8000.png');
 
     qx.event.Timer.once(function() {
-      expect(qx.bom.element.Attribute.get(qx.bom.Selector.query("img", domElement)[0], "src")).toMatch(/^\/source\/resource\/icon\/comet_64_ff8000.png\?/);
+      expect(qx.bom.Selector.query("img", domElement)[0].getAttribute("src")).toMatch(/^\/source\/resource\/icon\/comet_64_ff8000.png\?/);
 
       // cleanup
       widget.dispose();
@@ -120,11 +120,11 @@ describe("testing the refresh caching of the image widget", function() {
     });
     this.initWidget(widget);
     var domElement = widget.getDomElement();
-    expect(qx.bom.element.Attribute.get(qx.bom.Selector.query("img", domElement)[0], "src")).toBe('/source/resource/icon/comet_64_ff8000.png');
+    expect(qx.bom.Selector.query("img", domElement)[0].getAttribute("src")).toBe('/source/resource/icon/comet_64_ff8000.png');
     widget.setVisible(true);
 
     qx.event.Timer.once(function() {
-      expect(qx.bom.element.Attribute.get(qx.bom.Selector.query("img", domElement)[0], "src")).toMatch(/^\/source\/resource\/icon\/comet_64_ff8000.png#/);
+      expect(qx.bom.Selector.query("img", domElement)[0].getAttribute("src")).toMatch(/^\/source\/resource\/icon\/comet_64_ff8000.png#/);
 
       // cleanup
       widget.dispose();
@@ -142,10 +142,10 @@ describe("testing the refresh caching of the image widget", function() {
     });
     qx.event.message.Bus.dispatchByName("setup.dom.finished");
     var domElement = widget.getDomElement();
-    expect(qx.bom.element.Attribute.get(qx.bom.Selector.query("img", domElement)[0], "src")).toBe('/source/resource/icon/comet_64_ff8000.png');
+    expect(qx.bom.Selector.query("img", domElement)[0].getAttribute("src")).toBe('/source/resource/icon/comet_64_ff8000.png');
 
     qx.event.Timer.once(function() {
-      expect(qx.bom.element.Attribute.get(qx.bom.Selector.query("img", domElement)[0], "src")).toBe('/source/resource/icon/comet_64_ff8000.png');
+      expect(qx.bom.Selector.query("img", domElement)[0].getAttribute("src")).toBe('/source/resource/icon/comet_64_ff8000.png');
 
       // cleanup
       widget.dispose();
@@ -163,10 +163,10 @@ describe("testing the refresh caching of the image widget", function() {
     });
     qx.event.message.Bus.dispatchByName("setup.dom.finished");
     var domElement = widget.getDomElement();
-    expect(qx.bom.element.Attribute.get(qx.bom.Selector.query("img", domElement)[0], "src")).toBe('/source/resource/icon/comet_64_ff8000.png');
+    expect(qx.bom.Selector.query("img", domElement)[0].getAttribute("src")).toBe('/source/resource/icon/comet_64_ff8000.png');
 
     qx.event.Timer.once(function() {
-      expect(qx.bom.element.Attribute.get(qx.bom.Selector.query("img", domElement)[0], "src")).toBe('/source/resource/icon/comet_64_ff8000.png');
+      expect(qx.bom.Selector.query("img", domElement)[0].getAttribute("src")).toBe('/source/resource/icon/comet_64_ff8000.png');
 
       // cleanup
       widget.dispose();

--- a/source/test/karma/ui/structure/pure/Imagetrigger-spec.js
+++ b/source/test/karma/ui/structure/pure/Imagetrigger-spec.js
@@ -45,7 +45,7 @@ describe("testing a imagetrigger widget", function() {
   it("should test the imagetrigger creator", function() {
 
     var res = this.createTestWidgetString("imagetrigger", {flavour: 'potassium'}, '<label>Test</label>');
-    var widget = qx.bom.Html.clean([res[1]])[0];
+    var widget = (function(){var div=document.createElement('div');div.innerHTML=res[1];return div.childNodes[0];})();
 
     expect(widget).toHaveClass('imagetrigger');
     expect(widget).toHaveClass('image');

--- a/source/test/karma/ui/structure/pure/Imagetrigger-spec.js
+++ b/source/test/karma/ui/structure/pure/Imagetrigger-spec.js
@@ -80,7 +80,7 @@ describe("testing a imagetrigger widget", function() {
     res.update('12/7/37', 1);
     var actor = qx.bom.Selector.query('.actor img', this.container.children[0])[0];
     expect(actor).toBeVisible();
-    expect(qx.bom.element.Attribute.get(actor, 'src')).toBe('imgs.jpg');
+    expect(actor.getAttribute('src')).toBe('imgs.jpg');
 
     res.update('12/7/37', 0);
     expect(actor).not.toBeVisible();
@@ -97,7 +97,7 @@ describe("testing a imagetrigger widget", function() {
     var actor = qx.bom.Selector.query('.actor img', this.container.children[0])[0];
 
     expect(actor).toBeVisible();
-    expect(qx.bom.element.Attribute.get(actor, 'src')).toBe('imgs1.jpg');
+    expect(actor.getAttribute('src')).toBe('imgs1.jpg');
 
     res.update('12/7/37', 0);
     expect(actor).not.toBeVisible();

--- a/source/test/karma/ui/structure/pure/Imagetrigger-spec.js
+++ b/source/test/karma/ui/structure/pure/Imagetrigger-spec.js
@@ -78,7 +78,7 @@ describe("testing a imagetrigger widget", function() {
     });
 
     res.update('12/7/37', 1);
-    var actor = qx.bom.Selector.query('.actor img', this.container.children[0])[0];
+    var actor = this.container.children[0].querySelector('.actor img');
     expect(actor).toBeVisible();
     expect(actor.getAttribute('src')).toBe('imgs.jpg');
 
@@ -94,7 +94,7 @@ describe("testing a imagetrigger widget", function() {
     });
 
     res.update('12/7/37', 1);
-    var actor = qx.bom.Selector.query('.actor img', this.container.children[0])[0];
+    var actor = this.container.children[0].querySelector('.actor img');
 
     expect(actor).toBeVisible();
     expect(actor.getAttribute('src')).toBe('imgs1.jpg');
@@ -118,7 +118,7 @@ describe("testing a imagetrigger widget", function() {
     this.initWidget(res);
     var Reg = qx.event.Registration;
 
-    var actor = qx.bom.Selector.query('.actor', this.container.children[0])[0];
+    var actor = this.container.children[0].querySelector('.actor');
     expect(actor).not.toBe(null);
 
     // no write flag

--- a/source/test/karma/ui/structure/pure/Imagetrigger-spec.js
+++ b/source/test/karma/ui/structure/pure/Imagetrigger-spec.js
@@ -45,7 +45,7 @@ describe("testing a imagetrigger widget", function() {
   it("should test the imagetrigger creator", function() {
 
     var res = this.createTestWidgetString("imagetrigger", {flavour: 'potassium'}, '<label>Test</label>');
-    var widget = (function(){var div=document.createElement('div');div.innerHTML=res[1];return div.childNodes[0];})();
+    var widget = cv.util.String.htmlStringToDomElement(res[1]);
 
     expect(widget).toHaveClass('imagetrigger');
     expect(widget).toHaveClass('image');

--- a/source/test/karma/ui/structure/pure/Info-spec.js
+++ b/source/test/karma/ui/structure/pure/Info-spec.js
@@ -26,7 +26,7 @@ describe("testing a info widget", function() {
 
   it("should test the info creator", function() {
     var res = this.createTestWidgetString("info", {}, "<label>Test</label>");
-    var widget = (function(){var div=document.createElement('div');div.innerHTML=res[1];return div.childNodes[0];})();
+    var widget = cv.util.String.htmlStringToDomElement(res[1]);
     var obj = res[0];
 
     expect(widget).toHaveClass('info');

--- a/source/test/karma/ui/structure/pure/Info-spec.js
+++ b/source/test/karma/ui/structure/pure/Info-spec.js
@@ -26,7 +26,7 @@ describe("testing a info widget", function() {
 
   it("should test the info creator", function() {
     var res = this.createTestWidgetString("info", {}, "<label>Test</label>");
-    var widget = qx.bom.Html.clean([res[1]])[0];
+    var widget = (function(){var div=document.createElement('div');div.innerHTML=res[1];return div.childNodes[0];})();
     var obj = res[0];
 
     expect(widget).toHaveClass('info');

--- a/source/test/karma/ui/structure/pure/Infoaction-spec.js
+++ b/source/test/karma/ui/structure/pure/Infoaction-spec.js
@@ -27,7 +27,7 @@ describe("testing a infoaction widget", function() {
   it("should test the infoaction creator", function() {
 
     var res = this.createTestWidgetString("infoaction", {}, '<label>Test</label><widgetinfo><info></info></widgetinfo><widgetaction><switch></switch></widgetaction>');
-    var widget = qx.bom.Html.clean([res[1]])[0];
+    var widget = (function(){var div=document.createElement('div');div.innerHTML=res[1];return div.childNodes[0];})();
     expect(res[0].getPath()).toBe("id_0");
 
     expect(widget).toHaveClass('infoaction');

--- a/source/test/karma/ui/structure/pure/Infoaction-spec.js
+++ b/source/test/karma/ui/structure/pure/Infoaction-spec.js
@@ -27,7 +27,7 @@ describe("testing a infoaction widget", function() {
   it("should test the infoaction creator", function() {
 
     var res = this.createTestWidgetString("infoaction", {}, '<label>Test</label><widgetinfo><info></info></widgetinfo><widgetaction><switch></switch></widgetaction>');
-    var widget = (function(){var div=document.createElement('div');div.innerHTML=res[1];return div.childNodes[0];})();
+    var widget = cv.util.String.htmlStringToDomElement(res[1]);
     expect(res[0].getPath()).toBe("id_0");
 
     expect(widget).toHaveClass('infoaction');

--- a/source/test/karma/ui/structure/pure/Infotrigger-spec.js
+++ b/source/test/karma/ui/structure/pure/Infotrigger-spec.js
@@ -70,7 +70,7 @@ describe("testing a infotrigger widget", function() {
 
     // check infoposition
     var info = obj.getInfoActor();
-    var actors = qx.bom.Selector.matches(".actor", qx.dom.Hierarchy.getDescendants(widget));
+    var actors = Array.prototype.filter.call(qx.dom.Hierarchy.getDescendants(widget),function(m){return m.matches(".actor");});
     expect(actors.indexOf(info)).toBe(0);
   });
 
@@ -84,7 +84,7 @@ describe("testing a infotrigger widget", function() {
 
     // check infoposition
     var info = obj.getInfoActor();
-    actors = qx.bom.Selector.matches(".actor", qx.dom.Hierarchy.getDescendants(widget));
+    actors = Array.prototype.filter.call(qx.dom.Hierarchy.getDescendants(widget),function(m){return m.matches(".actor");});
     expect(actors.indexOf(info)).toBe(1);
   });
 
@@ -99,7 +99,7 @@ describe("testing a infotrigger widget", function() {
 
     // check infoposition
     var info = obj.getInfoActor();
-    actors = qx.bom.Selector.matches(".actor", qx.dom.Hierarchy.getDescendants(widget));
+    actors = Array.prototype.filter.call(qx.dom.Hierarchy.getDescendants(widget),function(m){return m.matches(".actor");});
     expect(actors.indexOf(info)).toBe(2);
   });
 

--- a/source/test/karma/ui/structure/pure/Infotrigger-spec.js
+++ b/source/test/karma/ui/structure/pure/Infotrigger-spec.js
@@ -70,7 +70,7 @@ describe("testing a infotrigger widget", function() {
 
     // check infoposition
     var info = obj.getInfoActor();
-    var actors = Array.prototype.filter.call(qx.dom.Hierarchy.getDescendants(widget),function(m){return m.matches(".actor");});
+    var actors = Array.from(widget.getElementsByTagName("*")).filter(function(m){return m.matches(".actor");});
     expect(actors.indexOf(info)).toBe(0);
   });
 
@@ -84,7 +84,7 @@ describe("testing a infotrigger widget", function() {
 
     // check infoposition
     var info = obj.getInfoActor();
-    actors = Array.prototype.filter.call(qx.dom.Hierarchy.getDescendants(widget),function(m){return m.matches(".actor");});
+    actors = Array.from(widget.getElementsByTagName("*")).filter(function(m){return m.matches(".actor");});
     expect(actors.indexOf(info)).toBe(1);
   });
 
@@ -99,7 +99,7 @@ describe("testing a infotrigger widget", function() {
 
     // check infoposition
     var info = obj.getInfoActor();
-    actors = Array.prototype.filter.call(qx.dom.Hierarchy.getDescendants(widget),function(m){return m.matches(".actor");});
+    actors = Array.from(widget.getElementsByTagName("*")).filter(function(m){return m.matches(".actor");});
     expect(actors.indexOf(info)).toBe(2);
   });
 

--- a/source/test/karma/ui/structure/pure/Infotrigger-spec.js
+++ b/source/test/karma/ui/structure/pure/Infotrigger-spec.js
@@ -77,7 +77,7 @@ describe("testing a infotrigger widget", function() {
   it("should test the infotrigger creator", function() {
     var obj = this.createTestElement("infotrigger", {'align': 'right', 'infoposition': 'middle'});
     var widget = obj.getWidgetElement();
-    var actors = qx.bom.Selector.query("div.actor", widget);
+    var actors = widget.querySelectorAll("div.actor");
     actors.forEach(function(actor) {
       expect(qx.bom.element.Style.get(actor, "text-align")).toBe("right");
     }, this);
@@ -92,7 +92,7 @@ describe("testing a infotrigger widget", function() {
 
     var obj = this.createTestElement("infotrigger", {'align': 'center', 'infoposition': 'right'});
     var widget = obj.getWidgetElement();
-    var actors = qx.bom.Selector.query("div.actor", widget);
+    var actors = widget.querySelectorAll("div.actor");
     actors.forEach(function(actor) {
       expect(qx.bom.element.Style.get(actor, "text-align")).toBe("center");
     }, this);

--- a/source/test/karma/ui/structure/pure/Infotrigger-spec.js
+++ b/source/test/karma/ui/structure/pure/Infotrigger-spec.js
@@ -79,7 +79,7 @@ describe("testing a infotrigger widget", function() {
     var widget = obj.getWidgetElement();
     var actors = widget.querySelectorAll("div.actor");
     actors.forEach(function(actor) {
-      expect(qx.bom.element.Style.get(actor, "text-align")).toBe("right");
+      expect(window.getComputedStyle(actor)["text-align"]).toBe("right");
     }, this);
 
     // check infoposition
@@ -94,7 +94,7 @@ describe("testing a infotrigger widget", function() {
     var widget = obj.getWidgetElement();
     var actors = widget.querySelectorAll("div.actor");
     actors.forEach(function(actor) {
-      expect(qx.bom.element.Style.get(actor, "text-align")).toBe("center");
+      expect(window.getComputedStyle(actor)["text-align"]).toBe("center");
     }, this);
 
     // check infoposition

--- a/source/test/karma/ui/structure/pure/Line-spec.js
+++ b/source/test/karma/ui/structure/pure/Line-spec.js
@@ -30,9 +30,9 @@ describe("testing a line widget", function() {
 
     var res = this.createTestWidgetString("line");
 
-    var line = qx.bom.Html.clean([res[1]])[0];
+    var line = (function(){var div=document.createElement('div');div.innerHTML=res[1];return div.childNodes[0];})();
 
-    expect(qx.dom.Node.getName(line).toLowerCase()).toBe('hr');
+    expect(line.nodeName.toLowerCase()).toBe('hr');
     expect(res[0].getPath()).toBe("id_0");
   });
 });

--- a/source/test/karma/ui/structure/pure/Line-spec.js
+++ b/source/test/karma/ui/structure/pure/Line-spec.js
@@ -30,7 +30,7 @@ describe("testing a line widget", function() {
 
     var res = this.createTestWidgetString("line");
 
-    var line = (function(){var div=document.createElement('div');div.innerHTML=res[1];return div.childNodes[0];})();
+    var line = cv.util.String.htmlStringToDomElement(res[1]);
 
     expect(line.nodeName.toLowerCase()).toBe('hr');
     expect(res[0].getPath()).toBe("id_0");

--- a/source/test/karma/ui/structure/pure/Multitrigger-spec.js
+++ b/source/test/karma/ui/structure/pure/Multitrigger-spec.js
@@ -53,7 +53,7 @@ describe("testing a multitrigger widget", function() {
 
     qx.event.message.Bus.dispatchByName("setup.dom.finished");
 
-    var values = qx.bom.Selector.query("div.actor > div.value", widget);
+    var values = widget.querySelectorAll("div.actor > div.value");
     for (var i=0; i<4; i++) {
       expect(qx.dom.Node.getText(values[i])).toBe('B'+(i+1));
     }
@@ -74,7 +74,7 @@ describe("testing a multitrigger widget", function() {
     this.initWidget(creator);
 
     var check = function(index) {
-      qx.bom.Selector.query(".actor_container .actor", this.container.children[0]).forEach(function(actor, i) {
+      this.container.children[0].querySelectorAll(".actor_container .actor").forEach(function(actor, i) {
         if (index === i) {
           expect(actor).toHaveClass('switchPressed');
           expect(actor).not.toHaveClass('switchUnpressed');
@@ -137,7 +137,7 @@ describe("testing a multitrigger widget", function() {
       'showstatus': 'true'
     }, null, '<address transform="DPT:4001" mode="read">1/0/0</address>', {'transform': '4.001'});
     spyOn(creator, "sendToBackend");
-    var actors = qx.bom.Selector.query(".actor_container .actor", this.container.children[0]);
+    var actors = this.container.children[0].querySelectorAll(".actor_container .actor");
     expect(actors.length).not.toBe(0);
 
     this.initWidget(creator);

--- a/source/test/karma/ui/structure/pure/Multitrigger-spec.js
+++ b/source/test/karma/ui/structure/pure/Multitrigger-spec.js
@@ -27,7 +27,7 @@ describe("testing a multitrigger widget", function() {
   it("should test the multitrigger creator", function() {
 
     var res = this.createTestWidgetString("multitrigger", {}, "<label>Test</label>");
-    var widget = qx.bom.Html.clean([res[1]])[0];
+    var widget = (function(){var div=document.createElement('div');div.innerHTML=res[1];return div.childNodes[0];})();
 
     expect(widget).toHaveClass('multitrigger');
     expect(widget).toHaveLabel('Test');
@@ -49,13 +49,13 @@ describe("testing a multitrigger widget", function() {
       'showstatus': 'true',
       'mapping': 'test'
     });
-    var widget = qx.bom.Html.clean([res[1]])[0];
+    var widget = (function(){var div=document.createElement('div');div.innerHTML=res[1];return div.childNodes[0];})();
 
     qx.event.message.Bus.dispatchByName("setup.dom.finished");
 
     var values = widget.querySelectorAll("div.actor > div.value");
     for (var i=0; i<4; i++) {
-      expect(qx.dom.Node.getText(values[i])).toBe('B'+(i+1));
+      expect(values[i].innerText).toBe('B'+(i+1));
     }
   });
 

--- a/source/test/karma/ui/structure/pure/Multitrigger-spec.js
+++ b/source/test/karma/ui/structure/pure/Multitrigger-spec.js
@@ -27,7 +27,7 @@ describe("testing a multitrigger widget", function() {
   it("should test the multitrigger creator", function() {
 
     var res = this.createTestWidgetString("multitrigger", {}, "<label>Test</label>");
-    var widget = (function(){var div=document.createElement('div');div.innerHTML=res[1];return div.childNodes[0];})();
+    var widget = cv.util.String.htmlStringToDomElement(res[1]);
 
     expect(widget).toHaveClass('multitrigger');
     expect(widget).toHaveLabel('Test');
@@ -49,7 +49,7 @@ describe("testing a multitrigger widget", function() {
       'showstatus': 'true',
       'mapping': 'test'
     });
-    var widget = (function(){var div=document.createElement('div');div.innerHTML=res[1];return div.childNodes[0];})();
+    var widget = cv.util.String.htmlStringToDomElement(res[1]);
 
     qx.event.message.Bus.dispatchByName("setup.dom.finished");
 

--- a/source/test/karma/ui/structure/pure/Navbar-spec.js
+++ b/source/test/karma/ui/structure/pure/Navbar-spec.js
@@ -53,7 +53,7 @@ describe("testing a navbar widget", function() {
 
     var navbar = qx.bom.Selector.query('#'+barContainerId+' .navbar')[0];
     expect(navbar).not.toBeNull();
-    expect(qx.bom.element.Attribute.get(navbar, 'id')).toBe('id_'+pos+'_navbar');
+    expect(navbar.getAttribute('id')).toBe('id_'+pos+'_navbar');
 
     if (pos === "left") {
       expect(navbar).toHaveClass("flavour_potassium");

--- a/source/test/karma/ui/structure/pure/Navbar-spec.js
+++ b/source/test/karma/ui/structure/pure/Navbar-spec.js
@@ -57,7 +57,7 @@ describe("testing a navbar widget", function() {
 
     if (pos === "left") {
       expect(navbar).toHaveClass("flavour_potassium");
-      expect(qx.dom.Node.getText(navbar.querySelector("h2"))).toBe('Testbar');
+      expect(navbar.querySelector("h2").innerText).toBe('Testbar');
       expect(templateEngine.pagePartsHandler.navbarSetSize).toHaveBeenCalledWith(pos,"200");
       expect(obj.getScope()).toBe(1);
     }

--- a/source/test/karma/ui/structure/pure/Navbar-spec.js
+++ b/source/test/karma/ui/structure/pure/Navbar-spec.js
@@ -51,13 +51,13 @@ describe("testing a navbar widget", function() {
     qx.event.message.Bus.dispatchByName("setup.dom.finished.before");
     qx.event.message.Bus.dispatchByName("setup.dom.finished");
 
-    var navbar = qx.bom.Selector.query('#'+barContainerId+' .navbar')[0];
+    var navbar = document.querySelector('#'+barContainerId+' .navbar');
     expect(navbar).not.toBeNull();
     expect(navbar.getAttribute('id')).toBe('id_'+pos+'_navbar');
 
     if (pos === "left") {
       expect(navbar).toHaveClass("flavour_potassium");
-      expect(qx.dom.Node.getText(qx.bom.Selector.query("h2", navbar)[0])).toBe('Testbar');
+      expect(qx.dom.Node.getText(navbar.querySelector("h2"))).toBe('Testbar');
       expect(templateEngine.pagePartsHandler.navbarSetSize).toHaveBeenCalledWith(pos,"200");
       expect(obj.getScope()).toBe(1);
     }

--- a/source/test/karma/ui/structure/pure/Page-spec.js
+++ b/source/test/karma/ui/structure/pure/Page-spec.js
@@ -43,7 +43,7 @@ describe("testing a page widget", function() {
 
     var elem = page.getDomElement();
     expect(elem).toHaveClass("type_text");
-    expect(qx.dom.Node.getText(qx.bom.Selector.matches("h1", qx.dom.Hierarchy.getDescendants(elem))[0])).toBe("Testpage");
+    expect(qx.dom.Node.getText(Array.prototype.filter.call(qx.dom.Hierarchy.getDescendants(elem),function(m){return m.matches("h1");})[0])).toBe("Testpage");
   });
 
   it("should test the page creator with some attributes", function() {

--- a/source/test/karma/ui/structure/pure/Page-spec.js
+++ b/source/test/karma/ui/structure/pure/Page-spec.js
@@ -101,7 +101,7 @@ describe("testing a page widget", function() {
     expect(backdrop).toHaveStyleSetting('height', '100%');
     expect(backdrop).toHaveStyleSetting('object-fit', 'contain');
     expect(backdrop).toHaveStyleSetting('object-position', 'left');
-    expect(qx.bom.element.Attribute.get(backdrop, 'src')).toBe('test.svg');
+    expect(backdrop.getAttribute('src')).toBe('test.svg');
   });
 
   it("should test the 2d-page creator with fixed png backdrop", function() {
@@ -120,7 +120,7 @@ describe("testing a page widget", function() {
     expect(page).toHaveClass("type_2d");
     var backdrop = qx.bom.Selector.query("img", page)[0];
 
-    expect(qx.bom.element.Attribute.get(backdrop, 'src')).toBe('test.png');
+    expect(backdrop.getAttribute('src')).toBe('test.png');
   });
 
   it("should test the page update", function() {

--- a/source/test/karma/ui/structure/pure/Page-spec.js
+++ b/source/test/karma/ui/structure/pure/Page-spec.js
@@ -93,10 +93,10 @@ describe("testing a page widget", function() {
 
     expect(page.getBackdropAlign()).toBe("left");
 
-    page = qx.bom.Selector.query('#pages .page')[0];
+    page = document.querySelector('#pages .page');
 
     expect(page).toHaveClass("type_2d");
-    var backdrop = qx.bom.Selector.query("embed", page)[0];
+    var backdrop = page.querySelector("embed");
     expect(backdrop).toHaveStyleSetting('width', '100%');
     expect(backdrop).toHaveStyleSetting('height', '100%');
     expect(backdrop).toHaveStyleSetting('object-fit', 'contain');
@@ -115,10 +115,10 @@ describe("testing a page widget", function() {
 
     cv.ui.structure.pure.Page.createFinal();
 
-    var page = qx.bom.Selector.query('#pages .page')[0];
+    var page = document.querySelector('#pages .page');
 
     expect(page).toHaveClass("type_2d");
-    var backdrop = qx.bom.Selector.query("img", page)[0];
+    var backdrop = page.querySelector("img");
 
     expect(backdrop.getAttribute('src')).toBe('test.png');
   });

--- a/source/test/karma/ui/structure/pure/Page-spec.js
+++ b/source/test/karma/ui/structure/pure/Page-spec.js
@@ -37,7 +37,7 @@ describe("testing a page widget", function() {
     var page = cv.ui.structure.WidgetFactory.getInstanceById(pageLink.getPath()+"_");
     expect(page.getPageType()).toBe("text");
 
-    var widget = (function(){var div=document.createElement('div');div.innerHTML=res[1];return div.childNodes[0];})();
+    var widget = cv.util.String.htmlStringToDomElement(res[1]);
     cv.ui.structure.pure.Page.createFinal();
     expect(widget).toHaveClass('pagelink');
 
@@ -63,7 +63,7 @@ describe("testing a page widget", function() {
     var pageLink = res[0];
     var page = cv.ui.structure.WidgetFactory.getInstanceById(pageLink.getPath()+"_");
 
-    var widget = (function(){var div=document.createElement('div');div.innerHTML=res[1];return div.childNodes[0];})();
+    var widget = cv.util.String.htmlStringToDomElement(res[1]);
     var actor = this.findChild(widget, ".actor");
     expect(actor.style['text-align']).toBe('right');
     cv.ui.structure.pure.Page.createFinal();

--- a/source/test/karma/ui/structure/pure/Page-spec.js
+++ b/source/test/karma/ui/structure/pure/Page-spec.js
@@ -65,7 +65,7 @@ describe("testing a page widget", function() {
 
     var widget = qx.bom.Html.clean([res[1]])[0];
     var actor = this.findChild(widget, ".actor");
-    expect(qx.bom.element.Style.get(actor, 'text-align')).toBe('right');
+    expect(actor.style['text-align']).toBe('right');
     cv.ui.structure.pure.Page.createFinal();
 
     expect(page.getShowTopNavigation()).toBeTruthy();

--- a/source/test/karma/ui/structure/pure/Page-spec.js
+++ b/source/test/karma/ui/structure/pure/Page-spec.js
@@ -37,13 +37,13 @@ describe("testing a page widget", function() {
     var page = cv.ui.structure.WidgetFactory.getInstanceById(pageLink.getPath()+"_");
     expect(page.getPageType()).toBe("text");
 
-    var widget = qx.bom.Html.clean([res[1]])[0];
+    var widget = (function(){var div=document.createElement('div');div.innerHTML=res[1];return div.childNodes[0];})();
     cv.ui.structure.pure.Page.createFinal();
     expect(widget).toHaveClass('pagelink');
 
     var elem = page.getDomElement();
     expect(elem).toHaveClass("type_text");
-    expect(qx.dom.Node.getText(Array.prototype.filter.call(qx.dom.Hierarchy.getDescendants(elem),function(m){return m.matches("h1");})[0])).toBe("Testpage");
+    expect(Array.from(elem.getElementsByTagName("*")).filter(function(m){return m.matches("h1");})[0].innerText).toBe("Testpage");
   });
 
   it("should test the page creator with some attributes", function() {
@@ -63,7 +63,7 @@ describe("testing a page widget", function() {
     var pageLink = res[0];
     var page = cv.ui.structure.WidgetFactory.getInstanceById(pageLink.getPath()+"_");
 
-    var widget = qx.bom.Html.clean([res[1]])[0];
+    var widget = (function(){var div=document.createElement('div');div.innerHTML=res[1];return div.childNodes[0];})();
     var actor = this.findChild(widget, ".actor");
     expect(actor.style['text-align']).toBe('right');
     cv.ui.structure.pure.Page.createFinal();

--- a/source/test/karma/ui/structure/pure/Pagejump-spec.js
+++ b/source/test/karma/ui/structure/pure/Pagejump-spec.js
@@ -28,7 +28,7 @@ describe("testing a pagejump widget", function() {
   it("should test the pagejump creator", function() {
 
     var res = this.createTestWidgetString("pagejump", {'name': 'Testpage'}, "<label>Test</label>");
-    var widget = (function(){var div=document.createElement('div');div.innerHTML=res[1];return div.childNodes[0];})();
+    var widget = cv.util.String.htmlStringToDomElement(res[1]);
     expect(widget).toHaveClass('pagejump');
     expect(widget).toHaveLabel('Test');
     expect(widget).toHaveValue('Testpage');
@@ -46,7 +46,7 @@ describe("testing a pagejump widget", function() {
       'path': 'ParentPage',
       'active_scope': 'path'
     }, '<layout colspan="6" rowspan="2"></layout>');
-    var widget = (function(){var div=document.createElement('div');div.innerHTML=res[1];return div.childNodes[0];})();
+    var widget = cv.util.String.htmlStringToDomElement(res[1]);
 
     expect(widget).toHaveClass('right');
     expect(widget).toHaveClass('innerrowspan');
@@ -65,7 +65,7 @@ describe("testing a pagejump widget", function() {
 
     var res = this.createTestWidgetString("pagejump", {},
       '<widgetinfo><text>Test</text></widgetinfo>');
-    var widget = (function(){var div=document.createElement('div');div.innerHTML=res[1];return div.childNodes[0];})();
+    var widget = cv.util.String.htmlStringToDomElement(res[1]);
 
     expect(widget).toHaveClass('infoaction');
   });

--- a/source/test/karma/ui/structure/pure/Pagejump-spec.js
+++ b/source/test/karma/ui/structure/pure/Pagejump-spec.js
@@ -135,7 +135,7 @@ describe("testing a pagejump widget", function() {
       return null;
     });
 
-    var actor = qx.bom.Selector.query(".pagejump", creator.getDomElement())[0];
+    var actor = creator.getDomElement().querySelector(".pagejump");
     qx.event.message.Bus.dispatchByName("path.pageChanged", "id_");
     expect(actor).toHaveClass("active");
     qx.event.message.Bus.dispatchByName("path.pageChanged", "id_1_");

--- a/source/test/karma/ui/structure/pure/Pagejump-spec.js
+++ b/source/test/karma/ui/structure/pure/Pagejump-spec.js
@@ -28,7 +28,7 @@ describe("testing a pagejump widget", function() {
   it("should test the pagejump creator", function() {
 
     var res = this.createTestWidgetString("pagejump", {'name': 'Testpage'}, "<label>Test</label>");
-    var widget = qx.bom.Html.clean([res[1]])[0];
+    var widget = (function(){var div=document.createElement('div');div.innerHTML=res[1];return div.childNodes[0];})();
     expect(widget).toHaveClass('pagejump');
     expect(widget).toHaveLabel('Test');
     expect(widget).toHaveValue('Testpage');
@@ -46,7 +46,7 @@ describe("testing a pagejump widget", function() {
       'path': 'ParentPage',
       'active_scope': 'path'
     }, '<layout colspan="6" rowspan="2"></layout>');
-    var widget = qx.bom.Html.clean([res[1]])[0];
+    var widget = (function(){var div=document.createElement('div');div.innerHTML=res[1];return div.childNodes[0];})();
 
     expect(widget).toHaveClass('right');
     expect(widget).toHaveClass('innerrowspan');
@@ -65,7 +65,7 @@ describe("testing a pagejump widget", function() {
 
     var res = this.createTestWidgetString("pagejump", {},
       '<widgetinfo><text>Test</text></widgetinfo>');
-    var widget = qx.bom.Html.clean([res[1]])[0];
+    var widget = (function(){var div=document.createElement('div');div.innerHTML=res[1];return div.childNodes[0];})();
 
     expect(widget).toHaveClass('infoaction');
   });

--- a/source/test/karma/ui/structure/pure/Pushbutton-spec.js
+++ b/source/test/karma/ui/structure/pure/Pushbutton-spec.js
@@ -27,7 +27,7 @@ describe("testing a pushbutton widget", function() {
   it("should test the pushbutton creator", function() {
 
     var res = this.createTestWidgetString("pushbutton", {}, '<label>Test</label>');
-    var widget = (function(){var div=document.createElement('div');div.innerHTML=res[1];return div.childNodes[0];})();
+    var widget = cv.util.String.htmlStringToDomElement(res[1]);
     expect(res[0].getPath()).toBe("id_0");
 
     expect(widget).toHaveClass('pushbutton');

--- a/source/test/karma/ui/structure/pure/Pushbutton-spec.js
+++ b/source/test/karma/ui/structure/pure/Pushbutton-spec.js
@@ -27,7 +27,7 @@ describe("testing a pushbutton widget", function() {
   it("should test the pushbutton creator", function() {
 
     var res = this.createTestWidgetString("pushbutton", {}, '<label>Test</label>');
-    var widget = qx.bom.Html.clean([res[1]])[0];
+    var widget = (function(){var div=document.createElement('div');div.innerHTML=res[1];return div.childNodes[0];})();
     expect(res[0].getPath()).toBe("id_0");
 
     expect(widget).toHaveClass('pushbutton');

--- a/source/test/karma/ui/structure/pure/Refresh-spec.js
+++ b/source/test/karma/ui/structure/pure/Refresh-spec.js
@@ -26,7 +26,7 @@ describe("testing a refresh widget", function() {
 
   it("should test the refresh creator", function() {
     var res = this.createTestWidgetString("refresh", {}, '<label>Test</label>');
-    var widget = qx.bom.Html.clean([res[1]])[0];
+    var widget = (function(){var div=document.createElement('div');div.innerHTML=res[1];return div.childNodes[0];})();
     expect(res[0].getPath()).toBe("id_0");
 
     expect(widget).toHaveClass('refresh');

--- a/source/test/karma/ui/structure/pure/Refresh-spec.js
+++ b/source/test/karma/ui/structure/pure/Refresh-spec.js
@@ -26,7 +26,7 @@ describe("testing a refresh widget", function() {
 
   it("should test the refresh creator", function() {
     var res = this.createTestWidgetString("refresh", {}, '<label>Test</label>');
-    var widget = (function(){var div=document.createElement('div');div.innerHTML=res[1];return div.childNodes[0];})();
+    var widget = cv.util.String.htmlStringToDomElement(res[1]);
     expect(res[0].getPath()).toBe("id_0");
 
     expect(widget).toHaveClass('refresh');

--- a/source/test/karma/ui/structure/pure/Rgb-spec.js
+++ b/source/test/karma/ui/structure/pure/Rgb-spec.js
@@ -27,7 +27,7 @@ describe("testing a rgb widget", function() {
   it("should test the rgb creator", function() {
 
     var res = this.createTestWidgetString("rgb", {}, '<label>Test</label>');
-    var widget = qx.bom.Html.clean([res[1]])[0];
+    var widget = (function(){var div=document.createElement('div');div.innerHTML=res[1];return div.childNodes[0];})();
     expect(res[0].getPath()).toBe("id_0");
 
     expect(widget).toHaveClass('rgb');

--- a/source/test/karma/ui/structure/pure/Rgb-spec.js
+++ b/source/test/karma/ui/structure/pure/Rgb-spec.js
@@ -27,7 +27,7 @@ describe("testing a rgb widget", function() {
   it("should test the rgb creator", function() {
 
     var res = this.createTestWidgetString("rgb", {}, '<label>Test</label>');
-    var widget = (function(){var div=document.createElement('div');div.innerHTML=res[1];return div.childNodes[0];})();
+    var widget = cv.util.String.htmlStringToDomElement(res[1]);
     expect(res[0].getPath()).toBe("id_0");
 
     expect(widget).toHaveClass('rgb');

--- a/source/test/karma/ui/structure/pure/Rgb-spec.js
+++ b/source/test/karma/ui/structure/pure/Rgb-spec.js
@@ -37,18 +37,18 @@ describe("testing a rgb widget", function() {
   it("should test the RGB update in R variant", function() {
     var widgetInstance = this.createTestElement("rgb", {}, null, "Test", {variant: "r", transform: 'OH:Number'});
     widgetInstance.update("Test", 255);
-    expect(qx.bom.element.Style.get(widgetInstance.getValueElement(), 'background-color')).toBe('rgb(255, 0, 0)');
+    expect(window.getComputedStyle(widgetInstance.getValueElement())['background-color']).toBe('rgb(255, 0, 0)');
   });
 
   it("should test the RGB update in G variant", function() {
     var widgetInstance = this.createTestElement("rgb", {}, null, "Test", {variant: "g", transform: 'OH:Number'});
     widgetInstance.update("Test", 255);
-    expect(qx.bom.element.Style.get(widgetInstance.getValueElement(), 'background-color')).toBe('rgb(0, 255, 0)');
+    expect(window.getComputedStyle(widgetInstance.getValueElement())['background-color']).toBe('rgb(0, 255, 0)');
   });
 
   it("should test the RGB update in B variant", function() {
     var widgetInstance = this.createTestElement("rgb", {}, null, "Test", {variant: "b", transform: 'OH:Number'});
     widgetInstance.update("Test", 255);
-    expect(qx.bom.element.Style.get(widgetInstance.getValueElement(), 'background-color')).toBe('rgb(0, 0, 255)');
+    expect(window.getComputedStyle(widgetInstance.getValueElement())['background-color']).toBe('rgb(0, 0, 255)');
   });
 });

--- a/source/test/karma/ui/structure/pure/Slide-spec.js
+++ b/source/test/karma/ui/structure/pure/Slide-spec.js
@@ -28,7 +28,7 @@ describe("testing a slide widget", function() {
   it("should test the slide creator", function() {
 
     var res = this.createTestWidgetString("slide", {}, '<label>Test</label>');
-    var widget = qx.bom.Html.clean([res[1]])[0];
+    var widget = (function(){var div=document.createElement('div');div.innerHTML=res[1];return div.childNodes[0];})();
     expect(res[0].getPath()).toBe("id_0");
 
     expect(widget).toHaveClass('slide');

--- a/source/test/karma/ui/structure/pure/Slide-spec.js
+++ b/source/test/karma/ui/structure/pure/Slide-spec.js
@@ -28,7 +28,7 @@ describe("testing a slide widget", function() {
   it("should test the slide creator", function() {
 
     var res = this.createTestWidgetString("slide", {}, '<label>Test</label>');
-    var widget = (function(){var div=document.createElement('div');div.innerHTML=res[1];return div.childNodes[0];})();
+    var widget = cv.util.String.htmlStringToDomElement(res[1]);
     expect(res[0].getPath()).toBe("id_0");
 
     expect(widget).toHaveClass('slide');

--- a/source/test/karma/ui/structure/pure/Switch-spec.js
+++ b/source/test/karma/ui/structure/pure/Switch-spec.js
@@ -28,7 +28,7 @@ describe("testing a switch", function() {
   it("should test the switch creator", function() {
 
     var res = this.createTestElement("switch", {flavour: 'potassium'}, '<label>Test</label>');
-    var switchWidget = qx.bom.Selector.matches(".switch", qx.dom.Hierarchy.getChildElements(res.getDomElement()))[0];
+    var switchWidget = Array.prototype.filter.call(qx.dom.Hierarchy.getChildElements(res.getDomElement()),function(m){return m.matches(".switch");})[0];
 
     expect(switchWidget).toHaveFlavour('potassium');
     var actor = res.getActor();
@@ -40,7 +40,7 @@ describe("testing a switch", function() {
     expect(value).not.toBeNull();
     expect(qx.dom.Node.getText(value)).toBe("-");
 
-    var label = qx.bom.Selector.matches(".label", qx.dom.Hierarchy.getChildElements(switchWidget))[0];
+    var label = Array.prototype.filter.call(qx.dom.Hierarchy.getChildElements(switchWidget),function(m){return m.matches(".label");})[0];
     expect(label).not.toBeNull();
     expect(qx.dom.Node.getText(label)).toBe("Test");
 

--- a/source/test/karma/ui/structure/pure/Switch-spec.js
+++ b/source/test/karma/ui/structure/pure/Switch-spec.js
@@ -38,11 +38,11 @@ describe("testing a switch", function() {
 
     var value = res.getValueElement();
     expect(value).not.toBeNull();
-    expect(qx.dom.Node.getText(value)).toBe("-");
+    expect(value.innerText).toBe("-");
 
     var label = Array.prototype.filter.call(qx.dom.Hierarchy.getChildElements(switchWidget),function(m){return m.matches(".label");})[0];
     expect(label).not.toBeNull();
-    expect(qx.dom.Node.getText(label)).toBe("Test");
+    expect(label.innerText).toBe("Test");
 
     expect(res.getOnValue()).toBe("1");
     expect(res.getOffValue()).toBe("0");

--- a/source/test/karma/ui/structure/pure/Switch-spec.js
+++ b/source/test/karma/ui/structure/pure/Switch-spec.js
@@ -28,7 +28,7 @@ describe("testing a switch", function() {
   it("should test the switch creator", function() {
 
     var res = this.createTestElement("switch", {flavour: 'potassium'}, '<label>Test</label>');
-    var switchWidget = Array.prototype.filter.call(qx.dom.Hierarchy.getChildElements(res.getDomElement()),function(m){return m.matches(".switch");})[0];
+    var switchWidget = Array.from(res.getDomElement().children).filter(function(m){return m.matches(".switch");})[0];
 
     expect(switchWidget).toHaveFlavour('potassium');
     var actor = res.getActor();
@@ -40,7 +40,7 @@ describe("testing a switch", function() {
     expect(value).not.toBeNull();
     expect(value.innerText).toBe("-");
 
-    var label = Array.prototype.filter.call(qx.dom.Hierarchy.getChildElements(switchWidget),function(m){return m.matches(".label");})[0];
+    var label = Array.from(switchWidget.children).filter(function(m){return m.matches(".label");})[0];
     expect(label).not.toBeNull();
     expect(label.innerText).toBe("Test");
 

--- a/source/test/karma/ui/structure/pure/Text-spec.js
+++ b/source/test/karma/ui/structure/pure/Text-spec.js
@@ -35,7 +35,7 @@ describe("testing a text widget", function() {
     expect(text).toHaveClass('text');
     // the text widget does not add the 'label' class to the label-div, so the toHaveLabel
     // helper does not work here and we have to check it manually
-    var label = Array.prototype.filter.call(qx.dom.Hierarchy.getChildElements(text),function(m){return m.matches("div");})[0];
+    var label = Array.from(text.children).filter(function(m){return m.matches("div");})[0];
     expect(label.innerText).toBe('Test');
   });
 });

--- a/source/test/karma/ui/structure/pure/Text-spec.js
+++ b/source/test/karma/ui/structure/pure/Text-spec.js
@@ -29,7 +29,7 @@ describe("testing a text widget", function() {
   it("should test the text creator", function() {
 
     var res = this.createTestWidgetString("text", {}, '<label>Test</label>');
-    var text = (function(){var div=document.createElement('div');div.innerHTML=res[1];return div.childNodes[0];})();
+    var text = cv.util.String.htmlStringToDomElement(res[1]);
     expect(res[0].getPath()).toBe("id_0");
 
     expect(text).toHaveClass('text');

--- a/source/test/karma/ui/structure/pure/Text-spec.js
+++ b/source/test/karma/ui/structure/pure/Text-spec.js
@@ -35,7 +35,7 @@ describe("testing a text widget", function() {
     expect(text).toHaveClass('text');
     // the text widget does not add the 'label' class to the label-div, so the toHaveLabel
     // helper does not work here and we have to check it manually
-    var label = qx.bom.Selector.matches("div", qx.dom.Hierarchy.getChildElements(text))[0];
+    var label = Array.prototype.filter.call(qx.dom.Hierarchy.getChildElements(text),function(m){return m.matches("div");})[0];
     expect(qx.dom.Node.getText(label)).toBe('Test');
   });
 });

--- a/source/test/karma/ui/structure/pure/Text-spec.js
+++ b/source/test/karma/ui/structure/pure/Text-spec.js
@@ -29,13 +29,13 @@ describe("testing a text widget", function() {
   it("should test the text creator", function() {
 
     var res = this.createTestWidgetString("text", {}, '<label>Test</label>');
-    var text = qx.bom.Html.clean([res[1]])[0];
+    var text = (function(){var div=document.createElement('div');div.innerHTML=res[1];return div.childNodes[0];})();
     expect(res[0].getPath()).toBe("id_0");
 
     expect(text).toHaveClass('text');
     // the text widget does not add the 'label' class to the label-div, so the toHaveLabel
     // helper does not work here and we have to check it manually
     var label = Array.prototype.filter.call(qx.dom.Hierarchy.getChildElements(text),function(m){return m.matches("div");})[0];
-    expect(qx.dom.Node.getText(label)).toBe('Test');
+    expect(label.innerText).toBe('Test');
   });
 });

--- a/source/test/karma/ui/structure/pure/Toggle-spec.js
+++ b/source/test/karma/ui/structure/pure/Toggle-spec.js
@@ -27,7 +27,7 @@ describe("testing a toggle widget", function() {
   it("should test the toggle creator", function() {
 
     var res = this.createTestWidgetString("toggle", {}, '<label>Test</label>');
-    var widget = qx.bom.Html.clean([res[1]])[0];
+    var widget = (function(){var div=document.createElement('div');div.innerHTML=res[1];return div.childNodes[0];})();
     expect(res[0].getPath()).toBe("id_0");
 
     expect(widget).toHaveClass('toggle');

--- a/source/test/karma/ui/structure/pure/Toggle-spec.js
+++ b/source/test/karma/ui/structure/pure/Toggle-spec.js
@@ -27,7 +27,7 @@ describe("testing a toggle widget", function() {
   it("should test the toggle creator", function() {
 
     var res = this.createTestWidgetString("toggle", {}, '<label>Test</label>');
-    var widget = (function(){var div=document.createElement('div');div.innerHTML=res[1];return div.childNodes[0];})();
+    var widget = cv.util.String.htmlStringToDomElement(res[1]);
     expect(res[0].getPath()).toBe("id_0");
 
     expect(widget).toHaveClass('toggle');

--- a/source/test/karma/ui/structure/pure/Trigger-spec.js
+++ b/source/test/karma/ui/structure/pure/Trigger-spec.js
@@ -70,15 +70,15 @@ describe("testing a trigger", function() {
 
     var value = Array.prototype.filter.call(qx.dom.Hierarchy.getChildElements(actor),function(m){return m.matches(".value");})[0];
     expect(value).not.toBeNull();
-    expect(qx.dom.Node.getText(value)).toBe("-");
+    expect(value.innerText).toBe("-");
 
     this.initWidget(res);
 
-    expect(qx.dom.Node.getText(value)).toBe("1");
+    expect(value.innerText).toBe("1");
 
     var label = Array.prototype.filter.call(qx.dom.Hierarchy.getChildElements(widget),function(m){return m.matches(".label");})[0];
     expect(label).not.toBeNull();
-    expect(qx.dom.Node.getText(label)).toBe("Test");
+    expect(label.innerText).toBe("Test");
 
     expect(res.getSendValue()).toBe("1");
     expect(res.getShortValue()).toBe("0");

--- a/source/test/karma/ui/structure/pure/Trigger-spec.js
+++ b/source/test/karma/ui/structure/pure/Trigger-spec.js
@@ -63,12 +63,12 @@ describe("testing a trigger", function() {
 
     expect(widget).toHaveFlavour('potassium');
 
-    var actor = qx.bom.Selector.matches(".actor", qx.dom.Hierarchy.getChildElements(widget))[0];
+    var actor = Array.prototype.filter.call(qx.dom.Hierarchy.getChildElements(widget),function(m){return m.matches(".actor");})[0];
     expect(actor).not.toBeNull();
     expect(actor).toHaveClass("switchUnpressed");
     expect(actor).not.toHaveClass("switchPressed");
 
-    var value = qx.bom.Selector.matches(".value", qx.dom.Hierarchy.getChildElements(actor))[0];
+    var value = Array.prototype.filter.call(qx.dom.Hierarchy.getChildElements(actor),function(m){return m.matches(".value");})[0];
     expect(value).not.toBeNull();
     expect(qx.dom.Node.getText(value)).toBe("-");
 
@@ -76,7 +76,7 @@ describe("testing a trigger", function() {
 
     expect(qx.dom.Node.getText(value)).toBe("1");
 
-    var label = qx.bom.Selector.matches(".label", qx.dom.Hierarchy.getChildElements(widget))[0];
+    var label = Array.prototype.filter.call(qx.dom.Hierarchy.getChildElements(widget),function(m){return m.matches(".label");})[0];
     expect(label).not.toBeNull();
     expect(qx.dom.Node.getText(label)).toBe("Test");
 

--- a/source/test/karma/ui/structure/pure/Trigger-spec.js
+++ b/source/test/karma/ui/structure/pure/Trigger-spec.js
@@ -63,12 +63,12 @@ describe("testing a trigger", function() {
 
     expect(widget).toHaveFlavour('potassium');
 
-    var actor = Array.prototype.filter.call(qx.dom.Hierarchy.getChildElements(widget),function(m){return m.matches(".actor");})[0];
+    var actor = Array.from(widget.children).filter(function(m){return m.matches(".actor");})[0];
     expect(actor).not.toBeNull();
     expect(actor).toHaveClass("switchUnpressed");
     expect(actor).not.toHaveClass("switchPressed");
 
-    var value = Array.prototype.filter.call(qx.dom.Hierarchy.getChildElements(actor),function(m){return m.matches(".value");})[0];
+    var value = Array.from(actor.children).filter(function(m){return m.matches(".value");})[0];
     expect(value).not.toBeNull();
     expect(value.innerText).toBe("-");
 
@@ -76,7 +76,7 @@ describe("testing a trigger", function() {
 
     expect(value.innerText).toBe("1");
 
-    var label = Array.prototype.filter.call(qx.dom.Hierarchy.getChildElements(widget),function(m){return m.matches(".label");})[0];
+    var label = Array.from(widget.children).filter(function(m){return m.matches(".label");})[0];
     expect(label).not.toBeNull();
     expect(label.innerText).toBe("Test");
 

--- a/source/test/karma/ui/structure/pure/Trigger-spec.js
+++ b/source/test/karma/ui/structure/pure/Trigger-spec.js
@@ -59,7 +59,7 @@ describe("testing a trigger", function() {
       flavour: "potassium"
     }, '<label>Test</label>');
 
-    var widget = qx.bom.Selector.query('#id_0 .widget')[0];
+    var widget = document.querySelector('#id_0 .widget');
 
     expect(widget).toHaveFlavour('potassium');
 

--- a/source/test/karma/ui/structure/pure/Unknown-spec.js
+++ b/source/test/karma/ui/structure/pure/Unknown-spec.js
@@ -32,6 +32,6 @@ describe("testing a unknown widget", function() {
     var inst = cv.ui.structure.WidgetFactory.createInstance("unknown", data);
     var unknown = qx.bom.Html.clean([inst.getDomString()])[0];
 
-    expect(qx.bom.Selector.query("pre", unknown)[0].textContent).toBe('unknown: unknown_widget');
+    expect(unknown.querySelector("pre").textContent).toBe('unknown: unknown_widget');
   });
 });

--- a/source/test/karma/ui/structure/pure/Unknown-spec.js
+++ b/source/test/karma/ui/structure/pure/Unknown-spec.js
@@ -28,9 +28,9 @@ describe("testing a unknown widget", function() {
 
   it("should test the unknown creator", function() {
 
-    var data = cv.parser.WidgetParser.parse(qx.dom.Element.create('unknown_widget'), 'id_0', null, "text");
+    var data = cv.parser.WidgetParser.parse(document.createElement('unknown_widget'), 'id_0', null, "text");
     var inst = cv.ui.structure.WidgetFactory.createInstance("unknown", data);
-    var unknown = qx.bom.Html.clean([inst.getDomString()])[0];
+    var unknown = (function(){var div=document.createElement('div');div.innerHTML=inst.getDomString();return div.childNodes[0];})();
 
     expect(unknown.querySelector("pre").textContent).toBe('unknown: unknown_widget');
   });

--- a/source/test/karma/ui/structure/pure/Unknown-spec.js
+++ b/source/test/karma/ui/structure/pure/Unknown-spec.js
@@ -30,7 +30,7 @@ describe("testing a unknown widget", function() {
 
     var data = cv.parser.WidgetParser.parse(document.createElement('unknown_widget'), 'id_0', null, "text");
     var inst = cv.ui.structure.WidgetFactory.createInstance("unknown", data);
-    var unknown = (function(){var div=document.createElement('div');div.innerHTML=inst.getDomString();return div.childNodes[0];})();
+    var unknown = cv.util.String.htmlStringToDomElement(inst.getDomString());
 
     expect(unknown.querySelector("pre").textContent).toBe('unknown: unknown_widget');
   });

--- a/source/test/karma/ui/structure/pure/Urltrigger-spec.js
+++ b/source/test/karma/ui/structure/pure/Urltrigger-spec.js
@@ -27,7 +27,7 @@ describe("testing a urltrigger widget", function() {
   it("should test the urltrigger creator", function() {
 
     var res = this.createTestWidgetString("urltrigger", {}, '<label>Test</label>');
-    var widget = qx.bom.Html.clean([res[1]])[0];
+    var widget = (function(){var div=document.createElement('div');div.innerHTML=res[1];return div.childNodes[0];})();
     expect(res[0].getPath()).toBe("id_0");
 
     expect(widget).toHaveClass('trigger');

--- a/source/test/karma/ui/structure/pure/Urltrigger-spec.js
+++ b/source/test/karma/ui/structure/pure/Urltrigger-spec.js
@@ -27,7 +27,7 @@ describe("testing a urltrigger widget", function() {
   it("should test the urltrigger creator", function() {
 
     var res = this.createTestWidgetString("urltrigger", {}, '<label>Test</label>');
-    var widget = (function(){var div=document.createElement('div');div.innerHTML=res[1];return div.childNodes[0];})();
+    var widget = cv.util.String.htmlStringToDomElement(res[1]);
     expect(res[0].getPath()).toBe("id_0");
 
     expect(widget).toHaveClass('trigger');

--- a/source/test/karma/ui/structure/pure/Video-spec.js
+++ b/source/test/karma/ui/structure/pure/Video-spec.js
@@ -27,7 +27,7 @@ describe("testing a video widget", function() {
   it("should test the video creator", function() {
 
     var res = this.createTestWidgetString("video", {src: '', width: "100%", height: "90%"}, '<label>Test</label>');
-    var widget = qx.bom.Html.clean([res[1]])[0];
+    var widget = (function(){var div=document.createElement('div');div.innerHTML=res[1];return div.childNodes[0];})();
     expect(res[0].getPath()).toBe("id_0");
     expect(widget).toHaveClass('video');
     expect(widget).toHaveLabel('Test');

--- a/source/test/karma/ui/structure/pure/Video-spec.js
+++ b/source/test/karma/ui/structure/pure/Video-spec.js
@@ -32,7 +32,7 @@ describe("testing a video widget", function() {
     expect(widget).toHaveClass('video');
     expect(widget).toHaveLabel('Test');
 
-    var videoWidget = qx.bom.Selector.query("video", widget)[0];
+    var videoWidget = widget.querySelector("video");
     expect(videoWidget).toHaveStyleSetting("width", "100%");
     expect(videoWidget).toHaveStyleSetting("height", "90%");
   });

--- a/source/test/karma/ui/structure/pure/Video-spec.js
+++ b/source/test/karma/ui/structure/pure/Video-spec.js
@@ -27,7 +27,7 @@ describe("testing a video widget", function() {
   it("should test the video creator", function() {
 
     var res = this.createTestWidgetString("video", {src: '', width: "100%", height: "90%"}, '<label>Test</label>');
-    var widget = (function(){var div=document.createElement('div');div.innerHTML=res[1];return div.childNodes[0];})();
+    var widget = cv.util.String.htmlStringToDomElement(res[1]);
     expect(res[0].getPath()).toBe("id_0");
     expect(widget).toHaveClass('video');
     expect(widget).toHaveLabel('Test');

--- a/source/test/karma/ui/structure/pure/Web-spec.js
+++ b/source/test/karma/ui/structure/pure/Web-spec.js
@@ -26,7 +26,7 @@ describe("testing a web widget", function() {
   it("should test the web creator", function() {
 
     var res = this.createTestWidgetString("web", {ga: 'Test'}, '<label>Test</label>');
-    var widget = qx.bom.Html.clean([res[1]])[0];
+    var widget = (function(){var div=document.createElement('div');div.innerHTML=res[1];return div.childNodes[0];})();
     expect(res[0].getPath()).toBe("id_0");
     expect(res[0].getAddress()['_Test'][0]).toBe('DPT:1.001');
     expect(res[0].getAddress()['_Test'][1]).toBe(0);

--- a/source/test/karma/ui/structure/pure/Web-spec.js
+++ b/source/test/karma/ui/structure/pure/Web-spec.js
@@ -26,7 +26,7 @@ describe("testing a web widget", function() {
   it("should test the web creator", function() {
 
     var res = this.createTestWidgetString("web", {ga: 'Test'}, '<label>Test</label>');
-    var widget = (function(){var div=document.createElement('div');div.innerHTML=res[1];return div.childNodes[0];})();
+    var widget = cv.util.String.htmlStringToDomElement(res[1]);
     expect(res[0].getPath()).toBe("id_0");
     expect(res[0].getAddress()['_Test'][0]).toBe('DPT:1.001');
     expect(res[0].getAddress()['_Test'][1]).toBe(0);

--- a/source/test/karma/ui/structure/pure/Wgplugininfo-spec.js
+++ b/source/test/karma/ui/structure/pure/Wgplugininfo-spec.js
@@ -27,7 +27,7 @@ describe("testing a wgplugin_info widget", function() {
   it("should test the wgplugin_info creator", function() {
 
     var res = this.createTestWidgetString("wgplugin_info", {}, '<label>Test</label>');
-    var widget = (function(){var div=document.createElement('div');div.innerHTML=res[1];return div.childNodes[0];})();
+    var widget = cv.util.String.htmlStringToDomElement(res[1]);
     expect(res[0].getPath()).toBe("id_0");
 
     expect(widget).toHaveClass('info');

--- a/source/test/karma/ui/structure/pure/Wgplugininfo-spec.js
+++ b/source/test/karma/ui/structure/pure/Wgplugininfo-spec.js
@@ -27,7 +27,7 @@ describe("testing a wgplugin_info widget", function() {
   it("should test the wgplugin_info creator", function() {
 
     var res = this.createTestWidgetString("wgplugin_info", {}, '<label>Test</label>');
-    var widget = qx.bom.Html.clean([res[1]])[0];
+    var widget = (function(){var div=document.createElement('div');div.innerHTML=res[1];return div.childNodes[0];})();
     expect(res[0].getPath()).toBe("id_0");
 
     expect(widget).toHaveClass('info');

--- a/source/test/karma/xml/parser/Meta-spec.js
+++ b/source/test/karma/xml/parser/Meta-spec.js
@@ -7,7 +7,7 @@ describe("testing the meta parser", function() {
   it("should test the meta parser", function () {
     // add footer to document
     var footer = qx.dom.Element.create("div", {"class": 'footer'});
-    var body = qx.bom.Selector.query("body")[0];
+    var body = document.querySelector("body");
     qx.dom.Element.insertEnd(footer, body);
 
     // ugly hack to allow multiline string

--- a/source/test/karma/xml/parser/Meta-spec.js
+++ b/source/test/karma/xml/parser/Meta-spec.js
@@ -8,7 +8,7 @@ describe("testing the meta parser", function() {
     // add footer to document
     var footer = qx.dom.Element.create("div", {"class": 'footer'});
     var body = document.querySelector("body");
-    qx.dom.Element.insertEnd(footer, body);
+    body.appendChild(footer);
 
     // ugly hack to allow multiline string
     var source = (function() {/*
@@ -128,7 +128,7 @@ describe("testing the meta parser", function() {
       expect(cv.parser.WidgetParser.__templates.hasOwnProperty('test')).toBeTruthy();
       expect(cv.parser.WidgetParser.__templates.test.trim()).toEqual('<root><text><label>Test template</label></text></root>');
 
-      qx.dom.Element.remove(footer);
+      footer.parentNode.removeChild(footer);
     });
   });
 });


### PR DESCRIPTION
See also #772

This patch reduces the vendor lock in to Qx in about 1000 instances where native JavaScript does the job exactly as well as the Qx layer on top of it.

So this patch means that for each of those actions less code is being run (should give a minimal speed advantage), the code is (at least uncompressed) smaller by about 3.6kb and - most importantly - helps us to stay as independent from any unnecessary code as possible.

There are still many places that would benefit from such a clean up, but it must start somewhere.