### PR TITLE
replace links in configs

### DIFF
--- a/source/class/cv/data/FileWorker.js
+++ b/source/class/cv/data/FileWorker.js
@@ -1,0 +1,88 @@
+/**
+ * Worker script that handles file related operations like modification checking or xml validation
+ */
+qx.Class.define('cv.data.FileWorker', {
+  extend: qx.core.Object,
+  type: 'singleton',
+
+  /*
+  ***********************************************
+    CONSTRUCTOR
+  ***********************************************
+  */
+  construct: function () {
+    this.base(arguments);
+    this._files = [];
+    this._worker = new Worker(qx.util.ResourceManager.getInstance().toUri('manager/worker.js'));
+    this._worker.onmessage = this._onMessage.bind(this);
+    this._validationCallbacks = {};
+  },
+
+  /*
+  ***********************************************
+    EVENTS
+  ***********************************************
+  */
+  events: {
+    message: 'qx.event.type.Data'
+  },
+
+  /*
+  ***********************************************
+    MEMBERS
+  ***********************************************
+  */
+  members: {
+    _worker: null,
+    _validationCallbacks: null,
+
+    postMessage: function (msg) {
+      this._worker.postMessage(msg);
+    },
+
+    validateConfig: function (url) {
+      return new Promise(function (resolve, reject) {
+        // check if there is already one validation request ongoing
+        if (!this._validationCallbacks.hasOwnProperty(url)) {
+          this._validationCallbacks[url] = [resolve];
+          this._worker.postMessage(["validateConfig", {
+            path: url
+          }]);
+        } else {
+          this._validationCallbacks[url].push(resolve);
+        }
+      }.bind(this));
+    },
+
+    _onMessage: function (e) {
+      let topic = e.data.shift();
+      let data = e.data.shift();
+      let path = e.data.shift();
+      switch(topic) {
+        case 'validationResult':
+          if (this._validationCallbacks.hasOwnProperty(path)) {
+            const callbacks = this._validationCallbacks[path];
+            delete this._validationCallbacks[path];
+            callbacks.forEach(function(cb) {
+              cb(data);
+            });
+          }
+          break;
+      }
+      this.fireDataEvent('message', {
+        topic: topic,
+        data: data,
+        path: path
+      })
+    }
+  },
+
+  /*
+  ***********************************************
+    DESTRUCTOR
+  ***********************************************
+  */
+  destruct: function () {
+    this._worker = null;
+  }
+});

--- a/source/class/cv/parser/MetaParser.js
+++ b/source/class/cv/parser/MetaParser.js
@@ -204,6 +204,43 @@ qx.Class.define("cv.parser.MetaParser", {
 
         var text = elem.textContent;
         var search;
+
+        // compability change to make existing customer configurations work with the new manager links
+        // this replaces all document links to old manager tools with the new ones
+        let linkMatch;
+        const linkRegex = /href="([^"]+)"/gm;
+        const matches = [];
+        while (linkMatch = linkRegex.exec(text)) {
+          matches.push(linkMatch);
+        }
+        let handled = false;
+        search = window.location.search.replace(/\$/g, '$$$$');
+        search = search.replace(/.*config=([^&]*).*|.*/, '$1');
+        matches.forEach(match => {
+          switch (match[1]) {
+            case 'manager.php':
+              text = text.replace(match[0], 'href="#" onclick="showManager()"');
+              handled = true;
+              break;
+
+            case 'check_config.php':
+              text = text.replace(match[0], 'href="#" onclick="qx.core.Init.getApplication().validateConfig(\'' + search + '\')"');
+              handled = true;
+              break;
+
+            case 'editor/':
+            case 'editor':
+              const suffix = search ? '_' + search : '';
+              text = text.replace(match[0], 'href="#" onclick="showManager(\'open\', \'visu_config' + suffix + '.xml\')"');
+              handled = true;
+              break;
+          }
+        });
+
+        if (handled) {
+          // this overrides the extends
+          extend = null;
+        }
         switch (extend) {
           case 'all': // append all parameters
             search = window.location.search.replace(/\$/g, '$$$$');
@@ -222,6 +259,26 @@ qx.Class.define("cv.parser.MetaParser", {
             }
 
             text = text.replace(/(href="[^"]*)(")/g, '$1' + search + '$2');
+            break;
+
+          case 'action':
+            search = window.location.search.replace(/\$/g, '$$$$');
+            search = search.replace(/.*config=([^&]*).*|.*/, '$1');
+            const match = /cv-action="([\w]+)"/.exec(text);
+            if (match) {
+              let replacement = 'href="#" '
+              switch (match[1]) {
+                case 'validate':
+                  replacement += 'onclick="qx.core.Init.getApplication().validateConfig(\'' + search + '\')"';
+                  break;
+
+                case 'edit':
+                  const configFile = search ? 'visu_config_' + search + '.xml' : 'visu_config.xml';
+                  replacement += 'onclick="showManager(\'open\', \'' + configFile + '\')"';
+                  break;
+              }
+              text = text.replace(match[0], replacement);
+            }
             break;
         }
         code += text;

--- a/source/class/cv/ui/manager/Main.js
+++ b/source/class/cv/ui/manager/Main.js
@@ -252,6 +252,29 @@ qx.Class.define('cv.ui.manager.Main', {
       }
     },
 
+    __findConfigFile: function (name) {
+      let file = null;
+      let demoFolder = null;
+      cv.ui.manager.model.FileItem.ROOT.getChildren().some(child => {
+        if (child.getName() === 'demo') {
+          demoFolder = child;
+        } else if (child.getName() === name) {
+          file = child;
+          return true;
+        }
+      });
+      if (!file && demoFolder) {
+        // check demo configs
+        demoFolder.getChildren().some(child => {
+          if (child.getName() === name) {
+            file = child;
+            return true;
+          }
+        })
+      }
+      return file;
+    },
+
     _onManagerEvent: function (ev) {
       var data = ev.getData();
       switch (ev.getName()) {
@@ -260,10 +283,18 @@ qx.Class.define('cv.ui.manager.Main', {
           break;
 
         case 'cv.manager.openWith':
+          if (typeof data.file === 'string') {
+            // this can only by a file in the root dir (a config)
+            data.file = this.__findConfigFile(data.file);
+          }
           this.openFile(data.file || this.getCurrentSelection(), false, data.handler);
           break;
 
         case 'cv.manager.open':
+          if (typeof data === 'string') {
+            // this can only by a file in the root dir (a config)
+            data = this.__findConfigFile(data);
+          }
           this.openFile(data || this.getCurrentSelection(), false);
           break;
       }

--- a/source/class/cv/ui/manager/editor/Worker.js
+++ b/source/class/cv/ui/manager/editor/Worker.js
@@ -14,9 +14,8 @@ qx.Class.define('cv.ui.manager.editor.Worker', {
     this.base(arguments);
     this._files = {};
     // create WebWorker
-    this._worker = new Worker(qx.util.ResourceManager.getInstance().toUri('manager/worker.js'));
-    this._worker.onmessage = this._onMessage.bind(this);
-    this._validationCallbacks = {};
+    this._worker = cv.data.FileWorker.getInstance();
+    this._worker.addListener('message', this._onMessage, this);
   },
 
   /*
@@ -39,7 +38,6 @@ qx.Class.define('cv.ui.manager.editor.Worker', {
   members: {
     _worker: null,
     _files: null,
-    _validationCallbacks: null,
 
     open: function (file, code, schema) {
       this._worker.postMessage(["openFile", {
@@ -66,33 +64,22 @@ qx.Class.define('cv.ui.manager.editor.Worker', {
 
     validateConfig: function (file) {
       if (file.isConfigFile()) {
-        return new Promise(function (resolve, reject) {
-          // check if there is already one validation request ongoing
-          var url = file.getServerPath();
-          if (!this._validationCallbacks.hasOwnProperty(url)) {
-            this._validationCallbacks[url] = [resolve];
-            this._worker.postMessage(["validateConfig", {
-              path: url
-            }]);
-          } else {
-            this._validationCallbacks[url].push(resolve);
-          }
-        }.bind(this));
+        return this._worker.validateConfig(file.getServerPath());
       } else {
         qx.log.Logger.error(this, file.getFullPath() + ' is no configuration file');
       }
     },
 
     _onMessage: function (e) {
-      var topic = e.data.shift();
-      var data = e.data.shift();
-      var path = e.data.shift();
-      var file = this._files[path];
+      let topic = e.getData().topic;
+      let data = e.getData().data;
+      let path = e.getData().path;
+      let file = this._files[path];
       if (!file && topic !== 'validationResult') {
         qx.log.Logger.error(this, 'no file found for path ' + path + ' ignoring worker message for topic ' + topic);
         return;
       }
-      var editor = this.getEditor();
+      let editor = this.getEditor();
       switch(topic) {
         case "modified":
           // new files are always modified, to not override that state
@@ -112,16 +99,6 @@ qx.Class.define('cv.ui.manager.editor.Worker', {
         case "decorations":
           if (editor) {
             editor.showDecorations(path, data);
-          }
-          break;
-
-        case 'validationResult':
-          if (this._validationCallbacks.hasOwnProperty(path)) {
-            var callbacks = this._validationCallbacks[path];
-            delete this._validationCallbacks[path];
-            callbacks.forEach(function(cb) {
-              cb(data);
-            });
           }
           break;
       }

--- a/source/resource/config/.templates/visu_config.xml
+++ b/source/resource/config/.templates/visu_config.xml
@@ -10,11 +10,11 @@
     <statusbar>
       <status type="html"><![CDATA[
           <img src="resource/icon/comet_64_ff8000.png" alt="CometVisu" /> by <a href="https://www.cometvisu.org/">CometVisu.org</a>
-          - <a href="manager.php">Config-Manager</a>
+          - <a href="#" onclick="showManager()">Config-Manager</a>
           - <a href=".?forceReload=true">Reload</a>
         ]]></status>
-      <status type="html" condition="!edit" hrefextend="config"><![CDATA[
-          - <a href="#" onclick="qx.core.Init.getApplication().showManager('open', 'visu_config.xml')">Edit</a>
+      <status type="html" condition="!edit" hrefextend="action"><![CDATA[
+          - <a cv-action="edit">Edit</a>
         ]]></status>
       <status type="html" condition="edit" hrefextend="config"><![CDATA[
           - <a href=".">normal Mode</a>
@@ -22,8 +22,8 @@
       <status type="html"><![CDATA[
           - <a href="?config=demo">Widget Demo</a>
         ]]></status>
-      <status type="html" hrefextend="config"><![CDATA[
-          - <a href="check_config.php">Check Config</a>
+      <status type="html" hrefextend="action"><![CDATA[
+          - <a cv-action="validate">Check Config</a>
         ]]></status>
     </statusbar>
   </meta>

--- a/source/resource/config/.templates/visu_config.xml
+++ b/source/resource/config/.templates/visu_config.xml
@@ -14,7 +14,7 @@
           - <a href=".?forceReload=true">Reload</a>
         ]]></status>
       <status type="html" condition="!edit" hrefextend="config"><![CDATA[
-          - <a href="editor/">Edit</a>
+          - <a href="#" onclick="qx.core.Init.getApplication().showManager('open', 'visu_config.xml')">Edit</a>
         ]]></status>
       <status type="html" condition="edit" hrefextend="config"><![CDATA[
           - <a href=".">normal Mode</a>

--- a/source/resource/config/visu_config.xml
+++ b/source/resource/config/visu_config.xml
@@ -10,11 +10,11 @@
     <statusbar>
       <status type="html"><![CDATA[
           <img src="resource/icon/comet_64_ff8000.png" alt="CometVisu" /> by <a href="https://www.cometvisu.org/">CometVisu.org</a>
-          - <a href="manager.php">Config-Manager</a>
+          - <a href="#" onclick="showManager()">Config-Manager</a>
           - <a href=".?forceReload=true">Reload</a>
         ]]></status>
-      <status type="html" condition="!edit" hrefextend="config"><![CDATA[
-          - <a href="editor/">Edit</a>
+      <status type="html" condition="!edit" hrefextend="action"><![CDATA[
+          - <a cv-action="edit">Edit</a>
         ]]></status>
       <status type="html" condition="edit" hrefextend="config"><![CDATA[
           - <a href=".">normal Mode</a>
@@ -22,8 +22,8 @@
       <status type="html"><![CDATA[
           - <a href="?config=demo">Widget Demo</a>
         ]]></status>
-      <status type="html" hrefextend="config"><![CDATA[
-          - <a href="check_config.php">Check Config</a>
+      <status type="html" hrefextend="action"><![CDATA[
+          - <a cv-action="validate">Check Config</a>
         ]]></status>
     </statusbar>
   </meta>

--- a/source/resource/demo/visu_config_demo.xml
+++ b/source/resource/demo/visu_config_demo.xml
@@ -125,15 +125,15 @@
     <statusbar>
       <status type="html"><![CDATA[
           <img src="resource/icon/comet_64_ff8000.png" alt="CometVisu" /> by <a href="https://www.cometvisu.org/">CometVisu.org</a>
-          - <a href="manager.php">Config-Manager</a>
+          - <a href="#" onclick="showManager()">Config-Manager</a>
           - <a href=".?config=demo&forceReload=true">Reload</a>
           - <a href=".">Default Config</a>
         ]]></status>
-      <status type="html" condition="!edit" hrefextend="config"><![CDATA[
-          - <a href="editor/">Edit</a>
+      <status type="html" condition="!edit" hrefextend="action"><![CDATA[
+          - <a cv-action="edit">Edit</a>
         ]]></status>
-      <status type="html" hrefextend="config"><![CDATA[
-          - <a href="check_config.php">Check Config</a>
+      <status type="html" hrefextend="action"><![CDATA[
+          - <a cv-action="validate">Check Config</a>
           <div style="float:right;padding-right:0.5em">Version: Git</div>
         ]]></status>
     </statusbar>

--- a/source/resource/demo/visu_config_demo_flat.xml
+++ b/source/resource/demo/visu_config_demo_flat.xml
@@ -53,11 +53,11 @@
     <statusbar>
       <status type="html"><![CDATA[
           <img src="resource/icon/comet_64_ff8000.png" alt="CometVisu" /> by <a href="https://www.cometvisu.org/">CometVisu.org</a>
-          - <a href="manager.php">Config-Manager</a>
+          - <a href="#" onclick="showManager()">Config-Manager</a>
           - <a href=".?forceReload=true">Reload</a>
         ]]></status>
-      <status type="html" condition="!edit" hrefextend="config"><![CDATA[
-          - <a href="editor/">Edit</a>
+      <status type="html" condition="!edit" hrefextend="action"><![CDATA[
+          - <a cv-action="edit">Edit</a>
         ]]></status>
       <status type="html" condition="edit" hrefextend="config"><![CDATA[
           - <a href=".">normal Mode</a>
@@ -65,8 +65,8 @@
       <status type="html"><![CDATA[
           - <a href="?config=demo">Widget Demo</a>
         ]]></status>
-      <status type="html" hrefextend="config"><![CDATA[
-          - <a href="check_config.php">Check Config</a>
+      <status type="html" hrefextend="action"><![CDATA[
+          - <a cv-action="validate">Check Config</a>
         ]]></status>
     </statusbar>
   </meta>
@@ -185,9 +185,15 @@
 
     <page name="Wohnzimmer" visible="false">
       <group name="Wohnzimmer">
-        <multitrigger button1label="Auto" button1value="auto" button2label="Komfort" button2value="comfort" button3label="Standy By" button3value="standby" button4label="Economy" button4value="economy" showstatus="true" mapping="KonnexHVAC">
+        <multitrigger showstatus="true" mapping="KonnexHVAC">
           <label>Heizung</label>
           <address transform="DPT:20.102" mode="readwrite">12/7/13</address>
+          <buttons>
+            <button label="Auto">auto</button>
+            <button label="Komfort">comfort</button>
+            <button label="Stand By">standby</button>
+            <button label="Economy">economy</button>
+          </buttons>
         </multitrigger>
         
         <colorchooser>

--- a/source/resource/demo/visu_config_demorss.xml
+++ b/source/resource/demo/visu_config_demorss.xml
@@ -16,18 +16,18 @@
     <statusbar>
       <status type="html"><![CDATA[
           <img src="resource/icon/comet_64_ff8000.png" alt="CometVisu" /> by <a href="https://www.cometvisu.org/">CometVisu.org</a>
-          - <a href="manager.php">Config-Manager</a>
+          - <a href="#" onclick="showManager()">Config-Manager</a>
           - <a href=".?forceReload=true">Reload</a>
           - <a href="?config=demo">Widget Demo</a>
         ]]></status>
-      <status type="html" condition="!edit" hrefextend="config"><![CDATA[
-          - <a href="editor/">Edit</a>
+      <status type="html" condition="!edit" hrefextend="action"><![CDATA[
+          - <a cv-action="edit">Edit</a>
         ]]></status>
       <status type="html" condition="edit" hrefextend="all"><![CDATA[
           - <a href=".">normal Mode</a>
         ]]></status>
-      <status type="html" hrefextend="config"><![CDATA[
-          - <a href="check_config.php">Check Config</a>
+      <status type="html" hrefextend="action"><![CDATA[
+          - <a cv-action="validate">Check Config</a>
         ]]></status>
     </statusbar>
   </meta>

--- a/source/resource/demo/visu_config_empty.xml
+++ b/source/resource/demo/visu_config_empty.xml
@@ -10,11 +10,11 @@
     <statusbar>
       <status type="html"><![CDATA[
           <img src="resource/icon/comet_64_ff8000.png" alt="CometVisu" /> by <a href="https://www.cometvisu.org/">CometVisu.org</a>
-          - <a href="manager.php">Config-Manager</a>
+          - <a href="#" onclick="showManager()">Config-Manager</a>
           - <a href=".?forceReload=true">Reload</a>
         ]]></status>
-      <status type="html" condition="!edit" hrefextend="config"><![CDATA[
-          - <a href="editor/">Edit</a>
+      <status type="html" condition="!edit" hrefextend="action"><![CDATA[
+          - <a cv-action="edit">Edit</a>
         ]]></status>
       <status type="html" condition="edit" hrefextend="config"><![CDATA[
           - <a href=".">normal Mode</a>
@@ -22,8 +22,8 @@
       <status type="html"><![CDATA[
           - <a href="?config=demo">Widget Demo</a>
         ]]></status>
-      <status type="html" hrefextend="config"><![CDATA[
-          - <a href="check_config.php">Check Config</a>
+      <status type="html" hrefextend="action"><![CDATA[
+          - <a cv-action="validate">Check Config</a>
         ]]></status>
     </statusbar>
   </meta>

--- a/source/resource/demo/visu_config_responsive.xml
+++ b/source/resource/demo/visu_config_responsive.xml
@@ -10,11 +10,11 @@
     <statusbar>
       <status type="html"><![CDATA[
           <img src="resource/icon/comet_64_ff8000.png" alt="CometVisu" /> by <a href="https://www.cometvisu.org/">CometVisu.org</a>
-          - <a href="manager.php">Config-Manager</a>
+          - <a href="#" onclick="showManager()">Config-Manager</a>
           - <a href=".?forceReload=true">Reload</a>
         ]]></status>
-      <status type="html" condition="!edit" hrefextend="config"><![CDATA[
-          - <a href="editor/">Edit</a>
+      <status type="html" condition="!edit" hrefextend="action"><![CDATA[
+          - <a cv-action="edit">Edit</a>
         ]]></status>
       <status type="html" condition="edit" hrefextend="config"><![CDATA[
           - <a href=".">normal Mode</a>
@@ -22,8 +22,8 @@
       <status type="html"><![CDATA[
           - <a href="?config=demo">Widget Demo</a>
         ]]></status>
-      <status type="html" hrefextend="config"><![CDATA[
-          - <a href="check_config.php">Check Config</a>
+      <status type="html" hrefextend="action"><![CDATA[
+          - <a cv-action="validate">Check Config</a>
         ]]></status>
     </statusbar>
   </meta>

--- a/source/resource/designs/designglobals.css
+++ b/source/resource/designs/designglobals.css
@@ -337,6 +337,7 @@ button.ui-slider-handle {
 
 #notification-center > .badge.normal, #toast-list .toast.normal {
   background-color: rgba(255, 244, 230, 0.9);
+  color: #000000;
 }
 
 #notification-center > .badge.low, #toast-list .toast.low {

--- a/source/resource/manager/worker.js
+++ b/source/resource/manager/worker.js
@@ -33,9 +33,14 @@ function getFileContent (path) {
     var xhr = new XMLHttpRequest();
     xhr.open('GET', path, false); // Note: synchronous
     xhr.send();
-    return xhr.response;
+    if (xhr.status === 200) {
+      return xhr.response;
+    } else {
+      console.error("XHR Error for ", path, xhr.status, xhr.statusText);
+      return null;
+    }
   } catch(e) {
-    console.error("XHR Error " + e.toString());
+    console.error("XHR Error for ", path, e.toString());
     return null;
   }
 }
@@ -157,12 +162,13 @@ function contentChange(data) { // jshint ignore:line
 }
 
 function validateConfig (data) {
-  var content = getFileContent('../../' + data.path);
+  const url = data.path.startsWith('http') ? data.path : '../../' + data.path;
+  const content = getFileContent(url);
   if (content) {
     if (!configSchema) {
       configSchema = getFileContent('../visu_config.xsd');
     }
-    var lint = xmllint.validateXML({
+    const lint = xmllint.validateXML({
       xml: content,
       schema: configSchema
     });


### PR DESCRIPTION
* replace config links for opening manager, editing config file and config file validation
* fix error in text editor not showing errors in readOnly files (e.g. demo configs)
* change toast messages text color with normal severity to black for better readability
* compability layer for existing configs that replaces the old manager links with the new ones