### PR TITLE
Allow user to reload browser after bad error

### DIFF
--- a/source/class/cv/ui/Popup.js
+++ b/source/class/cv/ui/Popup.js
@@ -265,6 +265,15 @@ qx.Class.define('cv.ui.Popup', {
       ret_val.style.left = placement.x;
       ret_val.style.top  = placement.y;
 
+      if (!closable) {
+        var reload = '<div class="reload">' +
+          '<a href="javascript:location.reload(true);">' +
+          qx.locale.Manager.tr('Reload').toString() +
+          '</a>' +
+          '</div>';
+        ret_val.insertAdjacentHTML('beforeend', reload);
+      }
+
       if (closable && addCloseListeners) {
         this.addListener('close', this.close, this);
         qx.event.Registration.addListener(ret_val, 'tap', function () {

--- a/source/resource/designs/designglobals.css
+++ b/source/resource/designs/designglobals.css
@@ -490,6 +490,7 @@ button.ui-slider-handle {
   font-size: 0.8em;
 }
 
+.popup .reload,
 .popup .actions { text-align: center; white-space: nowrap; clear: both; }
 .popup .actions button {
   padding: 0.3em 1em;


### PR DESCRIPTION
Errors that can't be closed are assumed to be such bad error cases.
Fixes #976

Should be backported to 0.11 as well