### PR TITLE
do not use page type in navbars because the content

### DIFF
--- a/source/class/cv/parser/widgets/NavBar.js
+++ b/source/class/cv/parser/widgets/NavBar.js
@@ -41,7 +41,8 @@ qx.Class.define('cv.parser.widgets.NavBar', {
      */
     parse: function (xml, path, flavour, pageType) {
       const data = cv.parser.WidgetParser.parseElement(this, xml, path, flavour, pageType, this.getAttributeToPropertyMappings());
-      cv.parser.WidgetParser.parseChildren(xml, path, flavour, pageType);
+      // navbars are no 2d/3d pages
+      cv.parser.WidgetParser.parseChildren(xml, path, flavour, 'text');
       return data;
     },
 


### PR DESCRIPTION
of a navbar is always treated like text page content.

In detail: All widgets on 2d pages get the style "position: absolute" which does not make sense for
navbar content.

closes #1106