### PR TITLE
allow editing of 'custom' childs (where no schema support is given, e…

### DIFF
--- a/source/class/cv/ui/manager/editor/Tree.js
+++ b/source/class/cv/ui/manager/editor/Tree.js
@@ -1611,19 +1611,22 @@ qx.Class.define('cv.ui.manager.editor.Tree', {
         });
         if (typeElement.isChildElementAllowed('*')) {
           const parser = new DOMParser();
-          formData['#outerHTML'] = {
+          const attrName = element.getNode().nodeName === 'custom' ? '#innerHTML' : '#outerHTML';
+          formData[attrName] = {
             type: "TextArea",
             label: "",
             lines: 5,
             autoSize: true,
             width: Math.min(qx.bom.Viewport.getWidth(), 500),
             enabled: element.isEditable(),
-            value: element.getNode().outerHTML,
+            value: attrName === '#outerHTML' ? element.getNode().outerHTML : element.getNode().innerHTML,
             validation: {
               validator: function (value) {
-                const dom = parser.parseFromString(value, "text/xml");
-                if (dom.getElementsByTagName('parsererror').length > 0) {
-                  throw new qx.core.ValidationError(qx.locale.Manager.tr("This is not a valid value."));
+                if (value) {
+                  const dom = parser.parseFromString(value, "text/xml");
+                  if (dom.getElementsByTagName('parsererror').length > 0) {
+                    throw new qx.core.ValidationError(qx.locale.Manager.tr("This is not a valid value."));
+                  }
                 }
               }
             }

--- a/source/class/cv/ui/manager/editor/Tree.js
+++ b/source/class/cv/ui/manager/editor/Tree.js
@@ -1425,10 +1425,7 @@ qx.Class.define('cv.ui.manager.editor.Tree', {
             let res = Promise.resolve(true);
             if (xmlElement.isShowEditButton()) {
               // only show edit dialog when we actually have something to edit
-              res = this._onEdit(null, xmlElement,
-                this.tr("Create new %1 element", xmlElement.getName()),
-                this.tr("Please edit the attributes of the new %1 element, that will be added to the chosen position.", xmlElement.getName())
-              );
+              res = this._onEdit(null, xmlElement, true);
             }
             res.then((data) => {
               if (data) {
@@ -1579,10 +1576,11 @@ qx.Class.define('cv.ui.manager.editor.Tree', {
       return def;
     },
 
-    _onEdit: function (ev, element, title, caption) {
+    _onEdit: function (ev, element, isNew) {
       if (!this.getFile() || !this.getFile().isWriteable()) {
         return;
       }
+      let title, caption;
       if (!element) {
         if (this.getSelected()) {
           element = this.getSelected();
@@ -1596,6 +1594,13 @@ qx.Class.define('cv.ui.manager.editor.Tree', {
       element.load();
       const formData = {};
       const typeElement = element.getSchemaElement();
+      if (isNew) {
+        title = this.tr("Create new %1 element", element.getName());
+        caption = this.tr("Please edit the attributes of the new %1 element, that will be added to the chosen position.", element.getName());
+      } else {
+        title = this.tr("Edit element attributes");
+        caption = element.isEditable() ? this.tr("Edit %1", element.getName()) : this.tr("Show %1", element.getName());
+      }
       if (element.getNode().nodeType === Node.ELEMENT_NODE) {
         const allowed = typeElement.getAllowedAttributes();
         Object.keys(allowed).forEach(name => {
@@ -1612,6 +1617,12 @@ qx.Class.define('cv.ui.manager.editor.Tree', {
         if (typeElement.isChildElementAllowed('*')) {
           const parser = new DOMParser();
           const attrName = element.getNode().nodeName === 'custom' ? '#innerHTML' : '#outerHTML';
+          if (isNew) {
+            title = this.tr("Create new %1 element", element.getName());
+            caption = this.tr("Please edit the content of the new %1 element, that will be added to the chosen position.", element.getName());
+          } else {
+            title = attrName === '#outerHTML' ? this.tr("Edit element and content") : this.tr("Edit element content");
+          }
           formData[attrName] = {
             type: "TextArea",
             label: "",
@@ -1633,6 +1644,8 @@ qx.Class.define('cv.ui.manager.editor.Tree', {
           }
         }
       } else if (element.getNode().nodeType === Node.TEXT_NODE || element.getNode().nodeType === Node.COMMENT_NODE || element.getNode().nodeType === Node.CDATA_SECTION_NODE) {
+        title = this.tr("Edit text content", element.getName());
+        caption = "";
         let nodeName = element.getNode().nodeName;
         // only in text-only mode we can add text editing to the form
         const docs = typeElement.getDocumentation();
@@ -1679,11 +1692,12 @@ qx.Class.define('cv.ui.manager.editor.Tree', {
         this.__checkProvider(element.getParent().getName() + "@" + element.getName(), formData[nodeName], element.getNode());
       }
       this.__editing = true;
+
       const formDialog = new cv.ui.manager.form.ElementForm({
         allowCancel: true,
         context: this,
-        caption:  title || this.tr("Edit element attributes"),
-        message: caption ? caption : (element.isEditable() ? this.tr("Edit %1", element.getName()) : this.tr("Show %1", element.getName())),
+        caption:  title,
+        message: caption,
         formData: formData,
         minWidth: Math.min(qx.bom.Viewport.getWidth(), 400),
         maxWidth: qx.bom.Viewport.getWidth()
@@ -1693,7 +1707,7 @@ qx.Class.define('cv.ui.manager.editor.Tree', {
           // save changes
           element.setAttributes(data);
           this.clearReDos();
-          if (!data.hasOwnProperty('#outerHTML')) {
+          if (!data.hasOwnProperty('#outerHTML') && !data.hasOwnProperty('#innerHTML')) {
             element.validate();
           }
         }

--- a/source/class/cv/ui/manager/model/XmlElement.js
+++ b/source/class/cv/ui/manager/model/XmlElement.js
@@ -901,24 +901,39 @@ qx.Class.define('cv.ui.manager.model.XmlElement', {
           if (change.changed) {
             parentChanges.push(change);
           }
-        } else if (attrName === '#outerHTML') {
+        } else if (attrName === '#outerHTML' || attrName === "#innerHTML") {
           if (this.getSchemaElement().isChildElementAllowed('*')) {
             const dom = new DOMParser().parseFromString(data[attrName], 'text/xml');
             if (dom.getElementsByTagName('parsererror').length === 0) {
-              const oldValue = this._node.outerHTML;
-              const oldNode = this._node;
+              const oldValue = attrName === '#outerHTML' ? this._node.outerHTML : this._node.innerHTML;
               const newNode = dom.documentElement;
-              oldNode.parentNode.replaceChild(newNode, oldNode);
-              this._node = newNode;
+              if (attrName === '#outerHTML') {
+                const oldNode = this._node;
+                oldNode.parentNode.replaceChild(newNode, oldNode);
+                this._node = newNode;
+                this.setName(this._node.nodeName);
+              } else {
+                this._node.innerHTML = data[attrName];
+              }
               changes.push({
                 changed: true,
                 attribute: attrName,
                 value: data[attrName],
                 old: oldValue
               });
-              this.setName(this._node.nodeName);
               this.load(true);
             }
+          } else if (attrName === "#innerHTML" && !data[attrName]) {
+            // allow empty values
+            const oldValue = this._node.innerHTML;
+            this._node.innerHTML = data[attrName];
+            changes.push({
+              changed: true,
+              attribute: attrName,
+              value: data[attrName],
+              old: oldValue
+            });
+            this.load(true);
           }
         } else {
           change = this.setAttribute(attrName, data[attrName]);

--- a/source/class/cv/ui/manager/model/XmlElement.js
+++ b/source/class/cv/ui/manager/model/XmlElement.js
@@ -257,7 +257,12 @@ qx.Class.define('cv.ui.manager.model.XmlElement', {
     },
 
     _updateShowEditButton: function () {
-      this.setShowEditButton(this.getSchemaElement().isTextContentAllowed() && this.getName().startsWith('#') || Object.keys(this.getSchemaElement().getAllowedAttributes()).length > 0);
+      const schemaElement = this.getSchemaElement();
+      this.setShowEditButton(
+        schemaElement.isTextContentAllowed() && this.getName().startsWith('#') ||
+        Object.keys(schemaElement.getAllowedAttributes()).length > 0 ||
+        schemaElement.isChildElementAllowed('*') // any element allowed, this is edited as text (outerHTML)
+      );
     },
 
     updateDeletable: function () {
@@ -896,6 +901,25 @@ qx.Class.define('cv.ui.manager.model.XmlElement', {
           if (change.changed) {
             parentChanges.push(change);
           }
+        } else if (attrName === '#outerHTML') {
+          if (this.getSchemaElement().isChildElementAllowed('*')) {
+            const dom = new DOMParser().parseFromString(data[attrName], 'text/xml');
+            if (dom.getElementsByTagName('parsererror').length === 0) {
+              const oldValue = this._node.outerHTML;
+              const oldNode = this._node;
+              const newNode = dom.documentElement;
+              oldNode.parentNode.replaceChild(newNode, oldNode);
+              this._node = newNode;
+              changes.push({
+                changed: true,
+                attribute: attrName,
+                value: data[attrName],
+                old: oldValue
+              });
+              this.setName(this._node.nodeName);
+              this.load(true);
+            }
+          }
         } else {
           change = this.setAttribute(attrName, data[attrName]);
           if (change.changed) {
@@ -1019,12 +1043,23 @@ qx.Class.define('cv.ui.manager.model.XmlElement', {
                   }
                 }
               } else if (childNode.nodeType === Node.ELEMENT_NODE) {
-                // only complain for real childs (no comments, textNodes)
-                this.setValid(false);
-                let msg = this.getInvalidMessage();
-                msg = (msg ? msg + "<br/>" : "") + qx.locale.Manager.tr("Child element '%1' not allowed.", childNode.nodeName);
-                this.setInvalidMessage(msg);
-                this.setValid(false);
+                if (schemaElement.isChildElementAllowed(childNode.nodeName)) {
+                  // allowed but no schema element
+                  const child = new cv.ui.manager.model.XmlElement(childNode, schemaElement, this.getEditor(), this);
+                  if (schemaElement.isMixed()) {
+                    // text nodes can be re-ordered in mixed content
+                    child.setSortable(true);
+                  }
+                  children.push(child);
+                  this._initialChildNames.push(childNode.nodeName);
+                } else {
+                  // only complain for real childs (no comments, textNodes)
+                  this.setValid(false);
+                  let msg = this.getInvalidMessage();
+                  msg = (msg ? msg + "<br/>" : "") + qx.locale.Manager.tr("Child element '%1' not allowed.", childNode.nodeName);
+                  this.setInvalidMessage(msg);
+                  this.setValid(false);
+                }
               }
             }
 

--- a/source/translation/de.po
+++ b/source/translation/de.po
@@ -955,3 +955,27 @@ msgstr "Bitte bearbeiten Sie die Attribute des neuen %1 Elements, welches an der
 #: cv/ui/manager/editor/Tree.js
 msgid "Edit element attributes"
 msgstr "Element Attribute bearbeiten"
+
+#: cv/ui/manager/editor/Tree.js
+msgid "Please edit the content of the new %1 element, that will be added to the chosen position."
+msgstr "Bitte bearbeiten Sie den Inhalt des neuen %1 Elements, welches an der gewünschten Stelle erzeugt wird."
+
+#: cv/ui/manager/editor/Tree.js
+msgid "Edit element and content"
+msgstr "Element und Inhalt bearbeiten"
+
+#: cv/ui/manager/editor/Tree.js
+msgid "Edit element content"
+msgstr "Elementinhalt bearbeiten"
+
+#: cv/ui/manager/editor/Tree.js
+msgid "Edit text content"
+msgstr "Textinhalt bearbeiten"
+
+#: cv/ui/manager/model/XmlElement.js
+msgid "Text content is invalid"
+msgstr "Textinhalt ist ungültig"
+
+#: cv/ui/manager/model/XmlElement.js
+msgid "Child element '%1' not allowed."
+msgstr "Kind-Element '%1' ist nicht erlaubt."

--- a/source/translation/en.po
+++ b/source/translation/en.po
@@ -1003,3 +1003,27 @@ msgstr ""
 #: cv/ui/manager/editor/Tree.js
 msgid "Edit element attributes"
 msgstr ""
+
+#: cv/ui/manager/editor/Tree.js
+msgid "Please edit the content of the new %1 element, that will be added to the chosen position."
+msgstr ""
+
+#: cv/ui/manager/editor/Tree.js
+msgid "Edit element and content"
+msgstr ""
+
+#: cv/ui/manager/editor/Tree.js
+msgid "Edit element content"
+msgstr ""
+
+#: cv/ui/manager/editor/Tree.js
+msgid "Edit text content"
+msgstr ""
+
+#: cv/ui/manager/model/XmlElement.js
+msgid "Text content is invalid"
+msgstr ""
+
+#: cv/ui/manager/model/XmlElement.js
+msgid "Child element '%1' not allowed."
+msgstr ""


### PR DESCRIPTION
….g. used for user plugins that are not known to the schema) by just editing the outerHTML content in a TextArea and validate if its valid XML code.

Example config code:
```xml
	<page name="Start">
		<line>
			<layout colspan="12" />
		</line>
		<text align="center">
			<label>Welcome to the CometVisu!</label>
		</text>
		<line>
			<layout colspan="12" />
		</line>
		<custom><test attr1="val1" attr2="attr2">1</test></custom>
	</page>
```	