### PR TITLE
do not show client connection error when the cometvisu is in the back…

### DIFF
--- a/source/class/cv/Application.js
+++ b/source/class/cv/Application.js
@@ -45,6 +45,10 @@ qx.Class.define("cv.Application",
     if (qx.io.PartLoader.getInstance().hasPart(lang)) {
       qx.io.PartLoader.require([lang]);
     }
+
+    qx.bom.PageVisibility.getInstance().addListener('change', function () {
+      this.setActive(qx.bom.PageVisibility.getInstance().getVisibilityState() === "visible");
+    }, this);
   },
 
   /*
@@ -112,6 +116,12 @@ qx.Class.define("cv.Application",
     commandManager: {
       check: 'qx.ui.command.GroupManager',
       deferredInit: true
+    },
+
+    active: {
+      check: "Boolean",
+      init: true,
+      event: "changeActive"
     }
   },
 

--- a/source/class/cv/TemplateEngine.js
+++ b/source/class/cv/TemplateEngine.js
@@ -137,6 +137,8 @@ qx.Class.define('cv.TemplateEngine', {
 
     // plugins that do not need to be loaded to proceed with the initial setup
     lazyPlugins: ["plugin-openhab"],
+    __activeChangedTimer: null,
+    __hasBeenConnected: false,
 
     /**
      * Load parts (e.g. plugins, structure)
@@ -278,26 +280,57 @@ qx.Class.define('cv.TemplateEngine', {
         })
         visu.addListener('changedServer', this._updateClientScope, this);
       }
+      var app = qx.core.Init.getApplication();
+      app.addListener('changeActive', this._onActiveChanged, this);
+
       // show connection state in NotificationCenter
-      this.visu.addListener("changeConnected", function(ev) {
-        var message = {
-          topic: "cv.client.connection",
-          title: qx.locale.Manager.tr("Connection error"),
-          severity: "urgent",
-          unique: true,
-          deletable: false,
-          condition: !ev.getData()
-        };
-        var lastError = this.visu.getLastError();
-        if (!ev.getData()) {
-          if (lastError && (Date.now() - lastError.time) < 100) {
-            message.message = qx.locale.Manager.tr("Error requesting %1: %2 - %3.", lastError.url, lastError.code, lastError.text);
-          } else {
-            message.message = qx.locale.Manager.tr("Connection to backend is lost.");
-          }
+      this.visu.addListener("changeConnected", this._checkBackendConnection, this);
+    },
+
+    _onActiveChanged: function () {
+      var app = qx.core.Init.getApplication();
+      if (app.isActive()) {
+        if (!this.visu.isConnected() && this.__hasBeenConnected) {
+          // reconnect
+          this.visu.restart(true);
         }
-        cv.core.notifications.Router.dispatchMessage(message.topic, message);
-      }, this);
+        // wait for 3 seconds before checking the backend connection
+        if (!this.__activeChangedTimer) {
+          this.__activeChangedTimer = new qx.event.Timer(3000);
+          this.__activeChangedTimer.addListener('interval', function () {
+            if (app.isActive()) {
+              this._checkBackendConnection();
+            }
+            this.__activeChangedTimer.stop();
+          }, this);
+        }
+        this.__activeChangedTimer.restart();
+      } else {
+        this._checkBackendConnection();
+      }
+    },
+
+    _checkBackendConnection: function () {
+      var connected = this.visu.isConnected();
+      var message = {
+        topic: "cv.client.connection",
+        title: qx.locale.Manager.tr("Connection error"),
+        severity: "urgent",
+        unique: true,
+        deletable: false,
+        condition: !connected && this.__hasBeenConnected && qx.core.Init.getApplication().isActive()
+      };
+      var lastError = this.visu.getLastError();
+      if (!connected) {
+        if (lastError && (Date.now() - lastError.time) < 100) {
+          message.message = qx.locale.Manager.tr("Error requesting %1: %2 - %3.", lastError.url, lastError.code, lastError.text);
+        } else {
+          message.message = qx.locale.Manager.tr("Connection to backend is lost.");
+        }
+      } else {
+        this.__hasBeenConnected = true;
+      }
+      cv.core.notifications.Router.dispatchMessage(message.topic, message);
     },
 
     _updateClientScope: function () {
@@ -858,5 +891,14 @@ qx.Class.define('cv.TemplateEngine', {
         });
       });
     }
+  },
+
+  /*
+  ***********************************************
+    DESTRUCTOR
+  ***********************************************
+  */
+  destruct: function () {
+    this._disposeObjects('__activeChangedTimer');
   }
 });

--- a/utils/compile/cv/CompileHandler.js
+++ b/utils/compile/cv/CompileHandler.js
@@ -99,6 +99,10 @@ class CvCompileHandler extends AbstractCompileHandler {
     }
 
     if (command.argv.watch) {
+      if (this._watcher) {
+        this._watcher.close();
+      }
+      this.__watcherReady = false;
       var watcher = this._watcher = chokidar.watch(Object.keys(this._watchList), {});
       watcher.on("change", filename => this.__onFileChange("change", filename));
       watcher.on("add", filename => this.__onFileChange("add", filename));


### PR DESCRIPTION
…ground and reconnect after resume then the connection is lost

This should prevent the error being shown after the cometvisu get re-opened on a smartphone.

This PR also includes a minor compiler improvement that prevents from files beeing synced every time the compiler is re-run in watchmode