### PR TITLE
workaround missing native paste support when running

### DIFF
--- a/source/class/cv/ui/manager/editor/AbstractEditor.js
+++ b/source/class/cv/ui/manager/editor/AbstractEditor.js
@@ -17,6 +17,7 @@ qx.Class.define('cv.ui.manager.editor.AbstractEditor', {
   construct: function () {
     this.base(arguments);
     this._initClient();
+    this._nativePasteSupported = document.queryCommandSupported('paste');
   },
 
   /*
@@ -61,11 +62,22 @@ qx.Class.define('cv.ui.manager.editor.AbstractEditor', {
 
   /*
   ***********************************************
+    STATICS
+  ***********************************************
+  */
+  statics: {
+    // fake clipboard data when native clipboard is not supported
+    CLIPBOARD: null
+  },
+
+  /*
+  ***********************************************
     MEMBERS
   ***********************************************
   */
   members: {
     _handledActions: null,
+    _nativePasteSupported: false,
 
     canHandleAction: function (actionName) {
       if (actionName === 'save' && this.getFile() && !this.getFile().isWriteable()) {

--- a/source/class/cv/ui/manager/editor/Tree.js
+++ b/source/class/cv/ui/manager/editor/Tree.js
@@ -352,9 +352,8 @@ qx.Class.define('cv.ui.manager.editor.Tree', {
           navigator.clipboard.writeText('');
         }
       } catch (e) {
-        // clipboard api is only available in secure environment, copying to clipboards only use case
-        // here is that it can be pasted in the source editor. And because that also only works when the clipboard
-        // api is available we fail silently here.
+        // clipboard api is only available in secure environment, otherwise we have to do it ourself
+        cv.ui.manager.editor.AbstractEditor.CLIPBOARD = value ? value.getNode().outerHTML : '';
       }
     },
 


### PR DESCRIPTION
in an unsafe environment (no https or localhost).
This adds basic copy/paste support in the config editors
that was not available yet.