### PR TITLE
obey mobile state when restoring cache

### DIFF
--- a/source/class/cv/ConfigCache.js
+++ b/source/class/cv/ConfigCache.js
@@ -99,6 +99,16 @@ qx.Class.define('cv.ConfigCache', {
             }
           }, this);
         }
+        if (cv.Config.mobileDevice) {
+          document.querySelector('body').classList.add('mobile');
+          const hasMobile = cv.Config.configSettings.stylesToLoad.some(style => style.endsWith('mobile.css'));
+          if (!hasMobile) {
+            cv.Config.configSettings.stylesToLoad.push("design/" + cv.Config.configSettings.clientDesign + "/mobile.css");
+          }
+        } else {
+          // do not load mobile css
+          cv.Config.configSettings.stylesToLoad = cv.Config.configSettings.stylesToLoad.filter(style => !style.endsWith('mobile.css'));
+        }
         model.setWidgetDataModel(cache.data);
         model.setAddressList(cache.addresses);
         const widgetsToInitialize = Object.keys(cache.data).filter(function (widgetId) {


### PR DESCRIPTION
Caching did not work when used on mobile because the "mobile" class that is added to the `<body>` is not part of the cache and has to be set manually when cache is used.

Also the need of loading the mobile.css is checked when restoring from cache. This is a developer only optimization because this can only happen if the same device can switch between mobile and non mobile use and thats only possible when you use the device emulation in the browsers developer tools (or manually change the user agent of yout browser)