### PR TITLE
Fix error pop up and rsslog

### DIFF
--- a/client/source/class/cv/io/parser/Json.js
+++ b/client/source/class/cv/io/parser/Json.js
@@ -23,7 +23,8 @@ qx.Class.define('cv.io.parser.Json', {
               var jsonString = i === 0 ? subData + "}" : "{" + subData;
               result = $.extend(result, JSON.parse(jsonString));
             } catch (se) {
-              qx.log.Logger.error(se);
+              qx.log.Logger.error(se, data);
+              result = data; // return the bad input
             }
           }, this);
         }
@@ -39,7 +40,8 @@ qx.Class.define('cv.io.parser.Json', {
               var jsonString = i === 0 ? subData + "}" : "{" + subData;
               result = Object.assign(result, JSON.parse(jsonString));
             } catch (se) {
-              qx.log.Logger.error(se);
+              qx.log.Logger.error(se, data);
+              result = data; // return the bad input
             }
           }, this);
         }

--- a/client/source/class/cv/io/transport/LongPolling.js
+++ b/client/source/class/cv/io/transport/LongPolling.js
@@ -143,6 +143,7 @@ qx.Class.define('cv.io.transport.LongPolling', {
         if (!json.hasOwnProperty('i')) {
           this.error('CometVisu protocol error: backend responded to a read request without an "i"-parameter');
           this.client.showError(cv.io.Client.ERROR_CODES.PROTOCOL_INVALID_READ_RESPONSE_MISSING_I, json);
+          return;
         }
         this.lastIndex = json.i;
         data = json.d;

--- a/source/class/cv/TemplateEngine.js
+++ b/source/class/cv/TemplateEngine.js
@@ -345,8 +345,12 @@ qx.Class.define('cv.TemplateEngine', {
 
     _handleClientError: function (errorCode, varargs) {
       varargs = Array.prototype.slice.call(arguments, 1);
-      var notification;
-      var message = '';
+      varargs = JSON.stringify(varargs[0], null, 2);
+      // escape HTML:
+      let div = document.createElement('div');
+      div.innerText = varargs;
+      varargs = div.innerHTML;
+      let notification;
       switch (errorCode) {
         case cv.io.Client.ERROR_CODES.PROTOCOL_MISSING_VERSION:
           notification = {
@@ -356,7 +360,7 @@ qx.Class.define('cv.TemplateEngine', {
               '<a href="https://github.com/CometVisu/CometVisu/wiki/Protocol#Login" target="_blank">',
               '</a>') + '<br/>' +
               qx.locale.Manager.tr('Please try to fix the problem in the backend.') +
-            '<br/><br/><strong>' + qx.locale.Manager.tr('Backend-Response:') + '</strong><pre>' + JSON.stringify(varargs[0], null, 2) +'</pre></div>',
+            '<br/><br/><strong>' + qx.locale.Manager.tr('Backend-Response:') + '</strong><pre>' + varargs + '</pre></div>',
             severity: "urgent",
             unique: true,
             deletable: false
@@ -371,7 +375,7 @@ qx.Class.define('cv.TemplateEngine', {
               '<a href="https://github.com/CometVisu/CometVisu/wiki/Protocol#Login" target="_blank">',
               '</a>') + '<br/>' +
               qx.locale.Manager.tr('Please try to fix the problem in the backend.') +
-              '<br/><br/><strong>' + qx.locale.Manager.tr('Backend-Response:') + '</strong><pre>' + JSON.stringify(varargs[0], null, 2) +'</pre></div>',
+              '<br/><br/><strong>' + qx.locale.Manager.tr('Backend-Response:') + '</strong><pre>' + varargs +'</pre></div>',
             severity: "urgent",
             unique: true,
             deletable: false

--- a/source/class/cv/plugins/RssLog.js
+++ b/source/class/cv/plugins/RssLog.js
@@ -21,7 +21,7 @@
 /**
  * @author Michael Markstaller
  * @since 2011
- * @asset(plugins/rsslog/rsslog.css)
+ * @asset(plugins/rsslog/*)
  */
 qx.Class.define('cv.plugins.RssLog', {
   extend: cv.ui.structure.AbstractWidget,
@@ -217,7 +217,8 @@ qx.Class.define('cv.plugins.RssLog', {
 
     _action: function () {
       var brss = cv.util.String.htmlStringToDomElement('<div class="rsslog_popup" id="rss_' + this.getPath() + '_big"/>');
-      var title = document.querySelector('#' + this.getPath() + ' .label').innerText || '';
+      var label = document.querySelector('#' + this.getPath() + ' .label');
+      var title = label ? (label.innerText || '') : '';
       var popup = cv.ui.PopupHandler.showPopup("rsslog", {title: title, content: brss});
       var parent = cv.util.Tree.getParent(brss, "div", null, 1)[0];
       Object.entries({height: "90%", width: "90%", margin: "auto"}).forEach(function(key_value){parent.style[key_value[0]]=key_value[1];}); // define parent as 100%!

--- a/source/class/cv/ui/Popup.js
+++ b/source/class/cv/ui/Popup.js
@@ -94,7 +94,7 @@ qx.Class.define('cv.ui.Popup', {
         ret_val = this.__domElement = qx.dom.Element.create("div", {
           id: "popup_" + this.__counter,
           "class": classes.join(" "),
-          style: "display:none",
+          style: "visibility:hidden",
           html: closable ? '<div class="popup_close">X</div>' : ""
         });
         body.appendChild(ret_val);
@@ -262,8 +262,8 @@ qx.Class.define('cv.ui.Popup', {
         align
       );
 
-      ret_val.style.left = placement.x;
-      ret_val.style.top  = placement.y;
+      ret_val.style.left = placement.x + 'px';
+      ret_val.style.top  = placement.y + 'px';
 
       if (!closable && ret_val.querySelector('.reload') === null) {
         var reload = '<div class="reload">' +
@@ -289,7 +289,7 @@ qx.Class.define('cv.ui.Popup', {
 
       attributes.id = this.__counter;
       if (isNew) {
-        ret_val.style.display = 'block';
+        ret_val.style.visibility = 'visible';
         this.__counter++;
       }
       return ret_val;

--- a/source/class/cv/ui/Popup.js
+++ b/source/class/cv/ui/Popup.js
@@ -265,7 +265,7 @@ qx.Class.define('cv.ui.Popup', {
       ret_val.style.left = placement.x;
       ret_val.style.top  = placement.y;
 
-      if (!closable) {
+      if (!closable && ret_val.querySelector('.reload') === null) {
         var reload = '<div class="reload">' +
           '<a href="javascript:location.reload(true);">' +
           qx.locale.Manager.tr('Reload').toString() +

--- a/source/resource/designs/designglobals.css
+++ b/source/resource/designs/designglobals.css
@@ -444,9 +444,6 @@ button.ui-slider-handle {
 .popup_background.notification {
   position: absolute;
   padding: 30px;
-  top: 50%;
-  transform: translate(-50%, -50%);
-  left: 50%;
   width: auto;
   height: auto;
   max-width: calc(100vw - 60px);

--- a/source/resource/designs/designglobals.css
+++ b/source/resource/designs/designglobals.css
@@ -488,7 +488,7 @@ button.ui-slider-handle {
   overflow-y: auto;
 }
 
-.popup .main .icon:not(.spinner):not(.rsslogRow) {
+.popup .main > div > .icon:not(.spinner) {
   float: left;
   margin: 0 1em 0 0;
   vertical-align: top;


### PR DESCRIPTION
This pull request fixes:
- error pop up is showing a huge number of "neu laden"
- a bad backend response during start up (e.g. a 404 page with HTML text instead of a JSON for "l") was giving a bad hint (only a "{}" response text instead of the real one)
- the error pop up might sometime end up half way out of the left side of the screen
- the rsslog didn't work anymore as the PHP file was missing in the compilation
- the rsslog popup looked broken as the icons were too big