### PR TITLE
fixes for openHAB REST API client

### DIFF
--- a/source/class/cv/util/ConfigLoader.js
+++ b/source/class/cv/util/ConfigLoader.js
@@ -81,14 +81,21 @@ qx.Class.define('cv.util.ConfigLoader', {
             this.configError("libraryerror");
           }
           else {
+            let backendName = ""
+            if (req.getResponseHeader("X-CometVisu-Backend-Name")) {
+              backendName = req.getResponseHeader("X-CometVisu-Backend-Name");
+            }
             if (req.getResponseHeader("X-CometVisu-Backend-LoginUrl")) {
               cv.Config.backendUrl = req.getResponseHeader("X-CometVisu-Backend-LoginUrl");
               if (!cv.Config.backendUrl.endsWith('/')) {
                 cv.Config.backendUrl += '/';
               }
+              if (!backendName && cv.Config.backendUrl.startsWith("/rest/")) {
+                backendName = "openhab";
+              }
             }
-            if (req.getResponseHeader("X-CometVisu-Backend-Name")) {
-              cv.Config.backend = req.getResponseHeader("X-CometVisu-Backend-Name");
+            if (backendName) {
+              cv.Config.backend = backendName;
             }
             this._checkQueue();
           }


### PR DESCRIPTION
- guess backend name from url when no name is set
- fix openhab active group member handling for rest client

This PR makes things like:

```xml
<info format="%d">
   <address transform="OH:number" mode="read">number:Windows</address>
</info>
```
work again. It counts the number of open windows in an openHAB GroupItem. Basically all GroupItems inside that group are counted, which have an "active" state (e.g. switches with state ON, contacts with state OPENED, etc.). This is not a new feature, the old openHAB-ConetVisu backend already supported this.

The other fix is just an fallback if the use has not defined a backend name in the config, but uses the docker image to serve the cometvisu.