### PR TITLE
Manager improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -380,9 +380,9 @@
       }
     },
     "@qooxdoo/compiler": {
-      "version": "1.0.0-beta.20200515-1215",
-      "resolved": "https://registry.npmjs.org/@qooxdoo/compiler/-/compiler-1.0.0-beta.20200515-1215.tgz",
-      "integrity": "sha512-sj+n/cs0ovkPVqaeQYmkxJEklKSok32a3Glwt0IiFgTRJqHZB0G01gcLUmk1pf1dzJWDbayi+Here9ErIvkq8w==",
+      "version": "1.0.0-beta.20200605-1953",
+      "resolved": "https://registry.npmjs.org/@qooxdoo/compiler/-/compiler-1.0.0-beta.20200605-1953.tgz",
+      "integrity": "sha512-gZj0zE4ifzpN2y4j6KIzqeUG2b9vnjyw9jm/0XCw/m9uH6CaepjTu1DCYJuj8faqgEcIbUTIy+twsKN2Mj/DzQ==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.9.0",
@@ -402,7 +402,7 @@
         "@qooxdoo/eslint-config-jsdoc-disable": "^1.0.3",
         "@qooxdoo/eslint-config-qx": "1.2.1",
         "@qooxdoo/eslint-plugin-qx": "^1.2.7",
-        "@qooxdoo/framework": "^6.0.0-beta",
+        "@qooxdoo/framework": "6.0.0-beta-20200515-0957",
         "ajv": "^6.12.0",
         "app-module-path": "^2.2.0",
         "async": "^2.6.3",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,9 @@
       "email": "tbraeutigam at gmail dot com"
     }
   ],
+  "org_cometvisu": {
+    "libraryVersion": 9
+  },
   "devDependencies": {
     "@babel/polyfill": "^7.8.7",
     "@qooxdoo/compiler": "^1.0.0-beta.20200605-1953",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   ],
   "devDependencies": {
     "@babel/polyfill": "^7.8.7",
-    "@qooxdoo/compiler": "^1.0.0-beta.20200515-1215",
+    "@qooxdoo/compiler": "^1.0.0-beta.20200605-1953",
     "chmodr": "^1.2.0",
     "csso": "^3.5.1",
     "easyimage": "^3.1.1",

--- a/source/class/cv/Application.js
+++ b/source/class/cv/Application.js
@@ -259,14 +259,15 @@ qx.Class.define("cv.Application",
       }, this);
     },
 
-    showConfigErrors: function(configName) {
+    showConfigErrors: function(configName, options) {
       configName = configName ? 'visu_config_'+configName+'.xml' : 'visu_config.xml';
+      const handlerId = options && options.upgradeVersion ? 'cv.ui.manager.editor.Diff' : 'cv.ui.manager.editor.Source';
       this.showManager('openWith', {
         file: configName,
-        handlerId: 'cv.ui.manager.editor.Source',
-        handlerOptions: {
+        handler: handlerId,
+        handlerOptions: Object.assign({
           jumpToError: true
-        }
+        }, options ? options : {})
       });
       // remove any config error messages shown
       cv.core.notifications.Router.dispatchMessage('cv.config.error', {

--- a/source/class/cv/Application.js
+++ b/source/class/cv/Application.js
@@ -312,7 +312,10 @@ qx.Class.define("cv.Application",
                   action: function () {
                     qx.core.Init.getApplication().showManager('openWith', {
                       file: `visu_config${configName}.xml`,
-                      handler: 'cv.ui.manager.editor.Source'
+                      handler: 'cv.ui.manager.editor.Source',
+                      handlerOptions: {
+                        jumpToError: true
+                      }
                     })
                   }
                 }]

--- a/source/class/cv/Config.js
+++ b/source/class/cv/Config.js
@@ -47,11 +47,6 @@ qx.Class.define('cv.Config', {
     currentPageId: null,
 
     /**
-     * Config file version
-     * @type {Number}
-     */
-    libraryVersion: 8,
-    /**
      * @type {Boolean}
      */
     libraryCheck: true,

--- a/source/class/cv/core/notifications/Router.js
+++ b/source/class/cv/core/notifications/Router.js
@@ -112,6 +112,10 @@ qx.Class.define("cv.core.notifications.Router", {
     __dateFormat: null,
     __timeFormat: null,
 
+    getStateMessageConfig: function () {
+      return this.__stateMessageConfig;
+    },
+
     /**
      * Register state update handler for one or more addresses.
      *

--- a/source/class/cv/data/Model.js
+++ b/source/class/cv/data/Model.js
@@ -70,6 +70,10 @@ qx.Class.define('cv.data.Model', {
     __addressList : null,
     __widgetData: null,
 
+    getStateListener: function () {
+      return this.__stateListeners;
+    },
+
     /**
      * Updates the state of a single address
      *

--- a/source/class/cv/io/Mockup.js
+++ b/source/class/cv/io/Mockup.js
@@ -308,6 +308,10 @@ qx.Class.define('cv.io.Mockup', {
 
     getResourcePath: function (name) {
       return name;
+    },
+
+    getLastError: function () {
+      return null;
     }
   }
 });

--- a/source/class/cv/io/Mockup.js
+++ b/source/class/cv/io/Mockup.js
@@ -312,6 +312,10 @@ qx.Class.define('cv.io.Mockup', {
 
     getLastError: function () {
       return null;
+    },
+
+    getBackend: function () {
+      return {};
     }
   }
 });

--- a/source/class/cv/io/rest/Client.js
+++ b/source/class/cv/io/rest/Client.js
@@ -21,7 +21,7 @@ qx.Class.define('cv.io.rest.Client', {
         var path = ""; 
         var engine = cv.TemplateEngine.getInstance();
         var clientBackend = engine.visu ? engine.visu.getBackend() : {};
-        if (clientBackend.resources.rest) {
+        if (clientBackend.resources && clientBackend.resources.rest) {
           path = clientBackend.resources.rest
         } else {
           path = qx.util.Uri.parseUri(window.location.href).directory + 'rest/manager/index.php';

--- a/source/class/cv/parser/WidgetParser.js
+++ b/source/class/cv/parser/WidgetParser.js
@@ -34,6 +34,10 @@ qx.Class.define('cv.parser.WidgetParser', {
     model: cv.data.Model.getInstance(),
     __templates: {},
 
+    getTemplates: function () {
+      return this.__templates;
+    },
+
     addTemplate: function(name, templateData) {
       this.__templates[name] = templateData;
     },

--- a/source/class/cv/theme/dark/Appearance.js
+++ b/source/class/cv/theme/dark/Appearance.js
@@ -76,7 +76,7 @@ qx.Theme.define("cv.theme.dark.Appearance", {
           iconPosition: states.list ? 'left' : 'top',
           show: states.list ? 'label' : 'both',
           font: states.list ? 'default' : 'small',
-          width: states.list ? 500 : 130,
+          width: states.list ? 500 : 160,
           backgroundColor: states.hovered ? 'rgba(255, 255, 255, 0.1)' : 'transparent'
         };
       }
@@ -114,6 +114,7 @@ qx.Theme.define("cv.theme.dark.Appearance", {
     },
     'cv-file-item/action-button': 'cv-file-item/download-button',
     'cv-file-item/open-button': 'cv-file-item/download-button',
+    'cv-file-item/edit-button': 'cv-file-item/download-button',
     'cv-icon': 'cv-file-item',
     'cv-icon/icon': {
       include: 'atom/icon',

--- a/source/class/cv/ui/MHandleMessage.js
+++ b/source/class/cv/ui/MHandleMessage.js
@@ -103,7 +103,11 @@ qx.Mixin.define("cv.ui.MHandleMessage", {
   members: {
     _messages: null,
     _severities: null,
-    __idCounter: 0,
+    _idCounter: 0,
+
+    getIdCounter: function () {
+      return this._idCounter;
+    },
 
     getSeverities: function() {
       return this._severities;
@@ -188,8 +192,8 @@ qx.Mixin.define("cv.ui.MHandleMessage", {
       }
       if (!found) {
         if (cv.core.notifications.Router.evaluateCondition(message)) {
-          message.id = this.__idCounter;
-          this.__idCounter++;
+          message.id = this._idCounter;
+          this._idCounter++;
           message.tooltip = this._getTooltip(message);
           if (!message.hasOwnProperty("deletable")) {
             message.deletable = true;
@@ -277,7 +281,7 @@ qx.Mixin.define("cv.ui.MHandleMessage", {
     clear: function(force) {
       if (force) {
         this._messages.removeAll();
-        this.__idCounter = 0;
+        this._idCounter = 0;
       } else {
         // collect all deletable messages
         var deletable = this._messages.filter(function (message) {

--- a/source/class/cv/ui/PageHandler.js
+++ b/source/class/cv/ui/PageHandler.js
@@ -114,7 +114,6 @@ qx.Class.define('cv.ui.PageHandler', {
         // set it to visible
         pageWidget.setVisible(true);
       }
-      console.log(speed, animationEnabled, animationConfig)
 
       if (!animationEnabled) {
         if (oldPageWidget) {

--- a/source/class/cv/ui/manager/Main.js
+++ b/source/class/cv/ui/manager/Main.js
@@ -287,7 +287,7 @@ qx.Class.define('cv.ui.manager.Main', {
             // this can only by a file in the root dir (a config)
             data.file = this.__findConfigFile(data.file);
           }
-          this.openFile(data.file || this.getCurrentSelection(), false, data.handler);
+          this.openFile(data.file || this.getCurrentSelection(), false, data.handler, null, data.handlerOptions);
           break;
 
         case 'cv.manager.open':
@@ -380,6 +380,9 @@ qx.Class.define('cv.ui.manager.Main', {
         } else {
           editorConfig.instance.setFile(file);
         }
+        if (editorConfig.instance instanceof cv.ui.manager.editor.AbstractEditor) {
+          editorConfig.instance.setHandlerOptions(openFile.getHandlerOptions());
+        }
         this._stack.setSelection([editorConfig.instance]);
         this.__actionDispatcher.setFocusedWidget(editorConfig.instance);
 
@@ -396,7 +399,7 @@ qx.Class.define('cv.ui.manager.Main', {
      * @param handlerId {String} use this handler to open the file (classname as string)
      * @param handlerType {String} use a special handler type, e.g. 'edit' if you want to open the file with an editor and not a viewer
      */
-    openFile: function (file, preview, handlerId, handlerType) {
+    openFile: function (file, preview, handlerId, handlerType, handlerOptions) {
       var openFiles = this.getOpenFiles();
       var openFile;
       if (!handlerId) {
@@ -418,6 +421,11 @@ qx.Class.define('cv.ui.manager.Main', {
       });
       if (!openFile) {
         openFile = new cv.ui.manager.model.OpenFile(file, handlerId);
+      }
+      if (handlerOptions) {
+        openFile.setHandlerOptions(handlerOptions);
+      } else {
+        openFile.resetHandlerOptions();
       }
       if (preview === true) {
         if (!openFile.isPermanent()) {

--- a/source/class/cv/ui/manager/Main.js
+++ b/source/class/cv/ui/manager/Main.js
@@ -380,9 +380,11 @@ qx.Class.define('cv.ui.manager.Main', {
         if (!editorConfig.instance) {
           editorConfig.instance = new editorConfig.Clazz();
           editorConfig.instance.setFile(file);
-          this._stack.add(editorConfig.instance);
         } else {
           editorConfig.instance.setFile(file);
+        }
+        if (this._stack.indexOf(editorConfig.instance) < 0) {
+          this._stack.add(editorConfig.instance);
         }
         if (editorConfig.instance instanceof cv.ui.manager.editor.AbstractEditor) {
           editorConfig.instance.setHandlerOptions(openFile.getHandlerOptions());

--- a/source/class/cv/ui/manager/Start.js
+++ b/source/class/cv/ui/manager/Start.js
@@ -44,6 +44,10 @@ qx.Class.define('cv.ui.manager.Start', {
       check: 'cv.ui.manager.model.FileItem',
       nullable: true,
       apply: '_applySelectedItem'
+    },
+    external: {
+      check: 'Boolean',
+      init: false
     }
   },
 

--- a/source/class/cv/ui/manager/control/FileController.js
+++ b/source/class/cv/ui/manager/control/FileController.js
@@ -264,7 +264,10 @@ qx.Class.define('cv.ui.manager.control.FileController', {
           file.setValid(false);
           qx.event.message.Bus.dispatchByName('cv.manager.openWith', {
             file: file,
-            handler: 'cv.ui.manager.editor.Source'
+            handler: 'cv.ui.manager.editor.Source',
+            handlerOptions: {
+              jumpToError: true
+            }
           });
           cv.ui.manager.snackbar.Controller.error(qx.locale.Manager.trn(
             '%1 error found in %2!',

--- a/source/class/cv/ui/manager/editor/AbstractEditor.js
+++ b/source/class/cv/ui/manager/editor/AbstractEditor.js
@@ -35,6 +35,11 @@ qx.Class.define('cv.ui.manager.editor.AbstractEditor', {
       nullable: true,
       event: 'changeContent',
       apply: '_applyContent'
+    },
+
+    handlerOptions: {
+      check: 'Map',
+      nullable: true
     }
   },
 

--- a/source/class/cv/ui/manager/editor/AbstractEditor.js
+++ b/source/class/cv/ui/manager/editor/AbstractEditor.js
@@ -40,6 +40,14 @@ qx.Class.define('cv.ui.manager.editor.AbstractEditor', {
     handlerOptions: {
       check: 'Map',
       nullable: true
+    },
+
+    /**
+     * External viewers just open the file in a new frame but to not show a new tab in the manager for the opened file
+     */
+    external: {
+      check: 'Boolean',
+      init: false
     }
   },
 

--- a/source/class/cv/ui/manager/editor/Diff.js
+++ b/source/class/cv/ui/manager/editor/Diff.js
@@ -141,10 +141,13 @@ qx.Class.define('cv.ui.manager.editor.Diff', {
                 qx.event.message.Bus.dispatchByName('cv.manager.action.close');
               } else {
                 this.setModifiedContent(this._convertToString(upgradedContent));
-                let msg = '<h3>' + qx.locale.Manager.tr('Config file has been upgraded to the current library version.').translate().toString() + '</h3>' +
+                let changesText = changes.length > 0 ?
                   '<div>' + qx.locale.Manager.tr('The following changes have been made') + '</div>' +
                   '<ul><li>'+changes.join('</li><li>')+ '</li></ul>' +
-                  '<div>' + qx.locale.Manager.tr('You can check the changes in the editor. The left side shows the content before the upgrade and the right side shows the content after the upgrade.') + '</div>' +
+                  '<div>' + qx.locale.Manager.tr('You can check the changes in the editor. The left side shows the content before the upgrade and the right side shows the content after the upgrade.') + '</div>' :
+                  '<div><strong>' + qx.locale.Manager.tr('No changes have been made') + '</strong></div>';
+
+                let msg = '<h3>' + qx.locale.Manager.tr('Config file has been upgraded to the current library version.').translate().toString() + '</h3>' + changesText +
                   '<div>' + qx.locale.Manager.tr('Click "Apply" if you want to save the changes and reload the browser.') + '</div>' +
                   '<div>' + qx.locale.Manager.tr('Click "Check" if you want to check the changes. You have to save the changes and reload your browser yourself in this case.') + '</div>';
                 const d = dialog.Dialog.confirm(msg, function (ok) {
@@ -156,10 +159,10 @@ qx.Class.define('cv.ui.manager.editor.Diff', {
                 }, this, qx.locale.Manager.tr('Upgrade successful'));
                 d.set({
                   width: Math.min(qx.bom.Viewport.getWidth(), 600),
-                  yesLabel: qx.locale.Manager.tr('Apply'),
-                  noLabel: qx.locale.Manager.tr('Check')
+                  yesButtonLabel: qx.locale.Manager.tr('Apply'),
+                  noButtonLabel: qx.locale.Manager.tr('Check')
                 });
-                file.setModified(changes.length > 0);
+                file.setModified(true);
               }
             }
           }, this);

--- a/source/class/cv/ui/manager/editor/IEditor.js
+++ b/source/class/cv/ui/manager/editor/IEditor.js
@@ -12,6 +12,14 @@ qx.Interface.define('cv.ui.manager.editor.IEditor', {
       check: 'cv.ui.manager.model.FileItem',
       nullable: true,
       apply: '_loadFile'
+    },
+
+    /**
+     * External viewers just open the file in a new frame but to not show a new tab in the manager for the opened file
+     */
+    external: {
+      check: 'Boolean',
+      init: false
     }
   },
 

--- a/source/class/cv/ui/manager/editor/Source.js
+++ b/source/class/cv/ui/manager/editor/Source.js
@@ -321,7 +321,7 @@ qx.Class.define('cv.ui.manager.editor.Source', {
     },
 
     _processHandlerOptions: function (content) {
-      var handlerOptions = this.getHandlerOptions();
+      var handlerOptions = this.getHandlerOptions() || {};
       if (handlerOptions.hasOwnProperty('upgradeVersion') && handlerOptions.upgradeVersion === true && content) {
         const [err, res] = this._upgradeConfig(content);
         if (err) {

--- a/source/class/cv/ui/manager/editor/Source.js
+++ b/source/class/cv/ui/manager/editor/Source.js
@@ -317,6 +317,28 @@ qx.Class.define('cv.ui.manager.editor.Source', {
         this._editor.setValue(value);
       }
       this._editor.updateOptions({ readOnly: !file.isWriteable() });
+      this._processHandlerOptions(value);
+    },
+
+    _processHandlerOptions: function (content) {
+      var handlerOptions = this.getHandlerOptions();
+      if (handlerOptions.hasOwnProperty('upgradeVersion') && handlerOptions.upgradeVersion === true && content) {
+        const [err, res] = this._upgradeConfig(content);
+        if (err) {
+          this.error(err);
+        } else {
+          this._editor.setValue(this._convertToString(res));
+        }
+      }
+    },
+
+    _convertToString: function (xml) {
+      return '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n' + xml.documentElement.outerHTML;
+    },
+
+    _upgradeConfig: function (content) {
+      const upgrader = new cv.util.ConfigUpgrader();
+      return upgrader.upgrade(content);
     },
 
     getCurrentContent: function () {

--- a/source/class/cv/ui/manager/form/FileListItem.js
+++ b/source/class/cv/ui/manager/form/FileListItem.js
@@ -306,24 +306,29 @@ qx.Class.define('cv.ui.manager.form.FileListItem', {
         var editorConf = cv.ui.manager.control.FileHandlerRegistry.getInstance().getFileHandler(file, 'edit');
         var viewerConf = cv.ui.manager.control.FileHandlerRegistry.getInstance().getFileHandler(file, 'view');
         var openButton = this.getChildControl('open-button');
+        var editButton = this.getChildControl('edit-button');
         if (file.isWriteable() && editorConf) {
-          openButton.setUserData('handlerId', editorConf.Clazz.classname);
-          openButton.set({
+          editButton.setUserData('handlerId', editorConf.Clazz.classname);
+          editButton.set({
             icon: editorConf.Clazz.ICON || cv.theme.dark.Images.getIcon('edit', 18),
             enabled: true,
-            toolTipText: editorConf.Clazz.TITLE
+            toolTipText: editorConf.Clazz.TITLE ? editorConf.Clazz.TITLE.translate().toString() : ""
           });
-        } else if(viewerConf) {
+          editButton.show();
+        } else {
+          editButton.exclude();
+        }
+        if(viewerConf) {
           openButton.setUserData('handlerId', viewerConf.Clazz.classname);
           openButton.set({
             icon: viewerConf.Clazz.ICON || cv.theme.dark.Images.getIcon('preview', 18),
             enabled: true,
-            toolTipText: viewerConf.Clazz.TITLE
+            toolTipText: viewerConf.Clazz.TITLE ? viewerConf.Clazz.TITLE.translate().toString() : ""
           });
+          openButton.show();
         } else {
-          openButton.setEnabled(false);
+          openButton.exclude();
         }
-        this.getChildControl('open-button');
         this.getChildControl('action-button');
         this.getChildControl('bottom-bar').show();
       } else {
@@ -416,6 +421,17 @@ qx.Class.define('cv.ui.manager.form.FileListItem', {
           break;
 
         case 'open-button':
+          control = new qx.ui.form.Button(null, cv.theme.dark.Images.getIcon('preview', 18));
+          control.addListener('execute', function () {
+            qx.event.message.Bus.dispatchByName('cv.manager.openWith', {
+              file: this.getModel(),
+              handler: control.getUserData('handlerId')
+            });
+          }, this);
+          this.getChildControl('bottom-bar').add(control);
+          break;
+
+        case 'edit-button':
           control = new qx.ui.form.Button(null, cv.theme.dark.Images.getIcon('preview', 18));
           control.addListener('execute', function () {
             qx.event.message.Bus.dispatchByName('cv.manager.openWith', {

--- a/source/class/cv/ui/manager/model/OpenFile.js
+++ b/source/class/cv/ui/manager/model/OpenFile.js
@@ -38,6 +38,11 @@ qx.Class.define('cv.ui.manager.model.OpenFile', {
       apply: '_maintainIcon'
     },
 
+    handlerOptions: {
+      check: 'Map',
+      nullable: true
+    },
+
     /**
      * The opening state: permanent false behaves like a quick preview, where
      * the current file content is replaces by the next selected file on single click.

--- a/source/class/cv/ui/manager/viewer/AbstractViewer.js
+++ b/source/class/cv/ui/manager/viewer/AbstractViewer.js
@@ -30,6 +30,14 @@ qx.Class.define('cv.ui.manager.viewer.AbstractViewer', {
       nullable: true,
       apply: '_applyFile',
       event: 'changeFile'
+    },
+
+    /**
+     * External viewers just open the file in a new frame but to not show a new tab in the manager for the opened file
+     */
+    external: {
+      check: 'Boolean',
+      init: false
     }
   },
 

--- a/source/class/cv/ui/manager/viewer/Config.js
+++ b/source/class/cv/ui/manager/viewer/Config.js
@@ -24,6 +24,22 @@ qx.Class.define('cv.ui.manager.viewer.Config', {
     appearance: {
       refine: true,
       init: 'config-viewer'
+    },
+
+    target: {
+      check: ['iframe', 'window'],
+      init: 'window'
+    },
+
+    external: {
+      refine: true,
+      init: true
+    },
+
+    connectToWindow: {
+      check: 'Boolean',
+      init: false,
+      apply: '_applyConnectToWindow'
     }
   },
 
@@ -44,31 +60,78 @@ qx.Class.define('cv.ui.manager.viewer.Config', {
   ***********************************************
   */
   members: {
+    _windowRef: null,
+
+    _applyConnectToWindow: function (value) {
+      this.setExternal(!value);
+    },
 
     _applyFile: function (file, old) {
-      var control = this.getChildControl('iframe');
       if (old && old.isConfigFile()) {
         qx.event.message.Bus.unsubscribe(old.getBusTopic(), this._onChange, this);
       }
       if (file) {
         if (file.isConfigFile()) {
           var configName = cv.ui.manager.model.FileItem.getConfigName(file.getFullPath());
-          var url = qx.util.Uri.getAbsolute(qx.util.LibraryManager.getInstance().get('cv', 'resourceUri')+ '/..') + '?config=' + (configName || '') + '&preview=1';
-          control.setSource(url);
-          control.show();
+          var url = qx.util.Uri.getAbsolute(qx.util.LibraryManager.getInstance().get('cv', 'resourceUri')+ '/..') + '?config=' + (configName || '');
+          if (this.getTarget() === 'iframe') {
+            url += '&preview=1';
+            var control = this.getChildControl('iframe');
+            control.setSource(url);
+            control.show();
+            const hint = this.getChildControl('hint', true);
+            if (hint && hint.isVisible()) {
+              hint.exclude();
+            }
+          } else {
+            let ref = window.open(url, configName);
+            if (this.isConnectToWindow()) {
+              this._windowRef = ref;
+              this._windowRef.onbeforeunload = this._onClose.bind(this);
+              const hint = this.getChildControl('hint');
+              hint.show();
+              const iframe = this.getChildControl('iframe', true);
+              if (iframe && iframe.isVisible()) {
+                iframe.exclude();
+              }
+            } else {
+              // no connection close this immediately
+              this._onClose();
+              return;
+            }
+          }
           qx.event.message.Bus.subscribe(file.getBusTopic(), this._onChange, this);
         } else {
           cv.ui.manager.snackbar.Controller.error(this.tr('%1 is no configuration file', file.getFullPath()));
         }
       } else {
-        control.exclude();
+        if (this.hasChildControl('iframe')) {
+          this.getChildControl('iframe').exclude();
+        }
+        if (this.hasChildControl('hint')) {
+          this.getChildControl('hint').exclude();
+        }
+        if (this._windowRef) {
+          this._windowRef.close();
+        }
       }
     },
 
     _onChange: function (ev) {
       var data = ev.getData();
       if (data.type === 'contentChanged') {
-        this.getChildControl('iframe').reload();
+        if (this.hasChildControl('iframe')) {
+          this.getChildControl('iframe').reload();
+        } else if (this._windowRef) {
+          this._windowRef.reload();
+        }
+      }
+    },
+
+    _onClose: function () {
+      if (this._windowRef) {
+        console.log(this, 'close', this.getFile().getFullPath());
+        qx.event.message.Bus.dispatchByName('cv.manager.action.close', this.getFile());
       }
     },
 
@@ -82,9 +145,32 @@ qx.Class.define('cv.ui.manager.viewer.Config', {
            control.exclude();
            this.getChildControl('scroll').add(control);
            break;
+
+         case 'hint':
+           control = new qx.ui.basic.Atom(this.tr('This configuration has been opened in another window. When you close this file, the window will also be closed. Click here top jump the the window.'));
+           control.set({
+             center: true,
+             font: 'title'
+           });
+           control.addListener('tap', function () {
+             if (this._windowRef) {
+               this._windowRef.focus();
+             }
+           }, this);
+           this.getChildControl('scroll').add(control);
+           break;
        }
 
        return control || this.base(arguments, id);
     }
+  },
+
+  /*
+  ***********************************************
+    DESTRUCTOR
+  ***********************************************
+  */
+  destruct: function () {
+    this._windowRef = null;
   }
 });

--- a/source/class/cv/ui/structure/pure/UrlTrigger.js
+++ b/source/class/cv/ui/structure/pure/UrlTrigger.js
@@ -51,6 +51,10 @@ qx.Class.define('cv.ui.structure.pure.UrlTrigger', {
   members: {
     __xhr: null,
 
+    getXhr: function () {
+      return this.__xhr;
+    },
+
     // property apply
     _applyUrl: function(value) {
       if (value) {

--- a/source/class/cv/ui/structure/pure/WgPluginInfo.js
+++ b/source/class/cv/ui/structure/pure/WgPluginInfo.js
@@ -67,6 +67,10 @@ qx.Class.define('cv.ui.structure.pure.WgPluginInfo', {
       }
     },
 
+    getRequest: function () {
+      return this.__request;
+    },
+
     /**
      * Handle successful requests from {@link qx.io.request.Xhr}
      * @param ev {Event}

--- a/source/class/cv/util/ConfigLoader.js
+++ b/source/class/cv/util/ConfigLoader.js
@@ -173,7 +173,7 @@ qx.Class.define('cv.util.ConfigLoader', {
       var message = '';
       switch (textStatus) {
         case 'parsererror':
-          message = qx.locale.Manager.tr("Invalid config file!")+'<br/><a href="check_config.php?config=' + configSuffix + '">'+qx.locale.Manager.tr("Please check!")+'</a>';
+          message = qx.locale.Manager.tr("Invalid config file!")+'<br/><a href="#" onclick="showConfigErrors(\'' + configSuffix + '\')">'+qx.locale.Manager.tr("Please check!")+'</a>';
           break;
         case 'libraryerror':
           var link = window.location.href;

--- a/source/class/cv/util/ConfigLoader.js
+++ b/source/class/cv/util/ConfigLoader.js
@@ -74,8 +74,10 @@ qx.Class.define('cv.util.ConfigLoader', {
           var xmlLibVersion = xml.querySelector('pages').getAttribute("lib_version");
           if (xmlLibVersion === undefined) {
             xmlLibVersion = -1;
+          } else {
+            xmlLibVersion = parseInt(xmlLibVersion);
           }
-          if (cv.Config.libraryCheck && xmlLibVersion < cv.Config.libraryVersion) {
+          if (cv.Config.libraryCheck && xmlLibVersion < cv.Version.LIBRARY_VERSION) {
             this.configError("libraryerror");
           }
           else {
@@ -183,7 +185,7 @@ qx.Class.define('cv.util.ConfigLoader', {
           link = link + '&libraryCheck=false';
           message = qx.locale.Manager.tr('Config file has wrong library version!').translate().toString()+'<br/>' +
             qx.locale.Manager.tr('This can cause problems with your configuration').translate().toString()+'</br>' +
-            '<p>'+qx.locale.Manager.tr("You can run the %1Configuration Upgrader%2.", '<a href="./upgrade/index.php?config=' + configSuffix + '">', '</a>').translate().toString() +'</br>' +
+            '<p>'+qx.locale.Manager.tr("You can run the %1Configuration Upgrader%2.", '<a href="#" onclick="showConfigErrors(\'' + configSuffix + '\', {upgradeVersion: true})">', '</a>').translate().toString() +'</br>' +
             qx.locale.Manager.tr('Or you can start without upgrading %1with possible configuration problems%2', '<a href="' + link + '">', '</a>').translate().toString()+'</p>';
           break;
         case 'filenotfound':

--- a/source/class/cv/util/ConfigLoader.js
+++ b/source/class/cv/util/ConfigLoader.js
@@ -178,7 +178,7 @@ qx.Class.define('cv.util.ConfigLoader', {
           message = qx.locale.Manager.tr("Invalid config file!")+'<br/><a href="#" onclick="showConfigErrors(\'' + configSuffix + '\')">'+qx.locale.Manager.tr("Please check!")+'</a>';
           break;
         case 'libraryerror':
-          var link = window.location.href;
+          var link = window.location.href.split('#')[0];
           if (link.indexOf('?') <= 0) {
             link = link + '?';
           }

--- a/source/class/cv/util/ConfigUpgrader.js
+++ b/source/class/cv/util/ConfigUpgrader.js
@@ -76,7 +76,9 @@ qx.Class.define('cv.util.ConfigUpgrader', {
         c++;
       });
       this.__setVersion(source, 8);
-      this.__log.push('removed ' + c + ' \'plugin\'-nodes with obsolete plugin (gweather)');
+      if (c > 0) {
+        this.__log.push('removed ' + c + ' \'plugin\'-nodes with obsolete plugin (gweather)');
+      }
       return 8;
     },
 
@@ -122,7 +124,9 @@ qx.Class.define('cv.util.ConfigUpgrader', {
         }
       });
       this.__setVersion(source, 9);
-      this.__log.push('converted ' + c + ' \'multitrigger\'-nodes to new button configuration');
+      if (c > 0) {
+        this.__log.push('converted ' + c + ' \'multitrigger\'-nodes to new button configuration');
+      }
       return 9;
     },
 

--- a/source/class/cv/util/ConfigUpgrader.js
+++ b/source/class/cv/util/ConfigUpgrader.js
@@ -1,0 +1,143 @@
+/* ConfigUpgrader.js
+ *
+ * copyright (c) 2010-2020, Christian Mayer and the CometVisu contributers.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+ */
+
+/**
+ * Upgrade config file to the current library version
+ * @since 0.12.0
+ * @author Tobias Bräutigam
+ */
+qx.Class.define('cv.util.ConfigUpgrader', {
+  extend: qx.core.Object,
+
+  /*
+  ***********************************************
+    MEMBERS
+  ***********************************************
+  */
+  members: {
+    __indentation: 2,
+    __log: null,
+
+    /**
+     * Upgrade config source
+     * @param source {String|Document} content of a config file
+     */
+    upgrade (source) {
+      this.__log = [];
+      if (typeof source === 'string') {
+        source = qx.xml.Document.fromString(source);
+      }
+      // read version from config
+      const pagesNode = source.querySelector('pages');
+      let version = parseInt(pagesNode.getAttribute('lib_version'));
+      if (version === cv.Version.LIBRARY_VERSION) {
+        // nothing to do
+        return [null, source, this.__log];
+      } else {
+        while (version < cv.Version.LIBRARY_VERSION) {
+          // upgrade step by step
+          const method = this['from' + version + 'to' + (version + 1)];
+          if (method) {
+            version = method.call(this, source);
+          } else {
+            return [qx.locale.Manager.tr('Upgrader from version %1 not implemented', version), source, this.__log]
+          }
+        }
+        this.info('  - ' + this.__log.join('\n  - '));
+        return [null, source, this.__log];
+      }
+    },
+
+    from7to8 (source) {
+      let c = 0;
+      source.querySelectorAll('plugins > plugin[name=\'gweather\']').forEach(node => {
+        const parent = node.parentNode;
+        const indentNode = node.previousSibling;
+        parent.removeChild(node);
+        if (indentNode.nodeType === 3) {
+          parent.removeChild(indentNode);
+        }
+        c++;
+      });
+      this.__setVersion(source, 8);
+      this.__log.push('removed ' + c + ' \'plugin\'-nodes with obsolete plugin (gweather)');
+      return 8;
+    },
+
+    from8to9 (source) {
+      let c = 0;
+      const singleIndent = ''.padEnd(this.__indentation, ' ');
+      source.querySelectorAll('multitrigger').forEach(node => {
+        let level = this.__getLevel(node);
+        level++;
+        const indent = ''.padEnd(this.__indentation * level, ' ');
+        const buttonConf = {};
+        const attributesToDelete = [];
+        const nameRegex = /^button([\d]+)(label|value)$/
+        for (let i = 0, l = node.attributes.length; i < l; i++) {
+          const match = nameRegex.exec(node.attributes[i].name);
+          if (match) {
+            if (!buttonConf.hasOwnProperty(match[1])) {
+              buttonConf[match[1]] = {};
+            }
+            buttonConf[match[1]][match[2]] = node.attributes[i].value;
+            attributesToDelete.push(node.attributes[i]);
+          }
+        }
+        attributesToDelete.forEach(attr => node.removeAttributeNode(attr));
+        const buttonIds = Object.keys(buttonConf).sort();
+        if (buttonIds.length > 0) {
+          const buttons = source.createElement('buttons');
+          buttonIds.forEach(bid => {
+            const button = source.createElement('button');
+            button.textContent = buttonConf[bid].value;
+            if (buttonConf[bid].label) {
+              button.setAttribute('label', buttonConf[bid].label);
+            }
+            const ind = source.createTextNode("\n" + indent + singleIndent);
+            buttons.appendChild(ind);
+            buttons.appendChild(button);
+          });
+          buttons.appendChild(source.createTextNode("\n" + indent));
+          node.appendChild(source.createTextNode(singleIndent));
+          node.appendChild(buttons);
+          node.appendChild(source.createTextNode("\n" + ''.padEnd(this.__indentation * (level - 1), ' ')));
+          c++;
+        }
+      });
+      this.__setVersion(source, 9);
+      this.__log.push('converted ' + c + ' \'multitrigger\'-nodes to new button configuration');
+      return 9;
+    },
+
+    __getLevel (node) {
+      let level = 1;
+      let parent = node.parentNode;
+      while (parent && parent.nodeName !== 'pages') {
+        parent = parent.parentNode;
+        level++;
+      }
+      return level;
+    },
+
+    __setVersion (xml, version) {
+      xml.querySelector('pages').getAttributeNode('lib_version').value = version;
+    }
+  }
+});

--- a/source/library_version.inc.php
+++ b/source/library_version.inc.php
@@ -27,8 +27,12 @@
  * @since       2013-02-05
  */
 /**
- * the current lib version
+ * the current lib version, read from package.json for backwards compability
  * @const   integer
  */
-define('LIBRARY_VERSION', 9);
-?>
+$packageJsonFile = dirname(__FILE__) . '/package.json';
+if (!file_exists($packageJsonFile)) {
+  $packageJsonFile = dirname(dirname(__FILE__)) . '/package.json';
+}
+$packageJson = json_decode(file_get_contents($packageJsonFile), true);
+define('LIBRARY_VERSION', $packageJson['org_cometvisu']['libraryVersion']);

--- a/source/resource/config/visu_config.xml
+++ b/source/resource/config/visu_config.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<pages xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" lib_version="8" design="pure" xsi:noNamespaceSchemaLocation="../visu_config.xsd">
+<pages xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" lib_version="9" design="pure" xsi:noNamespaceSchemaLocation="../visu_config.xsd">
   <meta>
     <plugins>
     </plugins>

--- a/source/resource/demo/visu_config_2d3d.xml
+++ b/source/resource/demo/visu_config_2d3d.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<pages xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" lib_version="8" design="pure" xsi:noNamespaceSchemaLocation="../visu_config.xsd">
+<pages xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" lib_version="9" design="pure" xsi:noNamespaceSchemaLocation="../visu_config.xsd">
   <meta>
     <plugins>
       <plugin name="colorchooser"/>

--- a/source/resource/demo/visu_config_demo_flat.xml
+++ b/source/resource/demo/visu_config_demo_flat.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<pages xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" lib_version="8" design="metal" scroll_speed="0" xsi:noNamespaceSchemaLocation="../visu_config.xsd">
+<pages xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" lib_version="9" design="metal" scroll_speed="0" xsi:noNamespaceSchemaLocation="../visu_config.xsd">
   <meta>
     <plugins>
       <plugin name="colorchooser"/>

--- a/source/resource/demo/visu_config_demorss.xml
+++ b/source/resource/demo/visu_config_demorss.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<pages xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" lib_version="8" design="pure" xsi:noNamespaceSchemaLocation="../visu_config.xsd">
+<pages xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" lib_version="9" design="pure" xsi:noNamespaceSchemaLocation="../visu_config.xsd">
   <meta>
     <plugins>
       <plugin name="rss"/>

--- a/source/resource/demo/visu_config_empty.xml
+++ b/source/resource/demo/visu_config_empty.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<pages xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" lib_version="8" design="pure" xsi:noNamespaceSchemaLocation="../visu_config.xsd">
+<pages xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" lib_version="9" design="pure" xsi:noNamespaceSchemaLocation="../visu_config.xsd">
   <meta>
     <plugins>
     </plugins>

--- a/source/resource/demo/visu_config_gauge.xml
+++ b/source/resource/demo/visu_config_gauge.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<pages lib_version="8" design="metal" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../visu_config.xsd">
+<pages lib_version="9" design="metal" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../visu_config.xsd">
   <meta>
     <plugins>
       <plugin name="gauge"/>

--- a/source/resource/demo/visu_config_responsive.xml
+++ b/source/resource/demo/visu_config_responsive.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<pages xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" lib_version="8" design="metal" xsi:noNamespaceSchemaLocation="../visu_config.xsd" min_column_width="70">
+<pages xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" lib_version="9" design="metal" xsi:noNamespaceSchemaLocation="../visu_config.xsd" min_column_width="70">
   <meta>
     <plugins>
     </plugins>

--- a/source/test/karma/ui/ToastManager-spec.js
+++ b/source/test/karma/ui/ToastManager-spec.js
@@ -36,7 +36,7 @@ describe('test the NotificationCenter', function () {
     message.severity = "high";
     message.unique = true;
 
-    var messageId = center.__idCounter-1;
+    var messageId = center.getIdCounter()-1;
     center.handleMessage(Object.assign({}, message));
     // as the message was unique it replaces the old one
     expect(center.getMessages().getLength()).toBe(1);
@@ -48,7 +48,7 @@ describe('test the NotificationCenter', function () {
     message.severity = "urgent";
     message.unique = false;
 
-    messageId = center.__idCounter;
+    messageId = center.getIdCounter();
     center.handleMessage(Object.assign({}, message));
     // as the message was unique it replaces the old one
     expect(center.getMessages().getLength()).toBe(2);
@@ -182,7 +182,7 @@ describe('test the NotificationCenter', function () {
         severity: "normal",
         target: "toast"
       };
-      var messageId = center.__idCounter;
+      var messageId = center.getIdCounter();
       center.handleMessage(message);
 
       var element = document.querySelector("#"+center.getMessageElementId()+messageId);

--- a/source/test/karma/ui/structure/pure/Urltrigger-spec.js
+++ b/source/test/karma/ui/structure/pure/Urltrigger-spec.js
@@ -36,11 +36,11 @@ describe("testing a urltrigger widget", function() {
 
   it("should test the urltrigger action", function() {
     var res = this.createTestElement("urltrigger", {url: "/test/test.txt", align: "center"});
-    spyOn(res.__xhr, "send");
+    spyOn(res.getXhr(), "send");
     expect(res.getActor()).toHaveClass("center");
     this.initWidget(res);
 
     res._action();
-    expect(res.__xhr.send).toHaveBeenCalled();
+    expect(res.getXhr().send).toHaveBeenCalled();
   });
 });

--- a/source/test/karma/ui/structure/pure/Wgplugininfo-spec.js
+++ b/source/test/karma/ui/structure/pure/Wgplugininfo-spec.js
@@ -36,7 +36,7 @@ describe("testing a wgplugin_info widget", function() {
 
   it("should test the wgplugin_info update", function() {
     var res = this.createTestElement("wgplugin_info", {variable: "Test"}, '', "Test", {transform: "raw"});
-    spyOn(res.__request, "send");
+    spyOn(res.getRequest(), "send");
     res.update("Test", 1);
 
   });

--- a/source/test/karma/xml/parser/Meta-spec.js
+++ b/source/test/karma/xml/parser/Meta-spec.js
@@ -111,7 +111,7 @@ describe("testing the meta parser", function() {
 
       // test notifications
       var router = cv.core.notifications.Router.getInstance();
-      var config = router.__stateMessageConfig;
+      var config = router.getStateMessageConfig();
 
       expect(config.hasOwnProperty("Motion_FF_Dining")).toBeTruthy();
       expect(config.hasOwnProperty("Motion_FF_Corridor")).toBeTruthy();
@@ -120,13 +120,13 @@ describe("testing the meta parser", function() {
       // state listeners must be set
       var model = cv.data.Model.getInstance();
       ["Motion_FF_Dining", "Motion_FF_Corridor", "Motion_FF_Kitchen"].forEach(function(address) {
-        expect(model.__stateListeners.hasOwnProperty(address)).toBeTruthy();
-        expect(model.__stateListeners[address].length).toEqual(1);
+        expect(model.getStateListener().hasOwnProperty(address)).toBeTruthy();
+        expect(model.getStateListener()[address].length).toEqual(1);
       });
 
       // template
-      expect(cv.parser.WidgetParser.__templates.hasOwnProperty('test')).toBeTruthy();
-      expect(cv.parser.WidgetParser.__templates.test.trim()).toEqual('<root><text><label>Test template</label></text></root>');
+      expect(cv.parser.WidgetParser.getTemplates().hasOwnProperty('test')).toBeTruthy();
+      expect(cv.parser.WidgetParser.getTemplates().test.trim()).toEqual('<root><text><label>Test template</label></text></root>');
 
       footer.parentNode.removeChild(footer);
     });

--- a/source/test/protractor/specs/metal-spec.js
+++ b/source/test/protractor/specs/metal-spec.js
@@ -16,7 +16,7 @@ describe('cometvisu metal design config test:', function () {
 
   var mockupConfig = [];
   var configParts = {
-    start : '<pages xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" lib_version="8" design="metal" xsi:noNamespaceSchemaLocation="../visu_config.xsd">',
+    start : '<pages xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" lib_version="9" design="metal" xsi:noNamespaceSchemaLocation="../visu_config.xsd">',
     end :   '</pages>'
   };
 

--- a/source/test/protractor/specs/widgets/Navbar-spec.js
+++ b/source/test/protractor/specs/widgets/Navbar-spec.js
@@ -12,7 +12,7 @@ describe('navbar widget testing', function () {
   'use strict';
   var mockupConfig = [];
   var configParts = {
-    start : '<pages xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" lib_version="8" design="metal" xsi:noNamespaceSchemaLocation="../visu_config.xsd">',
+    start : '<pages xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" lib_version="9" design="metal" xsi:noNamespaceSchemaLocation="../visu_config.xsd">',
     end :   '</pages>'
   };
 

--- a/source/test/protractor/specs/widgets/Switch-spec.js
+++ b/source/test/protractor/specs/widgets/Switch-spec.js
@@ -12,7 +12,7 @@ describe('switch widget testing', function () {
   'use strict';
   var mockupConfig = [];
   var configParts = {
-    start : '<pages xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" lib_version="8" design="metal" xsi:noNamespaceSchemaLocation="../visu_config.xsd">',
+    start : '<pages xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" lib_version="9" design="metal" xsi:noNamespaceSchemaLocation="../visu_config.xsd">',
     end :   '</pages>'
   };
 

--- a/source/translation/de.po
+++ b/source/translation/de.po
@@ -1,782 +1,741 @@
-#
+#. NO LONGER USED
 msgid ""
-msgstr ""
-"Project-Id-Version: 1.0\n"
-"Report-Msgid-Bugs-To: you@your.org\n"
-"POT-Creation-Date: 2017-04-26 18:57+0100\n"
-"PO-Revision-Date: 2019-04-15 18:49+0200\n"
-"Last-Translator: you <you@your.org>\n"
-"Language-Team: Team <yourteam@your.org>\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Language: de\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 2.2.1\n"
+msgstr "Project-Id-Version: 1.0\nReport-Msgid-Bugs-To: you@your.org\nPOT-Creation-Date: 2017-04-26 18:57+0100\nPO-Revision-Date: 2019-04-15 18:49+0200\nLast-Translator: you <you@your.org>\nLanguage-Team: Team <yourteam@your.org>\nMIME-Version: 1.0\nContent-Type: text/plain; charset=utf-8\nContent-Transfer-Encoding: 8bit\nLanguage: de\nPlural-Forms: nplurals=2; plural=(n != 1);\nX-Generator: Poedit 2.2.1\n"
 
-#: cv/Application.js:230
+#: cv/Application.js
 msgid "Please describe what you have done until the error occured?"
-msgstr ""
-"Bitte beschreiben, was Sie gemacht haben bis der Fehler aufgetreten ist."
+msgstr "Bitte beschreiben, was Sie gemacht haben bis der Fehler aufgetreten ist."
 
-#: cv/Application.js:297
+#: cv/Application.js
 msgid "An error occured"
 msgstr "Ein Fehler ist aufgetreten"
 
-#: cv/Application.js:303
+#: cv/Application.js
 msgid "Enable on reload:"
 msgstr "Aktivieren beim neu Laden:"
 
-#: cv/ui/Popup.js:271 cv/ui/manager/ToolBar.js:185 cv/Application.js:308
+#: cv/ui/Popup.js
 msgid "Reload"
 msgstr "Neu laden"
 
-#: cv/Application.js:340
+#: cv/Application.js
 msgid "Please do not forget to attach the downloaded Logfile to this ticket."
-msgstr ""
-"Bitte vergessen Sie nicht, die heruntergeladenen Log-Datei an dieses Ticket "
-"zu hängen."
+msgstr "Bitte vergessen Sie nicht, die heruntergeladenen Log-Datei an dieses Ticket zu hängen."
 
-#: cv/Application.js:347
+#: cv/Application.js
 msgid "Action recording"
 msgstr "Benutzerinteraktionen aufzeichnen"
 
-#: cv/Application.js:358
+#. NO LONGER USED
 msgid "Send error to sentry.io"
 msgstr "Fehlerbericht an sentry.io schicken"
 
-#: cv/Application.js:372
+#. NO LONGER USED
 msgid "Error reporting (on sentry.io)"
 msgstr "Absturzberichte senden (an sentry.io)"
 
-#: cv/TemplateEngine.js:264
+#: cv/TemplateEngine.js
 msgid "Connection error"
 msgstr "Verbindungsfehler"
 
-#: cv/TemplateEngine.js:273
+#: cv/TemplateEngine.js
 msgid "Error requesting %1: %2 - %3."
 msgstr "Fehler beim Laden von %1: %2 - %3."
 
-#: cv/TemplateEngine.js:275
+#: cv/TemplateEngine.js
 msgid "Connection to backend is lost."
 msgstr "Verbindung zum Backend verloren."
 
-#: cv/TemplateEngine.js:290 cv/TemplateEngine.js:305
+#: cv/TemplateEngine.js
 msgid "CometVisu protocol error"
 msgstr "CometVisu Protokollfehler"
 
-#: cv/TemplateEngine.js:291
-msgid ""
-"The backend did send an invalid response to the %1Login%2 request: missing "
-"protocol version."
-msgstr ""
-"Das Backend hat eine ungültige Antwort auf die %1Login%2-Anfrage geschickt: "
-"Fehlende Protokollversion."
+#: cv/TemplateEngine.js
+msgid "The backend did send an invalid response to the %1Login%2 request: missing protocol version."
+msgstr "Das Backend hat eine ungültige Antwort auf die %1Login%2-Anfrage geschickt: Fehlende Protokollversion."
 
-#: cv/TemplateEngine.js:294 cv/TemplateEngine.js:309
+#: cv/TemplateEngine.js
 msgid "Please try to fix the problem in the backend."
 msgstr "Bitte versuchen Sie das Problem im Backend zu lösen."
 
-#: cv/TemplateEngine.js:295 cv/TemplateEngine.js:310
+#: cv/TemplateEngine.js
 msgid "Backend-Response:"
 msgstr "Antwort des Backends:"
 
-#: cv/TemplateEngine.js:306
-msgid ""
-"The backend did send an invalid response to a %1read%2 request: Missing "
-"\"i\" value."
-msgstr ""
-"Das Backend hat eine ungültige Antwort auf eine %1read%2-Anfrage gesendet: "
-"Fehlender \"i\" Wert."
-
-#: cv/io/rest/Client.js:195
+#: cv/io/rest/Client.js
 msgid "Backend does not respond!"
 msgstr "Backend antwortet nicht!"
 
-#: cv/io/rest/Client.js:205 cv/ui/manager/editor/AbstractEditor.js:114
+#: cv/io/rest/Client.js
 msgid "File has been saved"
 msgstr "Datei wurde gespeichert"
 
-#: cv/io/rest/Client.js:214
+#: cv/io/rest/Client.js
 msgid "Error saving file"
 msgstr "Fehler beim Speichern der Datei"
 
-#: cv/parser/MetaParser.js:365
+#: cv/parser/MetaParser.js
 msgid "Template loading error"
 msgstr "Fehler beim Laden des Templates"
 
-#: cv/parser/MetaParser.js:368
+#: cv/parser/MetaParser.js
 msgid "Template '%1' could not be loaded from '%2'."
 msgstr "Template '%1' konnte nicht geladen werden von '%2'."
 
-#: cv/plugins/openhab/Settings.js:174
-msgid ""
-"The CometVisu seems to be delivered by a proxied webserver. Changing "
-"configuration values might not have the expected effect. Please proceed only"
-" if you know what you are doing."
-msgstr ""
-"Die CometVisu scheint über einen Proxy ausgeliefert zu werden. Änderungen an"
-" den Einstellungen könnten deshalb nicht den gewünschten Effekt habe.Bitte "
-"führen Sie daher nur Änderungen durch, wenn Sie wissen was Sie tun."
+#: cv/plugins/openhab/Settings.js
+msgid "The CometVisu seems to be delivered by a proxied webserver. Changing configuration values might not have the expected effect. Please proceed only if you know what you are doing."
+msgstr "Die CometVisu scheint über einen Proxy ausgeliefert zu werden. Änderungen an den Einstellungen könnten deshalb nicht den gewünschten Effekt habe.Bitte führen Sie daher nur Änderungen durch, wenn Sie wissen was Sie tun."
 
-#: cv/plugins/openhab/Settings.js:212
+#: cv/plugins/openhab/Settings.js
 msgid "openHAB backend settings"
 msgstr "openHAB Backend Einstellungen"
 
-#: cv/plugins/openhab/Settings.js:227
+#: cv/plugins/openhab/Settings.js
 msgid "Cancel"
 msgstr "Abbruch"
 
-#: cv/ui/manager/MenuBar.js:69 cv/plugins/openhab/Settings.js:232
+#: cv/ui/manager/MenuBar.js
 msgid "Save"
 msgstr "Speichern"
 
-#: cv/ui/NotificationCenter.js:236
+#: cv/ui/NotificationCenter.js
 msgid "Delete all"
 msgstr "Alle löschen"
 
-#: cv/ui/NotificationCenter.js:236
+#: cv/ui/NotificationCenter.js
 msgid "Message center"
 msgstr "Nachrichtenzentrale"
 
-#: cv/ui/manager/Main.js:120
+#: cv/ui/manager/Main.js
 msgid "config folder does not exists"
 msgstr "config Ordner existiert nicht"
 
-#: cv/ui/manager/Main.js:122
+#: cv/ui/manager/Main.js
 msgid "config folder is not readable"
 msgstr "config Ordner kann nicht gelesen werden"
 
-#: cv/ui/manager/Main.js:124
+#: cv/ui/manager/Main.js
 msgid "config folder is not writeable"
-msgstr "config Ordner ist nicht schreibbar"
+msgstr "config Ordner ist nicht beschreibbar"
 
-#: cv/ui/manager/Main.js:130
+#: cv/ui/manager/Main.js
 msgid "backup folder is not writeable"
-msgstr "backup Ordner ist nicht schreibbar"
+msgstr "backup Ordner ist nicht beschreibbar"
 
-#: cv/ui/manager/Main.js:136
+#: cv/ui/manager/Main.js
 msgid "media folder is not writeable"
-msgstr "media Ordner ist nicht schreibbar"
+msgstr "media Ordner ist nicht beschreibbar"
 
-#: cv/ui/manager/Main.js:142
+#: cv/ui/manager/Main.js
 msgid "Hidden configuration file (hidden.php) not writeable"
-msgstr ""
+msgstr "Die versteckte Konfiguration (hidden.php) ist nicht beschreibbar."
 
-#: cv/ui/manager/Main.js:176
+#: cv/ui/manager/Main.js
 msgid "Cannot load config template"
 msgstr "Template für Konfigurationsdatei kann nicht geladen werden"
 
-#: cv/ui/manager/Main.js:186
+#: cv/ui/manager/Main.js
 msgid "Cannot load file content"
 msgstr "Dateiinhalt kann nicht geladen werden"
 
-#: cv/ui/manager/Main.js:355
+#: cv/ui/manager/Main.js
 msgid "Cannot open file: \"%1\""
 msgstr "Datei \"%1\" kann nicht geöffnet werden"
 
-#: cv/ui/manager/Main.js:400
-msgid ""
-"This file has unsaved changes that will be lost when you close it. Do you "
-"really want to close the file?"
-msgstr ""
-"Diese Datei enthält ungesicherte Änderungen, die verloren gehen, wenn Sie "
-"die Datei schließen. Möchten Sie die Datei wirklich schließen?"
+#: cv/ui/manager/Main.js
+msgid "This file has unsaved changes that will be lost when you close it. Do you really want to close the file?"
+msgstr "Diese Datei enthält ungesicherte Änderungen, die verloren gehen, wenn Sie die Datei schließen. Möchten Sie die Datei wirklich schließen?"
 
-#: cv/ui/manager/Main.js:402
-msgid ""
-"This file has not been saved on the backend yet. It will be lost when you "
-"close it. Do you really want to close the file?"
-msgstr ""
-"Diese Datei wurde noch nicht gespeichert. Sie wird verloren gehen, wenn Sie "
-"sie schließen. Möchten Sie die Datei wirklich schließen?"
+#: cv/ui/manager/Main.js
+msgid "This file has not been saved on the backend yet. It will be lost when you close it. Do you really want to close the file?"
+msgstr "Diese Datei wurde noch nicht gespeichert. Sie wird verloren gehen, wenn Sie sie schließen. Möchten Sie die Datei wirklich schließen?"
 
-#: cv/ui/manager/Main.js:414
+#: cv/ui/manager/Main.js
 msgid "Unsaved changes"
 msgstr "Nicht gespeicherte Änderungen"
 
-#: cv/ui/manager/Main.js:554
-msgid ""
-"Please enter the name of the new configuration (without \"visu_config_\" at "
-"the beginning and \".xml\" at the end)"
-msgstr ""
-"Bitte geben Sie den Namen der neuen Konfigurationsdatei ein (ohne "
-"\"visu_config_\" am Anfang und \".xml\" am Ende)"
-
-#: cv/ui/manager/Main.js:555
+#: cv/ui/manager/Main.js
 msgid "A configuration with this name already exists."
 msgstr "Eine Konfigurationsdatei mit diesem Namen existiert bereits."
 
-#: cv/ui/manager/Main.js:557
+#: cv/ui/manager/Main.js
 msgid "Please enter the file name."
 msgstr "Bitte geben Sie den Dateinamen ein."
 
-#: cv/ui/manager/Main.js:558
+#: cv/ui/manager/Main.js
 msgid "A file with this name already exists."
 msgstr "Eine Datei mit diesem Namen exisitert bereits."
 
-#: cv/ui/manager/Main.js:560
+#: cv/ui/manager/Main.js
 msgid "Please enter the folder name."
 msgstr "Bitte geben Sie den Namen des Ordners ein."
 
-#: cv/ui/manager/Main.js:561
+#: cv/ui/manager/Main.js
 msgid "A folder with this name already exists."
 msgstr "Eine Ordner mit diesem Namen exisitert bereits."
 
-#: cv/ui/manager/Main.js:608
+#: cv/ui/manager/Main.js
 msgid "Folder has been created"
 msgstr "Verzeichnis wurde erstellt"
 
-#: cv/ui/manager/contextmenu/FileItem.js:274 cv/ui/manager/MenuBar.js:46
+#: cv/ui/manager/contextmenu/FileItem.js
 msgid "New file"
 msgstr "Neue Datei"
 
-#: cv/ui/manager/contextmenu/FileItem.js:291 cv/ui/manager/MenuBar.js:51
+#: cv/ui/manager/contextmenu/FileItem.js
 msgid "New folder"
 msgstr "Neuer Ordner"
 
-#: cv/ui/manager/MenuBar.js:57
+#: cv/ui/manager/MenuBar.js
 msgid "New config file"
 msgstr "Neue Konfigurationsdatei"
 
-#: cv/ui/manager/MenuBar.js:63 cv/ui/manager/viewer/Folder.js:34
+#: cv/ui/manager/viewer/Folder.js
 msgid "Upload file"
 msgstr "Datei hochladen"
 
-#: cv/ui/manager/MenuBar.js:75
+#: cv/ui/manager/MenuBar.js
 msgid "Save as..."
 msgstr "Speichern unter..."
 
-#: cv/ui/manager/contextmenu/FileItem.js:89
-#: cv/ui/manager/contextmenu/FileItem.js:171
-#: cv/ui/manager/contextmenu/FileItem.js:303 cv/ui/manager/MenuBar.js:79
+#: cv/ui/manager/contextmenu/FileItem.js
 msgid "Delete"
 msgstr "Löschen"
 
-#: cv/ui/manager/MenuBar.js:85
+#: cv/ui/manager/MenuBar.js
 msgid "Quit"
 msgstr "Beenden"
 
-#: cv/ui/manager/MenuBar.js:92
+#: cv/ui/manager/MenuBar.js
 msgid "Ctrl+Z"
 msgstr "Strg+Z"
 
-#: cv/ui/manager/MenuBar.js:92
+#: cv/ui/manager/MenuBar.js
 msgid "Undo"
 msgstr "Rückgängig"
 
-#: cv/ui/manager/MenuBar.js:97
+#: cv/ui/manager/MenuBar.js
 msgid "Ctrl+Y"
 msgstr "Strg+Y"
 
-#: cv/ui/manager/MenuBar.js:97
+#: cv/ui/manager/MenuBar.js
 msgid "Redo"
 msgstr "Wiederholen"
 
-#: cv/ui/manager/MenuBar.js:102
+#: cv/ui/manager/MenuBar.js
 msgid "Ctrl+X"
 msgstr "Strg+X"
 
-#: cv/ui/manager/MenuBar.js:102
+#: cv/ui/manager/MenuBar.js
 msgid "Cut"
 msgstr "Ausschneiden"
 
-#: cv/ui/manager/MenuBar.js:108
+#: cv/ui/manager/MenuBar.js
 msgid "Copy"
 msgstr "Kopieren"
 
-#: cv/ui/manager/MenuBar.js:108
+#: cv/ui/manager/MenuBar.js
 msgid "Ctrl+C"
 msgstr "Strg+C"
 
-#: cv/ui/manager/MenuBar.js:113
+#: cv/ui/manager/MenuBar.js
 msgid "Ctrl+V"
 msgstr "Strg+V"
 
-#: cv/ui/manager/MenuBar.js:113
+#: cv/ui/manager/MenuBar.js
 msgid "Paste"
 msgstr "Einfügen"
 
-#: cv/ui/manager/MenuBar.js:120
+#: cv/ui/manager/MenuBar.js
 msgid "Use text editor"
 msgstr "Texteditor benutzen"
 
-#: cv/ui/manager/MenuBar.js:131
+#: cv/ui/manager/MenuBar.js
 msgid "Use xml editor"
 msgstr "XML-Editor benutzen"
 
-#: cv/ui/manager/MenuBar.js:142
+#: cv/ui/manager/MenuBar.js
 msgid "Enable quick preview"
 msgstr "Schnellvorschau aktivieren"
 
-#: cv/ui/manager/MenuBar.js:150
+#: cv/ui/manager/MenuBar.js
 msgid "Expert mode"
 msgstr "Expertenansicht"
 
-#: cv/ui/manager/MenuBar.js:251
+#: cv/ui/manager/MenuBar.js
 msgid "CometVisu Manager"
 msgstr "CometVisu Manager"
 
-#: cv/ui/manager/MenuBar.js:256
+#: cv/ui/manager/MenuBar.js
 msgid "File"
 msgstr "Datei"
 
-#: cv/ui/manager/MenuBar.js:261
+#: cv/ui/manager/MenuBar.js
 msgid "Edit"
 msgstr "Bearbeiten"
 
-#: cv/ui/manager/MenuBar.js:266
+#: cv/ui/manager/MenuBar.js
 msgid "New"
 msgstr "Neu"
 
-#: cv/ui/manager/MenuBar.js:270
+#: cv/ui/manager/MenuBar.js
 msgid "Preferences"
 msgstr "Einstellungen"
 
-#: cv/ui/manager/Start.js:157
+#: cv/ui/manager/Start.js
 msgid "List mode"
 msgstr "Listenansicht"
 
-#: cv/ui/manager/Start.js:163
+#: cv/ui/manager/Start.js
 msgid "Preview mode"
 msgstr "Vorschau-Modus"
 
-#: cv/ui/manager/Start.js:180
+#: cv/ui/manager/Start.js
 msgid "Configurations"
 msgstr "Konfigurationen"
 
-#: cv/ui/manager/Start.js:223
+#: cv/ui/manager/Start.js
 msgid "Demo configurations"
 msgstr "Demo Konfigurationen"
 
-#: cv/ui/manager/Start.js:248
+#: cv/ui/manager/Start.js
 msgid "Media files"
 msgstr "Mediendateien"
 
-#: cv/ui/manager/Start.js:278
+#: cv/ui/manager/Start.js
 msgid "Miscellaneous"
 msgstr "Sonstiges"
 
-#: cv/ui/manager/Start.js:313 cv/ui/manager/model/FileItem.js:90
-#: cv/ui/manager/editor/Config.js:26
+#: cv/ui/manager/model/FileItem.js
 msgid "Hidden configuration"
 msgstr "Versteckte Konfiguration"
 
-#: cv/ui/manager/contextmenu/FileItem.js:310 cv/ui/manager/ToolBar.js:151
+#: cv/ui/manager/contextmenu/FileItem.js
 msgid "Download"
 msgstr "Herunterladen"
 
-#: cv/ui/manager/contextmenu/FileItem.js:328 cv/ui/manager/ToolBar.js:168
+#: cv/ui/manager/contextmenu/FileItem.js
 msgid "Validate"
 msgstr "Prüfen"
 
-#: cv/ui/manager/contextmenu/FileItem.js:88
+#: cv/ui/manager/contextmenu/FileItem.js
 msgid "Clear"
 msgstr "Leeren"
 
-#: cv/ui/manager/contextmenu/FileItem.js:114
+#: cv/ui/manager/contextmenu/FileItem.js
 msgid "Backup from %1"
 msgstr "Sicherung vom %1"
 
-#: cv/ui/manager/contextmenu/FileItem.js:233
+#: cv/ui/manager/contextmenu/FileItem.js
 msgid "New name"
 msgstr "Neuer Name"
 
-#: cv/ui/manager/contextmenu/FileItem.js:238
+#: cv/ui/manager/contextmenu/FileItem.js
 msgid "Rename file"
 msgstr "Datei umbenennen"
 
-#: cv/ui/manager/contextmenu/FileItem.js:285
+#: cv/ui/manager/contextmenu/FileItem.js
 msgid "Clone file"
 msgstr "Datei duplizieren"
 
-#: cv/ui/manager/contextmenu/FileItem.js:298
+#: cv/ui/manager/contextmenu/FileItem.js
 msgid "Rename"
 msgstr "Umbenennen"
 
-#: cv/ui/manager/contextmenu/FileItem.js:315
+#: cv/ui/manager/contextmenu/FileItem.js
 msgid "Open"
 msgstr "Öffnen"
 
-#: cv/ui/manager/contextmenu/FileItem.js:322
+#: cv/ui/manager/contextmenu/FileItem.js
 msgid "Restore"
 msgstr "Wiederherstellen"
 
-#: cv/ui/manager/contextmenu/FileItem.js:334
+#: cv/ui/manager/contextmenu/FileItem.js
 msgid "Replace"
 msgstr "Ersetzen"
 
-#: cv/ui/manager/contextmenu/FileItem.js:346
+#: cv/ui/manager/contextmenu/FileItem.js
 msgid "Compare with..."
 msgstr "Vergleichen mit..."
 
-#: cv/ui/manager/contextmenu/FileItem.js:350
+#: cv/ui/manager/contextmenu/FileItem.js
 msgid "Open with..."
 msgstr "Öffnen mit..."
 
-#: cv/ui/manager/control/FileController.js:39
+#: cv/ui/manager/control/FileController.js
 msgid "File \"%1\" has been created"
 msgstr "Datei \"%1\" wurde angelegt"
 
-#: cv/ui/manager/control/FileController.js:40
+#: cv/ui/manager/control/FileController.js
 msgid "Folder \"%1\" has been created"
 msgstr "Ordner \"%1\" wurde angelegt"
 
-#: cv/ui/manager/control/FileController.js:54
+#: cv/ui/manager/control/FileController.js
 msgid "File \"%1\" has been renamed"
 msgstr "Datei \"%1\" wurde umbenannt"
 
-#: cv/ui/manager/control/FileController.js:55
+#: cv/ui/manager/control/FileController.js
 msgid "Folder \"%1\" has been renamed"
 msgstr "Ordner \"%1\" wurde umbenannt"
 
-#: cv/ui/manager/control/FileController.js:77
+#: cv/ui/manager/control/FileController.js
 msgid "File \"%1\" has been moved"
 msgstr "Datei \"%1\" wurde verschoben"
 
-#: cv/ui/manager/control/FileController.js:78
+#: cv/ui/manager/control/FileController.js
 msgid "Folder \"%1\" has been moved"
 msgstr "Ordner \"%1\" wurde verschoben"
 
-#: cv/ui/manager/control/FileController.js:125
-#: cv/ui/manager/control/FileController.js:144
+#: cv/ui/manager/control/FileController.js
 msgid "%1 has been restored"
 msgstr "%1 wurde wieder hergestellt"
 
-#: cv/ui/manager/control/FileController.js:160
+#: cv/ui/manager/control/FileController.js
 msgid "File \"%1\" has been restored"
 msgstr "Datei \"%1\" wurde wieder hergestellt"
 
-#: cv/ui/manager/control/FileController.js:161
+#: cv/ui/manager/control/FileController.js
 msgid "Folder \"%1\" has been restored"
 msgstr "Ordner \"%1\" wurde wieder hergestellt"
 
-#: cv/ui/manager/control/FileController.js:181
+#: cv/ui/manager/control/FileController.js
 msgid "Do you really want to clear the trash?"
 msgstr "Mächten Sie den Papirtkorb wirklich leeren?"
 
-#: cv/ui/manager/control/FileController.js:184
+#: cv/ui/manager/control/FileController.js
 msgid "Do you really want to delete file \"%1\" from the trash?"
 msgstr "Möchten Sie die Datei \"%1\" wirklich aus dem Papierkorb löschen?"
 
-#: cv/ui/manager/control/FileController.js:185
+#: cv/ui/manager/control/FileController.js
 msgid "Do you really want to delete folder \"%1\" from the trash?"
 msgstr "Möchten Sie den Ordner \"%1\" wirklich aus dem Papierkorb löschen?"
 
-#: cv/ui/manager/control/FileController.js:188
+#: cv/ui/manager/control/FileController.js
 msgid "Do you really want to delete file \"%1\"?"
 msgstr "Möchten Sie die Datei \"%1\" wirklich löschen?"
 
-#: cv/ui/manager/control/FileController.js:189
+#: cv/ui/manager/control/FileController.js
 msgid "Do you really want to delete folder \"%1\"?"
 msgstr "Möchten Sie den Ordner \"%1\" wirklich löschen?"
 
-#: cv/ui/manager/control/FileController.js:197
+#: cv/ui/manager/control/FileController.js
 msgid "Confirm deletion"
 msgstr "Löschen bestätigen"
 
-#: cv/ui/manager/control/FileController.js:212
+#: cv/ui/manager/control/FileController.js
 msgid "Trash has been cleared"
 msgstr "Der Papierkorb wurde geleert"
 
-#: cv/ui/manager/control/FileController.js:215
+#: cv/ui/manager/control/FileController.js
 msgid "File \"%1\" has been removed from trash"
 msgstr "Datei \"%1\" wurde aus dem Papierkorb gelöscht"
 
-#: cv/ui/manager/control/FileController.js:216
+#: cv/ui/manager/control/FileController.js
 msgid "Folder \"%1\" has been removed from trash"
 msgstr "Ornder \"%1\" wurde aus dem Papierkorb gelöscht"
 
-#: cv/ui/manager/control/FileController.js:219
+#: cv/ui/manager/control/FileController.js
 msgid "File \"%1\" has been deleted"
 msgstr "Datei \"%1\" wurde gelöscht"
 
-#: cv/ui/manager/control/FileController.js:220
+#: cv/ui/manager/control/FileController.js
 msgid "Folder \"%1\" has been deleted"
 msgstr "Ordner \"%1\" wurde gelöscht"
 
-#: cv/ui/manager/control/FileController.js:257
+#: cv/ui/manager/control/FileController.js
 msgid "Validating %1"
 msgstr "Prüfe %1"
 
-#: cv/ui/manager/control/FileController.js:262
+#: cv/ui/manager/control/FileController.js
 msgid "%1 has no errors!"
 msgstr "%1 hat keine Fehler!"
 
-#: cv/ui/manager/control/FileController.js:270
+#: cv/ui/manager/control/FileController.js
 msgid "%1 error found in %2!"
 msgid_plural "%1 errors found in %2!"
 msgstr[0] "%1 Fehler gefunden in %2!"
 msgstr[1] "%1 Fehler gefunden in %2!"
 
-#: cv/ui/manager/editor/AbstractEditor.js:114
+#: cv/ui/manager/editor/AbstractEditor.js
 msgid "File has been created"
 msgstr "Datei wurde erstellt"
 
-#: cv/ui/manager/editor/Config.js:121
+#: cv/ui/manager/editor/Config.js
 msgid "Section name duplicate: \"%1\"."
 msgstr "Doppelter Sektionsname: \"%1\"."
 
-#: cv/ui/manager/editor/Config.js:131
+#: cv/ui/manager/editor/Config.js
 msgid "Option key duplicate: \"%1\" in section \"%2\"."
 msgstr "Doppelter Optionsname \"%1\" in Sektion \"%2\"."
 
-#: cv/ui/manager/editor/Config.js:140
+#: cv/ui/manager/editor/Source.js
 msgid "Saving hidden config failed with error %1 (%2)"
-msgstr ""
-"Das Speichern der versteckten Konfiguration ist fehlgeschlagen: %1 (%2)"
+msgstr "Das Speichern der versteckten Konfiguration ist fehlgeschlagen: %1 (%2)"
 
-#: cv/ui/manager/editor/Config.js:142
+#: cv/ui/manager/editor/Source.js
 msgid "Hidden config has been saved"
 msgstr "Die Verstackte Konfiguration wurde gespeichert"
 
-#: cv/ui/manager/editor/Config.js:147
+#: cv/ui/manager/editor/Config.js
 msgid "Section is invalid and has not been saved."
 msgstr "Diese Sektion ist ungültig und wurde nicht gespeichert."
 
-#: cv/ui/manager/editor/Config.js:183
+#: cv/ui/manager/editor/Config.js
 msgid "Add section"
 msgstr "Sektion hinzufügen"
 
-#: cv/ui/manager/editor/Diff.js:24
+#: cv/ui/manager/editor/Diff.js
 msgid "File compare"
 msgstr "Datei vergleichen"
 
-#: cv/ui/manager/editor/Source.js:46
+#: cv/ui/manager/editor/Source.js
 msgid "Texteditor"
 msgstr "Texteditor"
 
-#: cv/ui/manager/editor/Xml.js:27
+#: cv/ui/manager/editor/Xml.js
 msgid "Xml-editor"
 msgstr "XML-Editor"
 
-#: cv/ui/manager/editor/completion/Config.js:408
+#: cv/ui/manager/editor/completion/Config.js
 msgid "Variable from template %1"
 msgstr "Variable aus Template %1"
 
-#: cv/ui/manager/form/FileListItem.js:29
+#: cv/ui/manager/form/FileListItem.js
 msgid "Drop the file here to replace the content."
 msgstr "Lassen Sie die Datei hier fallen um den Inhalt zu ersetzen."
 
-#: cv/ui/manager/form/FileListItem.js:220
-msgid ""
-"Do you really want to replace the \'%1\' with the uploaded files content?"
-msgstr ""
-"Möchten Sie \'%1\' wirklich mit dem Inhalt der hochgeladenen Datei ersetzen?"
+#. NO LONGER USED
+msgid "Do you really want to replace the \'%1\' with the uploaded files content?"
+msgstr "Möchten Sie \'%1\' wirklich mit dem Inhalt der hochgeladenen Datei ersetzen?"
 
-#: cv/ui/manager/form/FileListItem.js:235
+#: cv/ui/manager/form/FileListItem.js
 msgid "Double click to open \"%1\""
 msgstr "Doppelklick zum Öffnen von \"%1\""
 
-#: cv/ui/manager/form/FileListItem.js:402
+#: cv/ui/manager/form/FileListItem.js
 msgid "Download file"
 msgstr "Datei herunterladen"
 
-#: cv/ui/manager/form/FileListItem.js:411
+#: cv/ui/manager/form/FileListItem.js
 msgid "Other file actions"
 msgstr "Andere Datei-Aktionen"
 
-#: cv/ui/manager/form/FileTabItem.js:167
+#: cv/ui/manager/form/FileTabItem.js
 msgid "This file is not writeable"
 msgstr "Diese Datei ist nicht änderbar"
 
-#: cv/ui/manager/form/OptionListItem.js:130
+#: cv/ui/manager/form/OptionListItem.js
 msgid "Delete option"
 msgstr "Option löschen"
 
-#: cv/ui/manager/form/OptionListItem.js:139
+#: cv/ui/manager/form/OptionListItem.js
 msgid "Add option"
 msgstr "Option hinzufügen"
 
-#: cv/ui/manager/form/OptionListItem.js:147
+#: cv/ui/manager/form/OptionListItem.js
 msgid "Key"
 msgstr "Schlüssel"
 
-#: cv/ui/manager/form/OptionListItem.js:153
+#: cv/ui/manager/form/OptionListItem.js
 msgid "Value"
 msgstr "Wert"
 
-#: cv/ui/manager/form/SectionListItem.js:154
+#: cv/ui/manager/form/SectionListItem.js
 msgid "Section"
 msgstr "Sektion"
 
-#: cv/ui/manager/form/SectionListItem.js:169
+#: cv/ui/manager/form/SectionListItem.js
 msgid "Delete section"
 msgstr "Sektion löschen"
 
-#: cv/ui/manager/model/CompareFiles.js:76
+#: cv/ui/manager/model/CompareFiles.js
 msgid "Diff: %1"
 msgstr "Vergleich: %1"
 
-#: cv/ui/manager/tree/VirtualFsItem.js:83
+#: cv/ui/manager/tree/VirtualFsItem.js
 msgid "Trash"
 msgstr "Papierkorb"
 
-#: cv/ui/manager/upload/UploadMgr.js:95
+#: cv/ui/manager/upload/UploadMgr.js
 msgid "Replacing the file failed."
-msgstr ""
+msgstr "Das Ersetzen der Datei ist fehlgeschlagen."
 
-#: cv/ui/manager/upload/UploadMgr.js:97
+#: cv/ui/manager/upload/UploadMgr.js
 msgid "This file already exists, do you want to replace it?"
 msgstr "Diese Datei existiert bereits, möchten Sie sie überschreiben?"
 
-#: cv/ui/manager/upload/UploadMgr.js:101
+#: cv/ui/manager/upload/UploadMgr.js
 msgid "File already exists"
 msgstr "Diese Datei existiert bereits"
 
-#: cv/ui/manager/upload/UploadMgr.js:106
+#: cv/ui/manager/upload/UploadMgr.js
 msgid "Uploading this file is not allowed here."
 msgstr "Das Hochladen der Datei ist an dieser Stelle nicht erleubt."
 
-#: cv/ui/manager/upload/UploadMgr.js:116
+#: cv/ui/manager/upload/UploadMgr.js
 msgid "File upload stopped with an error: %1"
 msgstr "Das Hochladen der Datei wurde mit einem Fehler beendet: %1"
 
-#: cv/ui/manager/upload/UploadMgr.js:120
+#: cv/ui/manager/upload/UploadMgr.js
 msgid "File has been uploaded"
 msgstr "Die Datei wurde hochgeladen"
 
-#: cv/ui/manager/viewer/Config.js:37
+#: cv/ui/manager/viewer/Config.js
 msgid "Config viewer"
 msgstr "Konfiguration anzeigen"
 
-#: cv/ui/manager/viewer/Config.js:61
+#: cv/ui/manager/viewer/Config.js
 msgid "%1 is no configuration file"
 msgstr "%1 ist keine Konfigurationsdatei"
 
-#: cv/ui/manager/viewer/Folder.js:55
+#: cv/ui/manager/viewer/Folder.js
 msgid "Show folder"
 msgstr "Ordner anzeigen"
 
-#: cv/ui/manager/viewer/Folder.js:370
+#: cv/ui/manager/viewer/Folder.js
 msgid "Filter by name..."
 msgstr "Nach Namen filtern..."
 
-#: cv/ui/manager/viewer/Icons.js:24
+#: cv/ui/manager/viewer/Icons.js
 msgid "Show icons"
 msgstr "Icons anzeigen"
 
-#: cv/ui/manager/viewer/Image.js:36
+#: cv/ui/manager/viewer/Image.js
 msgid "Show image"
 msgstr "Bild anzeigen"
 
-#: cv/ui/structure/pure/Unknown.js:88
+#: cv/ui/structure/pure/Unknown.js
 msgid "unknown: %1"
 msgstr "Unbekannt: %1"
 
-#: cv/util/ConfigLoader.js:172
+#: cv/util/ConfigLoader.js
 msgid "Config-File Error!"
 msgstr "Fehler in Konfigurations-Datei!"
 
-#: cv/util/ConfigLoader.js:176
+#: cv/util/ConfigLoader.js
 msgid "Invalid config file!"
 msgstr "Ungültige Konfigurations-Datei!"
 
-#: cv/util/ConfigLoader.js:176
+#: cv/util/ConfigLoader.js
 msgid "Please check!"
 msgstr "Bitte prüfen!"
 
-#: cv/util/ConfigLoader.js:184
+#: cv/util/ConfigLoader.js
 msgid "Config file has wrong library version!"
 msgstr "Konfigurations-Datei hat die falsche 'library' Version"
 
-#: cv/util/ConfigLoader.js:185
+#: cv/util/ConfigLoader.js
 msgid "This can cause problems with your configuration"
 msgstr "Das kann Probleme in Ihrer Konfiguration verursachen"
 
-#: cv/util/ConfigLoader.js:186
+#: cv/util/ConfigLoader.js
 msgid "You can run the %1Configuration Upgrader%2."
 msgstr "Sie können den %1Konfigurations-Upgrader%2 laufen lassen."
 
-#: cv/util/ConfigLoader.js:187
-msgid ""
-"Or you can start without upgrading %1with possible configuration problems%2"
-msgstr ""
-"Oder Sie starten ohne Upgrade %1mit möglichen Konfigurations-Problemen%2"
+#: cv/util/ConfigLoader.js
+msgid "Or you can start without upgrading %1with possible configuration problems%2"
+msgstr "Oder Sie starten ohne Upgrade %1mit möglichen Konfigurations-Problemen%2"
 
-#: cv/util/ConfigLoader.js:190
-msgid ""
-"404: Config file not found. Neither as normal config (%1) nor as demo config"
-" (%2)."
-msgstr ""
-"404: Konfigurations-Datei nicht gefunden. Weder als normale Konfiguration "
-"(%1) noch als Demo-Konfiguration (%2)"
+#: cv/util/ConfigLoader.js
+msgid "404: Config file not found. Neither as normal config (%1) nor as demo config (%2)."
+msgstr "404: Konfigurations-Datei nicht gefunden. Weder als normale Konfiguration (%1) noch als Demo-Konfiguration (%2)"
 
-#: cv/util/ConfigLoader.js:193
+#: cv/util/ConfigLoader.js
 msgid "Unhandled error of type \"%1\""
 msgstr "Unbekannter Fehler vom Typ \"%1\""
 
-#: cv/util/ScriptLoader.js:157
+#: cv/util/ScriptLoader.js
 msgid "Error loading plugin \"%1\""
 msgstr "Plugin \"%1\" konnte nicht geladen werden"
 
-#: cv/util/ScriptLoader.js:158 cv/util/ScriptLoader.js:166
+#: cv/util/ScriptLoader.js
 msgid "File %1 could not be loaded."
 msgstr "Date %1 konnte nicht geladen werden"
 
-#: cv/util/ScriptLoader.js:165
+#: cv/util/ScriptLoader.js
 msgid "File loading error"
 msgstr "Datei-Ladefehler"
 
-#~ msgid "Close file"
-#~ msgstr "Datei schließen"
+#: cv/Application.js
+msgid "Validating configuration file..."
+msgstr "Validiere Konfigurations-Datei..."
 
-#~ msgid "Do you really want to delete this file from the trash?"
-#~ msgstr "Möchten Sie diese Datei wirklich aus dem Papierkorb entfernen?"
+#: cv/Application.js
+msgid "The %1 configuration has no errors!"
+msgstr "Die %1 Konfiguration hat keine Fehler!"
 
-#~ msgid "Do you really want to delete this file?"
-#~ msgstr "Möchten Sie diese Datei wirklich löschen?"
+#: cv/Application.js
+msgid "The %1 configuration has %2 errors!"
+msgstr "Die %1 Konfiguration hat %2 Fehler!"
 
-#~ msgid "Do you really want to delete this folder from the trash?"
-#~ msgstr "Möchten Sie diesen Ordner wirklich aus dem Papierkorb entfernen?"
+#: cv/Application.js
+msgid "Show errors"
+msgstr "Fehler anzeigen"
 
-#~ msgid "Do you really want to delete this folder?"
-#~ msgstr "Möchten Sie diesen Ordner wirklich löschen?"
+#: cv/ui/manager/Main.js
+msgid "Please enter the name of the new configuration (without \"visu_config_\" at the beginning and \".xml\" at the end)"
+msgstr "Bitte geben Sie den Namen der neuen Konfiguraton (ohne \"visu_config_\" am Anfang und \".xml\" am Ende) ein"
 
-#~ msgid "Double click to open"
-#~ msgstr "Doppelklick zum Öffnen"
+#: cv/ui/manager/editor/Diff.js
+msgid "Config file has been upgraded to the current library version."
+msgstr "Die Konfigurations-Datei wurde auf die aktuelle Version aktualisiert."
 
-#~ msgid "Edit hidden config"
-#~ msgstr "Versteckte Konfiguration bearbeiten"
+#: cv/ui/manager/editor/Diff.js
+msgid "The following changes have been made"
+msgstr "Die folgendenen Änderungen wurden vorgenommen"
 
-#~ msgid "Enable error sending on reload"
-#~ msgstr "Neu laden mit aktiviertem Senden von Fehlerberichten"
+#: cv/ui/manager/editor/Diff.js
+msgid "You can check the changes in the editor. The left side shows the content before the upgrade and the right side shows the content after the upgrade."
+msgstr "Sie können die Änderungen im Editor überprüfen. Die linke Seite zeigt den Inhalt vor der Aktualisierung, die rechte Seite nachher."
 
-#~ msgid "Enable reporting on reload"
-#~ msgstr "Neu laden mit aktivierter Aufzeichnung"
+#. NO LONGER USED
+msgid "Changes are highlighted. Please save the file and reload the browser to apply the changes."
+msgstr "Die Änderungen wurden hervorgehoben. Bitte speichern Sie die Datei und aktualisieren Sie die Seite im Browser, damit die Änderungen wirksam werden."
 
-#~ msgid "Entries"
-#~ msgstr "Einträge"
+#: cv/ui/manager/editor/Diff.js
+msgid "Upgrade successful"
+msgstr "Aktualisierung erfolgreich"
 
-#~ msgid "File has been deleted"
-#~ msgstr "Datei wurde gelöscht"
+#: cv/ui/manager/editor/Source.js
+msgid "Hidden config is invalid, please correct the errors"
+msgstr "Die versteckte Konfiguration ist ungültig, bitte beheben Sie die Fehler"
 
-#~ msgid "File has been moved"
-#~ msgstr "Datei wurde verschoben"
+#: cv/ui/manager/editor/Source.js
+msgid "Hidden config content has some warnings! It is recommended to fix the warnings before saving. Save anyways?"
+msgstr "Die versteckte Konfiguration enthält eventuell Fehler! Es wird empfohlen die Warnungen zu beheben, bevor gespeichert wird. Trotzdem speichern?"
 
-#~ msgid "File has been removed from trash"
-#~ msgstr "Die Datei wurde aus dem Papierkorb entfernt"
+#: cv/ui/manager/editor/Source.js
+msgid "Confirm saving with warnings"
+msgstr "Speichen trotz Warnungen bestätigen"
 
-#~ msgid "File has been renamed"
-#~ msgstr "Datei wurde umbenannt"
+#: cv/ui/manager/editor/Xml.js
+msgid "The XML-Editor does not support files that are not writeable!"
+msgstr "Der XML-Editor unterstützt keine Dateien, die nicht gespeichert werden können!"
 
-#~ msgid "File has been restored"
-#~ msgstr "Datei wurde wiederhergestellt"
+#: cv/ui/manager/form/FileListItem.js
+msgid "Do you really want to replace the '%1' with the uploaded files content?"
+msgstr "Möchten Sie wirklich '%1' mit der hochgeladenen Datei ersetzen?"
 
-#~ msgid "Folder has been deleted"
-#~ msgstr "Verzeichnis wurde gelöscht"
+#: cv/TemplateEngine.js
+msgid "The backend did send an invalid response to a %1read%2 request: Missing \"i\" value."
+msgstr "Das Backend hat eine ungültige Antwort für eine %1Lese%2-Anfrage gesendet: Fehlender \"i\" Wert."
 
-#~ msgid "Folder has been moved"
-#~ msgstr "Order wurde verschoben"
+#: cv/util/ConfigUpgrader.js
+msgid "Upgrader from version %1 not implemented"
+msgstr "Aktualisieren von Version %1 nicht implementiert"
 
-#~ msgid "Folder has been removed from trash"
-#~ msgstr "Der Ordner wurde aus dem Papierkorb entfernt"
+#: cv/ui/manager/editor/Diff.js
+msgid "Click \"Apply\" if you want to save the changes and reload the browser."
+msgstr "Klicken Sie \"Anwenden\", wenn Sie die Änderungen speichern und die aktualisierte Konfigurations-Datei laden möchten."
 
-#~ msgid "Folder has been renamed"
-#~ msgstr "Verzeichnis wurde umbenannt"
+#: cv/ui/manager/editor/Diff.js
+msgid "Click \"Check\" if you want to check the changes. You have to save the changes and reload your browser yourself in this case."
+msgstr "Klicken Sie \"Prüfen\", wenn Sie die Änderungen überprüfen möchten. In diesem Fall müssen Sie selbst die Datei speichern und den Browser neu laden, damit die Änderungen wirksam werden."
 
-#~ msgid "Folder has been restored"
-#~ msgstr "Ornder wurde wiederhergestellt"
+#: cv/ui/manager/editor/Diff.js
+msgid "Apply"
+msgstr "Anwenden"
 
-#~ msgid "Report Bug"
-#~ msgstr "Fehler berichten"
+#: cv/ui/manager/editor/Diff.js
+msgid "Check"
+msgstr "Prüfen"

--- a/source/translation/de.po
+++ b/source/translation/de.po
@@ -739,3 +739,7 @@ msgstr "Anwenden"
 #: cv/ui/manager/editor/Diff.js
 msgid "Check"
 msgstr "Prüfen"
+
+#: cv/ui/manager/editor/Diff.js
+msgid "No changes have been made"
+msgstr "Es wurden keine Änderungen vorgenommen"

--- a/source/translation/en.po
+++ b/source/translation/en.po
@@ -747,3 +747,7 @@ msgstr ""
 #: cv/ui/manager/editor/Diff.js
 msgid "Check"
 msgstr ""
+
+#: cv/ui/manager/editor/Diff.js
+msgid "No changes have been made"
+msgstr ""

--- a/source/translation/en.po
+++ b/source/translation/en.po
@@ -1,761 +1,749 @@
-#
+#. NO LONGER USED
 msgid ""
-msgstr ""
-"Project-Id-Version: 1.0\n"
-"Report-Msgid-Bugs-To: you@your.org\n"
-"POT-Creation-Date: 2017-04-26 18:57+0100\n"
-"PO-Revision-Date: 2017-04-26 18:57+0100\n"
-"Last-Translator: you <you@your.org>\n"
-"Language-Team: Team <yourteam@your.org>\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+msgstr "Project-Id-Version: 1.0\nReport-Msgid-Bugs-To: you@your.org\nPOT-Creation-Date: 2017-04-26 18:57+0100\nPO-Revision-Date: 2017-04-26 18:57+0100\nLast-Translator: you <you@your.org>\nLanguage-Team: Team <yourteam@your.org>\nMIME-Version: 1.0\nContent-Type: text/plain; charset=utf-8\nContent-Transfer-Encoding: 8bit\n"
 
-#: cv/Application.js:230
+#: cv/Application.js
 msgid "Please describe what you have done until the error occured?"
 msgstr ""
 
-#: cv/Application.js:297
+#: cv/Application.js
 msgid "An error occured"
 msgstr ""
 
-#: cv/Application.js:303
+#: cv/Application.js
 msgid "Enable on reload:"
 msgstr ""
 
-#: cv/ui/Popup.js:271 cv/ui/manager/ToolBar.js:185 cv/Application.js:308
+#: cv/ui/Popup.js
 msgid "Reload"
 msgstr ""
 
-#: cv/Application.js:340
+#: cv/Application.js
 msgid "Please do not forget to attach the downloaded Logfile to this ticket."
 msgstr ""
 
-#: cv/Application.js:347
+#: cv/Application.js
 msgid "Action recording"
 msgstr ""
 
-#: cv/Application.js:358
+#. NO LONGER USED
 msgid "Send error to sentry.io"
 msgstr ""
 
-#: cv/Application.js:372
+#. NO LONGER USED
 msgid "Error reporting (on sentry.io)"
 msgstr ""
 
-#: cv/TemplateEngine.js:264
+#: cv/TemplateEngine.js
 msgid "Connection error"
 msgstr ""
 
-#: cv/TemplateEngine.js:273
+#: cv/TemplateEngine.js
 msgid "Error requesting %1: %2 - %3."
 msgstr ""
 
-#: cv/TemplateEngine.js:275
+#: cv/TemplateEngine.js
 msgid "Connection to backend is lost."
 msgstr ""
 
-#: cv/TemplateEngine.js:290 cv/TemplateEngine.js:305
+#: cv/TemplateEngine.js
 msgid "CometVisu protocol error"
 msgstr ""
 
-#: cv/TemplateEngine.js:291
-msgid ""
-"The backend did send an invalid response to the %1Login%2 request: missing "
-"protocol version."
+#: cv/TemplateEngine.js
+msgid "The backend did send an invalid response to the %1Login%2 request: missing protocol version."
 msgstr ""
 
-#: cv/TemplateEngine.js:294 cv/TemplateEngine.js:309
+#: cv/TemplateEngine.js
 msgid "Please try to fix the problem in the backend."
 msgstr ""
 
-#: cv/TemplateEngine.js:295 cv/TemplateEngine.js:310
+#: cv/TemplateEngine.js
 msgid "Backend-Response:"
 msgstr ""
 
-#: cv/TemplateEngine.js:306
-msgid ""
-"The backend did send an invalid response to a %1read%2 request: Missing "
-"\"i\" value."
-msgstr ""
-
-#: cv/io/rest/Client.js:195
+#: cv/io/rest/Client.js
 msgid "Backend does not respond!"
 msgstr ""
 
-#: cv/io/rest/Client.js:205 cv/ui/manager/editor/AbstractEditor.js:114
+#: cv/io/rest/Client.js
 msgid "File has been saved"
 msgstr ""
 
-#: cv/io/rest/Client.js:214
+#: cv/io/rest/Client.js
 msgid "Error saving file"
 msgstr ""
 
-#: cv/parser/MetaParser.js:365
+#: cv/parser/MetaParser.js
 msgid "Template loading error"
 msgstr ""
 
-#: cv/parser/MetaParser.js:368
+#: cv/parser/MetaParser.js
 msgid "Template '%1' could not be loaded from '%2'."
 msgstr ""
 
-#: cv/plugins/openhab/Settings.js:174
-msgid ""
-"The CometVisu seems to be delivered by a proxied webserver. Changing "
-"configuration values might not have the expected effect. Please proceed only"
-" if you know what you are doing."
+#: cv/plugins/openhab/Settings.js
+msgid "The CometVisu seems to be delivered by a proxied webserver. Changing configuration values might not have the expected effect. Please proceed only if you know what you are doing."
 msgstr ""
 
-#: cv/plugins/openhab/Settings.js:212
+#: cv/plugins/openhab/Settings.js
 msgid "openHAB backend settings"
 msgstr ""
 
-#: cv/plugins/openhab/Settings.js:227
+#: cv/plugins/openhab/Settings.js
 msgid "Cancel"
 msgstr ""
 
-#: cv/ui/manager/MenuBar.js:69 cv/plugins/openhab/Settings.js:232
+#: cv/ui/manager/MenuBar.js
 msgid "Save"
 msgstr ""
 
-#: cv/ui/NotificationCenter.js:236
+#: cv/ui/NotificationCenter.js
 msgid "Delete all"
 msgstr ""
 
-#: cv/ui/NotificationCenter.js:236
+#: cv/ui/NotificationCenter.js
 msgid "Message center"
 msgstr ""
 
-#: cv/ui/manager/Main.js:120
+#: cv/ui/manager/Main.js
 msgid "config folder does not exists"
 msgstr ""
 
-#: cv/ui/manager/Main.js:122
+#: cv/ui/manager/Main.js
 msgid "config folder is not readable"
 msgstr ""
 
-#: cv/ui/manager/Main.js:124
+#: cv/ui/manager/Main.js
 msgid "config folder is not writeable"
 msgstr ""
 
-#: cv/ui/manager/Main.js:130
+#: cv/ui/manager/Main.js
 msgid "backup folder is not writeable"
 msgstr ""
 
-#: cv/ui/manager/Main.js:136
+#: cv/ui/manager/Main.js
 msgid "media folder is not writeable"
 msgstr ""
 
-#: cv/ui/manager/Main.js:142
+#: cv/ui/manager/Main.js
 msgid "Hidden configuration file (hidden.php) not writeable"
 msgstr ""
 
-#: cv/ui/manager/Main.js:176
+#: cv/ui/manager/Main.js
 msgid "Cannot load config template"
 msgstr ""
 
-#: cv/ui/manager/Main.js:186
+#: cv/ui/manager/Main.js
 msgid "Cannot load file content"
 msgstr ""
 
-#: cv/ui/manager/Main.js:355
+#: cv/ui/manager/Main.js
 msgid "Cannot open file: \"%1\""
 msgstr ""
 
-#: cv/ui/manager/Main.js:400
-msgid ""
-"This file has unsaved changes that will be lost when you close it. Do you "
-"really want to close the file?"
+#: cv/ui/manager/Main.js
+msgid "This file has unsaved changes that will be lost when you close it. Do you really want to close the file?"
 msgstr ""
 
-#: cv/ui/manager/Main.js:402
-msgid ""
-"This file has not been saved on the backend yet. It will be lost when you "
-"close it. Do you really want to close the file?"
+#: cv/ui/manager/Main.js
+msgid "This file has not been saved on the backend yet. It will be lost when you close it. Do you really want to close the file?"
 msgstr ""
 
-#: cv/ui/manager/Main.js:414
+#: cv/ui/manager/Main.js
 msgid "Unsaved changes"
 msgstr ""
 
-#: cv/ui/manager/Main.js:554
-msgid ""
-"Please enter the name of the new configuration (without \"visu_config_\" at "
-"the beginning and \".xml\" at the end)"
-msgstr ""
-
-#: cv/ui/manager/Main.js:555
+#: cv/ui/manager/Main.js
 msgid "A configuration with this name already exists."
 msgstr ""
 
-#: cv/ui/manager/Main.js:557
+#: cv/ui/manager/Main.js
 msgid "Please enter the file name."
 msgstr ""
 
-#: cv/ui/manager/Main.js:558
+#: cv/ui/manager/Main.js
 msgid "A file with this name already exists."
 msgstr ""
 
-#: cv/ui/manager/Main.js:560
+#: cv/ui/manager/Main.js
 msgid "Please enter the folder name."
 msgstr ""
 
-#: cv/ui/manager/Main.js:561
+#: cv/ui/manager/Main.js
 msgid "A folder with this name already exists."
 msgstr ""
 
-#: cv/ui/manager/Main.js:608
+#: cv/ui/manager/Main.js
 msgid "Folder has been created"
 msgstr ""
 
-#: cv/ui/manager/contextmenu/FileItem.js:274 cv/ui/manager/MenuBar.js:46
+#: cv/ui/manager/contextmenu/FileItem.js
 msgid "New file"
 msgstr ""
 
-#: cv/ui/manager/contextmenu/FileItem.js:291 cv/ui/manager/MenuBar.js:51
+#: cv/ui/manager/contextmenu/FileItem.js
 msgid "New folder"
 msgstr ""
 
-#: cv/ui/manager/MenuBar.js:57
+#: cv/ui/manager/MenuBar.js
 msgid "New config file"
 msgstr ""
 
-#: cv/ui/manager/MenuBar.js:63 cv/ui/manager/viewer/Folder.js:34
+#: cv/ui/manager/viewer/Folder.js
 msgid "Upload file"
 msgstr ""
 
-#: cv/ui/manager/MenuBar.js:75
+#: cv/ui/manager/MenuBar.js
 msgid "Save as..."
 msgstr ""
 
-#: cv/ui/manager/contextmenu/FileItem.js:89
-#: cv/ui/manager/contextmenu/FileItem.js:171
-#: cv/ui/manager/contextmenu/FileItem.js:303 cv/ui/manager/MenuBar.js:79
+#: cv/ui/manager/contextmenu/FileItem.js
 msgid "Delete"
 msgstr ""
 
-#: cv/ui/manager/MenuBar.js:85
+#: cv/ui/manager/MenuBar.js
 msgid "Quit"
 msgstr ""
 
-#: cv/ui/manager/MenuBar.js:92
+#: cv/ui/manager/MenuBar.js
 msgid "Ctrl+Z"
 msgstr ""
 
-#: cv/ui/manager/MenuBar.js:92
+#: cv/ui/manager/MenuBar.js
 msgid "Undo"
 msgstr ""
 
-#: cv/ui/manager/MenuBar.js:97
+#: cv/ui/manager/MenuBar.js
 msgid "Ctrl+Y"
 msgstr ""
 
-#: cv/ui/manager/MenuBar.js:97
+#: cv/ui/manager/MenuBar.js
 msgid "Redo"
 msgstr ""
 
-#: cv/ui/manager/MenuBar.js:102
+#: cv/ui/manager/MenuBar.js
 msgid "Ctrl+X"
 msgstr ""
 
-#: cv/ui/manager/MenuBar.js:102
+#: cv/ui/manager/MenuBar.js
 msgid "Cut"
 msgstr ""
 
-#: cv/ui/manager/MenuBar.js:108
+#: cv/ui/manager/MenuBar.js
 msgid "Copy"
 msgstr ""
 
-#: cv/ui/manager/MenuBar.js:108
+#: cv/ui/manager/MenuBar.js
 msgid "Ctrl+C"
 msgstr ""
 
-#: cv/ui/manager/MenuBar.js:113
+#: cv/ui/manager/MenuBar.js
 msgid "Ctrl+V"
 msgstr ""
 
-#: cv/ui/manager/MenuBar.js:113
+#: cv/ui/manager/MenuBar.js
 msgid "Paste"
 msgstr ""
 
-#: cv/ui/manager/MenuBar.js:120
+#: cv/ui/manager/MenuBar.js
 msgid "Use text editor"
 msgstr ""
 
-#: cv/ui/manager/MenuBar.js:131
+#: cv/ui/manager/MenuBar.js
 msgid "Use xml editor"
 msgstr ""
 
-#: cv/ui/manager/MenuBar.js:142
+#: cv/ui/manager/MenuBar.js
 msgid "Enable quick preview"
 msgstr ""
 
-#: cv/ui/manager/MenuBar.js:150
+#: cv/ui/manager/MenuBar.js
 msgid "Expert mode"
 msgstr ""
 
-#: cv/ui/manager/MenuBar.js:251
+#: cv/ui/manager/MenuBar.js
 msgid "CometVisu Manager"
 msgstr ""
 
-#: cv/ui/manager/MenuBar.js:256
+#: cv/ui/manager/MenuBar.js
 msgid "File"
 msgstr ""
 
-#: cv/ui/manager/MenuBar.js:261
+#: cv/ui/manager/MenuBar.js
 msgid "Edit"
 msgstr ""
 
-#: cv/ui/manager/MenuBar.js:266
+#: cv/ui/manager/MenuBar.js
 msgid "New"
 msgstr ""
 
-#: cv/ui/manager/MenuBar.js:270
+#: cv/ui/manager/MenuBar.js
 msgid "Preferences"
 msgstr ""
 
-#: cv/ui/manager/Start.js:157
+#: cv/ui/manager/Start.js
 msgid "List mode"
 msgstr ""
 
-#: cv/ui/manager/Start.js:163
+#: cv/ui/manager/Start.js
 msgid "Preview mode"
 msgstr ""
 
-#: cv/ui/manager/Start.js:180
+#: cv/ui/manager/Start.js
 msgid "Configurations"
 msgstr ""
 
-#: cv/ui/manager/Start.js:223
+#: cv/ui/manager/Start.js
 msgid "Demo configurations"
 msgstr ""
 
-#: cv/ui/manager/Start.js:248
+#: cv/ui/manager/Start.js
 msgid "Media files"
 msgstr ""
 
-#: cv/ui/manager/Start.js:278
+#: cv/ui/manager/Start.js
 msgid "Miscellaneous"
 msgstr ""
 
-#: cv/ui/manager/Start.js:313 cv/ui/manager/model/FileItem.js:90
-#: cv/ui/manager/editor/Config.js:26
+#: cv/ui/manager/model/FileItem.js
 msgid "Hidden configuration"
 msgstr ""
 
-#: cv/ui/manager/contextmenu/FileItem.js:310 cv/ui/manager/ToolBar.js:151
+#: cv/ui/manager/contextmenu/FileItem.js
 msgid "Download"
 msgstr ""
 
-#: cv/ui/manager/contextmenu/FileItem.js:328 cv/ui/manager/ToolBar.js:168
+#: cv/ui/manager/contextmenu/FileItem.js
 msgid "Validate"
 msgstr ""
 
-#: cv/ui/manager/contextmenu/FileItem.js:88
+#: cv/ui/manager/contextmenu/FileItem.js
 msgid "Clear"
 msgstr ""
 
-#: cv/ui/manager/contextmenu/FileItem.js:114
+#: cv/ui/manager/contextmenu/FileItem.js
 msgid "Backup from %1"
 msgstr ""
 
-#: cv/ui/manager/contextmenu/FileItem.js:233
+#: cv/ui/manager/contextmenu/FileItem.js
 msgid "New name"
 msgstr ""
 
-#: cv/ui/manager/contextmenu/FileItem.js:238
+#: cv/ui/manager/contextmenu/FileItem.js
 msgid "Rename file"
 msgstr ""
 
-#: cv/ui/manager/contextmenu/FileItem.js:285
+#: cv/ui/manager/contextmenu/FileItem.js
 msgid "Clone file"
 msgstr ""
 
-#: cv/ui/manager/contextmenu/FileItem.js:298
+#: cv/ui/manager/contextmenu/FileItem.js
 msgid "Rename"
 msgstr ""
 
-#: cv/ui/manager/contextmenu/FileItem.js:315
+#: cv/ui/manager/contextmenu/FileItem.js
 msgid "Open"
 msgstr ""
 
-#: cv/ui/manager/contextmenu/FileItem.js:322
+#: cv/ui/manager/contextmenu/FileItem.js
 msgid "Restore"
 msgstr ""
 
-#: cv/ui/manager/contextmenu/FileItem.js:334
+#: cv/ui/manager/contextmenu/FileItem.js
 msgid "Replace"
 msgstr ""
 
-#: cv/ui/manager/contextmenu/FileItem.js:346
+#: cv/ui/manager/contextmenu/FileItem.js
 msgid "Compare with..."
 msgstr ""
 
-#: cv/ui/manager/contextmenu/FileItem.js:350
+#: cv/ui/manager/contextmenu/FileItem.js
 msgid "Open with..."
 msgstr ""
 
-#: cv/ui/manager/control/FileController.js:39
+#: cv/ui/manager/control/FileController.js
 msgid "File \"%1\" has been created"
 msgstr ""
 
-#: cv/ui/manager/control/FileController.js:40
+#: cv/ui/manager/control/FileController.js
 msgid "Folder \"%1\" has been created"
 msgstr ""
 
-#: cv/ui/manager/control/FileController.js:54
+#: cv/ui/manager/control/FileController.js
 msgid "File \"%1\" has been renamed"
 msgstr ""
 
-#: cv/ui/manager/control/FileController.js:55
+#: cv/ui/manager/control/FileController.js
 msgid "Folder \"%1\" has been renamed"
 msgstr ""
 
-#: cv/ui/manager/control/FileController.js:77
+#: cv/ui/manager/control/FileController.js
 msgid "File \"%1\" has been moved"
 msgstr ""
 
-#: cv/ui/manager/control/FileController.js:78
+#: cv/ui/manager/control/FileController.js
 msgid "Folder \"%1\" has been moved"
 msgstr ""
 
-#: cv/ui/manager/control/FileController.js:125
-#: cv/ui/manager/control/FileController.js:144
+#: cv/ui/manager/control/FileController.js
 msgid "%1 has been restored"
 msgstr ""
 
-#: cv/ui/manager/control/FileController.js:160
+#: cv/ui/manager/control/FileController.js
 msgid "File \"%1\" has been restored"
 msgstr ""
 
-#: cv/ui/manager/control/FileController.js:161
+#: cv/ui/manager/control/FileController.js
 msgid "Folder \"%1\" has been restored"
 msgstr ""
 
-#: cv/ui/manager/control/FileController.js:181
+#: cv/ui/manager/control/FileController.js
 msgid "Do you really want to clear the trash?"
 msgstr ""
 
-#: cv/ui/manager/control/FileController.js:184
+#: cv/ui/manager/control/FileController.js
 msgid "Do you really want to delete file \"%1\" from the trash?"
 msgstr ""
 
-#: cv/ui/manager/control/FileController.js:185
+#: cv/ui/manager/control/FileController.js
 msgid "Do you really want to delete folder \"%1\" from the trash?"
 msgstr ""
 
-#: cv/ui/manager/control/FileController.js:188
+#: cv/ui/manager/control/FileController.js
 msgid "Do you really want to delete file \"%1\"?"
 msgstr ""
 
-#: cv/ui/manager/control/FileController.js:189
+#: cv/ui/manager/control/FileController.js
 msgid "Do you really want to delete folder \"%1\"?"
 msgstr ""
 
-#: cv/ui/manager/control/FileController.js:197
+#: cv/ui/manager/control/FileController.js
 msgid "Confirm deletion"
 msgstr ""
 
-#: cv/ui/manager/control/FileController.js:212
+#: cv/ui/manager/control/FileController.js
 msgid "Trash has been cleared"
 msgstr ""
 
-#: cv/ui/manager/control/FileController.js:215
+#: cv/ui/manager/control/FileController.js
 msgid "File \"%1\" has been removed from trash"
 msgstr ""
 
-#: cv/ui/manager/control/FileController.js:216
+#: cv/ui/manager/control/FileController.js
 msgid "Folder \"%1\" has been removed from trash"
 msgstr ""
 
-#: cv/ui/manager/control/FileController.js:219
+#: cv/ui/manager/control/FileController.js
 msgid "File \"%1\" has been deleted"
 msgstr ""
 
-#: cv/ui/manager/control/FileController.js:220
+#: cv/ui/manager/control/FileController.js
 msgid "Folder \"%1\" has been deleted"
 msgstr ""
 
-#: cv/ui/manager/control/FileController.js:257
+#: cv/ui/manager/control/FileController.js
 msgid "Validating %1"
 msgstr ""
 
-#: cv/ui/manager/control/FileController.js:262
+#: cv/ui/manager/control/FileController.js
 msgid "%1 has no errors!"
 msgstr ""
 
-#: cv/ui/manager/control/FileController.js:270
+#: cv/ui/manager/control/FileController.js
 msgid "%1 error found in %2!"
 msgid_plural "%1 errors found in %2!"
 msgstr[0] ""
 msgstr[1] ""
 
-#: cv/ui/manager/editor/AbstractEditor.js:114
+#: cv/ui/manager/editor/AbstractEditor.js
 msgid "File has been created"
 msgstr ""
 
-#: cv/ui/manager/editor/Config.js:121
+#: cv/ui/manager/editor/Config.js
 msgid "Section name duplicate: \"%1\"."
 msgstr ""
 
-#: cv/ui/manager/editor/Config.js:131
+#: cv/ui/manager/editor/Config.js
 msgid "Option key duplicate: \"%1\" in section \"%2\"."
 msgstr ""
 
-#: cv/ui/manager/editor/Config.js:140
+#: cv/ui/manager/editor/Source.js
 msgid "Saving hidden config failed with error %1 (%2)"
 msgstr ""
 
-#: cv/ui/manager/editor/Config.js:142
+#: cv/ui/manager/editor/Source.js
 msgid "Hidden config has been saved"
 msgstr ""
 
-#: cv/ui/manager/editor/Config.js:147
+#: cv/ui/manager/editor/Config.js
 msgid "Section is invalid and has not been saved."
 msgstr ""
 
-#: cv/ui/manager/editor/Config.js:183
+#: cv/ui/manager/editor/Config.js
 msgid "Add section"
 msgstr ""
 
-#: cv/ui/manager/editor/Diff.js:24
+#: cv/ui/manager/editor/Diff.js
 msgid "File compare"
 msgstr ""
 
-#: cv/ui/manager/editor/Source.js:46
+#: cv/ui/manager/editor/Source.js
 msgid "Texteditor"
 msgstr ""
 
-#: cv/ui/manager/editor/Xml.js:27
+#: cv/ui/manager/editor/Xml.js
 msgid "Xml-editor"
 msgstr ""
 
-#: cv/ui/manager/editor/completion/Config.js:408
+#: cv/ui/manager/editor/completion/Config.js
 msgid "Variable from template %1"
 msgstr ""
 
-#: cv/ui/manager/form/FileListItem.js:29
+#: cv/ui/manager/form/FileListItem.js
 msgid "Drop the file here to replace the content."
 msgstr ""
 
-#: cv/ui/manager/form/FileListItem.js:220
-msgid ""
-"Do you really want to replace the \'%1\' with the uploaded files content?"
+#. NO LONGER USED
+msgid "Do you really want to replace the \'%1\' with the uploaded files content?"
 msgstr ""
 
-#: cv/ui/manager/form/FileListItem.js:235
+#: cv/ui/manager/form/FileListItem.js
 msgid "Double click to open \"%1\""
 msgstr ""
 
-#: cv/ui/manager/form/FileListItem.js:402
+#: cv/ui/manager/form/FileListItem.js
 msgid "Download file"
 msgstr ""
 
-#: cv/ui/manager/form/FileListItem.js:411
+#: cv/ui/manager/form/FileListItem.js
 msgid "Other file actions"
 msgstr ""
 
-#: cv/ui/manager/form/FileTabItem.js:167
+#: cv/ui/manager/form/FileTabItem.js
 msgid "This file is not writeable"
 msgstr ""
 
-#: cv/ui/manager/form/OptionListItem.js:130
+#: cv/ui/manager/form/OptionListItem.js
 msgid "Delete option"
 msgstr ""
 
-#: cv/ui/manager/form/OptionListItem.js:139
+#: cv/ui/manager/form/OptionListItem.js
 msgid "Add option"
 msgstr ""
 
-#: cv/ui/manager/form/OptionListItem.js:147
+#: cv/ui/manager/form/OptionListItem.js
 msgid "Key"
 msgstr ""
 
-#: cv/ui/manager/form/OptionListItem.js:153
+#: cv/ui/manager/form/OptionListItem.js
 msgid "Value"
 msgstr ""
 
-#: cv/ui/manager/form/SectionListItem.js:154
+#: cv/ui/manager/form/SectionListItem.js
 msgid "Section"
 msgstr ""
 
-#: cv/ui/manager/form/SectionListItem.js:169
+#: cv/ui/manager/form/SectionListItem.js
 msgid "Delete section"
 msgstr ""
 
-#: cv/ui/manager/model/CompareFiles.js:76
+#: cv/ui/manager/model/CompareFiles.js
 msgid "Diff: %1"
 msgstr ""
 
-#: cv/ui/manager/tree/VirtualFsItem.js:83
+#: cv/ui/manager/tree/VirtualFsItem.js
 msgid "Trash"
 msgstr ""
 
-#: cv/ui/manager/upload/UploadMgr.js:95
+#: cv/ui/manager/upload/UploadMgr.js
 msgid "Replacing the file failed."
 msgstr ""
 
-#: cv/ui/manager/upload/UploadMgr.js:97
+#: cv/ui/manager/upload/UploadMgr.js
 msgid "This file already exists, do you want to replace it?"
 msgstr ""
 
-#: cv/ui/manager/upload/UploadMgr.js:101
+#: cv/ui/manager/upload/UploadMgr.js
 msgid "File already exists"
 msgstr ""
 
-#: cv/ui/manager/upload/UploadMgr.js:106
+#: cv/ui/manager/upload/UploadMgr.js
 msgid "Uploading this file is not allowed here."
 msgstr ""
 
-#: cv/ui/manager/upload/UploadMgr.js:116
+#: cv/ui/manager/upload/UploadMgr.js
 msgid "File upload stopped with an error: %1"
 msgstr ""
 
-#: cv/ui/manager/upload/UploadMgr.js:120
+#: cv/ui/manager/upload/UploadMgr.js
 msgid "File has been uploaded"
 msgstr ""
 
-#: cv/ui/manager/viewer/Config.js:37
+#: cv/ui/manager/viewer/Config.js
 msgid "Config viewer"
 msgstr ""
 
-#: cv/ui/manager/viewer/Config.js:61
+#: cv/ui/manager/viewer/Config.js
 msgid "%1 is no configuration file"
 msgstr ""
 
-#: cv/ui/manager/viewer/Folder.js:55
+#: cv/ui/manager/viewer/Folder.js
 msgid "Show folder"
 msgstr ""
 
-#: cv/ui/manager/viewer/Folder.js:370
+#: cv/ui/manager/viewer/Folder.js
 msgid "Filter by name..."
 msgstr ""
 
-#: cv/ui/manager/viewer/Icons.js:24
+#: cv/ui/manager/viewer/Icons.js
 msgid "Show icons"
 msgstr ""
 
-#: cv/ui/manager/viewer/Image.js:36
+#: cv/ui/manager/viewer/Image.js
 msgid "Show image"
 msgstr ""
 
-#: cv/ui/structure/pure/Unknown.js:88
+#: cv/ui/structure/pure/Unknown.js
 msgid "unknown: %1"
 msgstr ""
 
-#: cv/util/ConfigLoader.js:172
+#: cv/util/ConfigLoader.js
 msgid "Config-File Error!"
 msgstr ""
 
-#: cv/util/ConfigLoader.js:176
+#: cv/util/ConfigLoader.js
 msgid "Invalid config file!"
 msgstr ""
 
-#: cv/util/ConfigLoader.js:176
+#: cv/util/ConfigLoader.js
 msgid "Please check!"
 msgstr ""
 
-#: cv/util/ConfigLoader.js:184
+#: cv/util/ConfigLoader.js
 msgid "Config file has wrong library version!"
 msgstr ""
 
-#: cv/util/ConfigLoader.js:185
+#: cv/util/ConfigLoader.js
 msgid "This can cause problems with your configuration"
 msgstr ""
 
-#: cv/util/ConfigLoader.js:186
+#: cv/util/ConfigLoader.js
 msgid "You can run the %1Configuration Upgrader%2."
 msgstr ""
 
-#: cv/util/ConfigLoader.js:187
-msgid ""
-"Or you can start without upgrading %1with possible configuration problems%2"
+#: cv/util/ConfigLoader.js
+msgid "Or you can start without upgrading %1with possible configuration problems%2"
 msgstr ""
 
-#: cv/util/ConfigLoader.js:190
-msgid ""
-"404: Config file not found. Neither as normal config (%1) nor as demo config"
-" (%2)."
+#: cv/util/ConfigLoader.js
+msgid "404: Config file not found. Neither as normal config (%1) nor as demo config (%2)."
 msgstr ""
 
-#: cv/util/ConfigLoader.js:193
+#: cv/util/ConfigLoader.js
 msgid "Unhandled error of type \"%1\""
 msgstr ""
 
-#: cv/util/ScriptLoader.js:157
+#: cv/util/ScriptLoader.js
 msgid "Error loading plugin \"%1\""
 msgstr ""
 
-#: cv/util/ScriptLoader.js:158 cv/util/ScriptLoader.js:166
+#: cv/util/ScriptLoader.js
 msgid "File %1 could not be loaded."
 msgstr ""
 
-#: cv/util/ScriptLoader.js:165
+#: cv/util/ScriptLoader.js
 msgid "File loading error"
 msgstr ""
 
-#~ msgid "Close file"
-#~ msgstr ""
+#: cv/Application.js
+msgid "Validating configuration file..."
+msgstr ""
 
-#~ msgid "Do you really want to delete this file from the trash?"
-#~ msgstr ""
+#: cv/Application.js
+msgid "The %1 configuration has no errors!"
+msgstr ""
 
-#~ msgid "Do you really want to delete this file?"
-#~ msgstr ""
+#: cv/Application.js
+msgid "The %1 configuration has %2 errors!"
+msgstr ""
 
-#~ msgid "Do you really want to delete this folder from the trash?"
-#~ msgstr ""
+#: cv/Application.js
+msgid "Show errors"
+msgstr ""
 
-#~ msgid "Do you really want to delete this folder?"
-#~ msgstr ""
+#: cv/ui/manager/Main.js
+msgid "Please enter the name of the new configuration (without \"visu_config_\" at the beginning and \".xml\" at the end)"
+msgstr ""
 
-#~ msgid "Double click to open"
-#~ msgstr ""
+#: cv/ui/manager/editor/Diff.js
+msgid "Config file has been upgraded to the current library version."
+msgstr ""
 
-#~ msgid "Edit hidden config"
-#~ msgstr ""
+#: cv/ui/manager/editor/Diff.js
+msgid "The following changes have been made"
+msgstr ""
 
-#~ msgid "Enable error reporting"
-#~ msgstr ""
+#: cv/ui/manager/editor/Diff.js
+msgid "You can check the changes in the editor. The left side shows the content before the upgrade and the right side shows the content after the upgrade."
+msgstr ""
 
-#~ msgid "Enable error sending on reload"
-#~ msgstr ""
+#. NO LONGER USED
+msgid "Changes are highlighted. Please save the file and reload the browser to apply the changes."
+msgstr ""
 
-#~ msgid "Enable reporting on reload"
-#~ msgstr ""
+#: cv/ui/manager/editor/Diff.js
+msgid "Upgrade successful"
+msgstr ""
 
-#~ msgid "Entries"
-#~ msgstr ""
+#: cv/ui/manager/editor/Source.js
+msgid "Hidden config is invalid, please correct the errors"
+msgstr ""
 
-#~ msgid "File has been deleted"
-#~ msgstr ""
+#: cv/ui/manager/editor/Source.js
+msgid "Hidden config content has some warnings! It is recommended to fix the warnings before saving. Save anyways?"
+msgstr ""
 
-#~ msgid "File has been moved"
-#~ msgstr ""
+#: cv/ui/manager/editor/Source.js
+msgid "Confirm saving with warnings"
+msgstr ""
 
-#~ msgid "File has been removed from trash"
-#~ msgstr ""
+#: cv/ui/manager/editor/Xml.js
+msgid "The XML-Editor does not support files that are not writeable!"
+msgstr ""
 
-#~ msgid "File has been renamed"
-#~ msgstr ""
+#: cv/ui/manager/form/FileListItem.js
+msgid "Do you really want to replace the '%1' with the uploaded files content?"
+msgstr ""
 
-#~ msgid "File has been restored"
-#~ msgstr ""
+#: cv/TemplateEngine.js
+msgid "The backend did send an invalid response to a %1read%2 request: Missing \"i\" value."
+msgstr ""
 
-#~ msgid "Folder has been deleted"
-#~ msgstr ""
+#: cv/util/ConfigUpgrader.js
+msgid "Upgrader from version %1 not implemented"
+msgstr ""
 
-#~ msgid "Folder has been moved"
-#~ msgstr ""
+#. NO LONGER USED
+msgid "Click \"yes\" if you want to save the changes and reload the browser."
+msgstr ""
 
-#~ msgid "Folder has been removed from trash"
-#~ msgstr ""
+#. NO LONGER USED
+msgid "Click \"no\" if you want to check the changes. You have to save the changes and reload your browser yourself in this case."
+msgstr ""
 
-#~ msgid "Folder has been renamed"
-#~ msgstr ""
+#: cv/ui/manager/editor/Diff.js
+msgid "Click \"Apply\" if you want to save the changes and reload the browser."
+msgstr ""
 
-#~ msgid "Folder has been restored"
-#~ msgstr ""
+#: cv/ui/manager/editor/Diff.js
+msgid "Click \"Check\" if you want to check the changes. You have to save the changes and reload your browser yourself in this case."
+msgstr ""
 
-#~ msgid "Report Bug"
-#~ msgstr ""
+#: cv/ui/manager/editor/Diff.js
+msgid "Apply"
+msgstr ""
+
+#: cv/ui/manager/editor/Diff.js
+msgid "Check"
+msgstr ""

--- a/utils/compile/AbstractCompileHandler.js
+++ b/utils/compile/AbstractCompileHandler.js
@@ -32,6 +32,7 @@ class AbstractCompileHandler {
       revision: revision,
       branch: branch,
       date: new Date().toISOString(),
+      libraryVersion: 0,
       tags: []
     }
     Object.keys(this._customSettings).forEach(key => {
@@ -43,7 +44,16 @@ class AbstractCompileHandler {
       data.tags[data.tags.length - 1].last = true
     }
     const packageData = JSON.parse(fs.readFileSync("package.json"));
-    data.version = packageData.version
+    data.version = packageData.version;
+
+    // get library version
+    const libVer = fs.readFileSync(path.join("source", "library_version.inc.php"));
+    const match = /LIBRARY_VERSION',\s?([\d]+)/gm.exec(libVer);
+
+    if (match) {
+      data.libraryVersion = match[1];
+    }
+
     const code = mustache.render(`
 qx.Class.define("cv.Version", {
   type: "static",
@@ -52,6 +62,7 @@ qx.Class.define("cv.Version", {
     REV: "{{ revision }}",
     BRANCH: "{{ branch }}",
     VERSION: "{{ version }}",
+    LIBRARY_VERSION: {{ libraryVersion }},
     DATE: "{{ date }}",
     TAGS: { {{#tags}}
       {{ name }}: "{{value}}"{{^last}},{{/last}}{{/tags}}

--- a/utils/compile/AbstractCompileHandler.js
+++ b/utils/compile/AbstractCompileHandler.js
@@ -47,12 +47,7 @@ class AbstractCompileHandler {
     data.version = packageData.version;
 
     // get library version
-    const libVer = fs.readFileSync(path.join("source", "library_version.inc.php"));
-    const match = /LIBRARY_VERSION',\s?([\d]+)/gm.exec(libVer);
-
-    if (match) {
-      data.libraryVersion = match[1];
-    }
+    data.libraryVersion = packageData.org_cometvisu.libraryVersion;
 
     const code = mustache.render(`
 qx.Class.define("cv.Version", {


### PR DESCRIPTION
* remove old links to config checking and config upgrading
* implement a client side config upgrader (only from version =>7) that shows the changes in the diff editor
* open text editor with validation errors if the validation failed
* fix automatic library version  check when a config is loaded
* another compiler upgrade + fixes in tests to avoid accessing private members
* upgrade all lib_versions references the the current one (9)
* strip down the build by not copying the monaco editor dev files
* add some missing `;` in the compiler files