### PR TITLE
Fix errors using the MQTT backend

### DIFF
--- a/source/class/cv/io/mqtt/Client.js
+++ b/source/class/cv/io/mqtt/Client.js
@@ -235,8 +235,12 @@ qx.Class.define('cv.io.mqtt.Client', {
       if (this.isConnected()) {
         let message = new Paho.MQTT.Message(value);
         message.destinationName = address;
-        message.qos = options.qos;
-        message.retained = options.retain;
+        if (options.qos !== undefined) {
+          message.qos = options.qos;
+        }
+        if (options.retain !== undefined) {
+          message.retained = options.retain;
+        }
         this._client.send(message);
       }
     },

--- a/source/resource/visu_config.xsd
+++ b/source/resource/visu_config.xsd
@@ -8,7 +8,7 @@
       <xsd:documentation xml:lang="de">Die Gruppenaddresse (z.B: 12/0/7) bei KNX-Backends, der Item-Name beim openHAB-Backend oder das Topic bei MQTT.</xsd:documentation>
     </xsd:annotation>
     <xsd:restriction base="xsd:string">
-      <xsd:pattern value="[0-9]{1,2}/[0-9]{1,2}/[0-9]{1,3}|\{{0,3}\s*[A-Za-z][A-Za-z0-9_\-\.:\{\}\s]*\s*\}{0,3}|$?([a-zA-Z0-9+#_\- ]+/)*[a-zA-Z0-9+#_\- ]+" />
+      <xsd:pattern value="[0-9]{1,2}/[0-9]{1,2}/[0-9]{1,3}|\{{0,3}\s*[A-Za-z][A-Za-z0-9_\-\.:\{\}\s]*\s*\}{0,3}|$?([a-zA-Z0-9+#_\- ]+/)*[a-zA-Z0-9+#_\- ]+|.*" />
     </xsd:restriction>
   </xsd:simpleType>
 


### PR DESCRIPTION
Note: the change in the XSD is effectively disabling the content check for the `addr`. But with MQTT there's hardly any structure left to validate for