### PR TITLE
As the speech plugin in no DOM widget is has to set a flat to be init…

### DIFF
--- a/source/class/cv/plugins/Speech.js
+++ b/source/class/cv/plugins/Speech.js
@@ -65,6 +65,7 @@ qx.Class.define('cv.plugins.Speech', {
    ******************************************************
    */
   construct: function(props) {
+    this._initOnCreate = true;
     this.base(arguments);
     this.set(props);
     this.__lastSpeech = {};


### PR DESCRIPTION
…ialized correctly

fixes error reported here: https://knx-user-forum.de/forum/supportforen/cometvisu/1416309-speech-plugin-will-nicht