### PR TITLE
Make PHP more robust

### DIFF
--- a/doc/manual/de/config/widgets/plugins/diagram/index.rst
+++ b/doc/manual/de/config/widgets/plugins/diagram/index.rst
@@ -77,6 +77,13 @@ Die in der versteckte Konfiguration verwendeten Schlüssel/Wert-Paare sind:
 |selfsigned |Erlaube selbst signierte HTTPS Verbindung zum Server, wenn Wert ``true`` ist |``false``                   |
 +-----------+-----------------------------------------------------------------------------+----------------------------+
 
+.. hint::
+
+    Wenn die Verbindung zur Datenbank mit der Fehlermeldung
+    ``failed to open stream: operation failed``
+    nicht aufgebaut werden kann, so kann dies ein Hinweis darauf sein, dass
+    ``selfsigned`` auf ``true`` gesetzt werden muss.
+
 ``consolidationFunction`` Attribut
 """"""""""""""""""""""""""""""""""
 

--- a/doc/manual/de/config/widgets/plugins/tr064/index.rst
+++ b/doc/manual/de/config/widgets/plugins/tr064/index.rst
@@ -169,6 +169,10 @@ Die in der versteckte Konfiguration verwendeten Schlüssel/Wert-Paare sind:
     ``https`` beginnt), so ist meist ``selfsigned`` auf ``true`` zu setzen, da ein Router
     im Heimnetz üblicher Weise mit einem selbst signierten Zertifikat arbeitet.
 
+    Eine Fehlermeldung mit dem Inhalt
+    ``{"faultstring":"Could not connect to host","faultcode":"HTTP"}`` kann darauf hinweisen,
+    dass ``selfsigned`` auf ``true`` gesetzt werden muss.
+
 .. rubric:: Fußnoten
 
 .. [#f1] In der vereinfachten Ansicht sind ggf. einige Dinge ausgeblendet. In der Expertenansicht ist alles zu sehen.

--- a/doc/manual/en/config/widgets/plugins/tr064/index.rst
+++ b/doc/manual/en/config/widgets/plugins/tr064/index.rst
@@ -189,6 +189,10 @@ manually and add a line like::
     ``https``) it is usual that ``selfsigned`` must be set to ``true`` as a
     router in the home network will work usually with a self signed certificate.
 
+    The error message
+    ``{"faultstring":"Could not connect to host","faultcode":"HTTP"}`` can be a
+    hint that ``selfsigned`` should be set to ``true``.
+
 .. rubric:: Footnotes
 
 .. [#f1] In the simple view some things might be not visible. The expert view

--- a/source/class/cv/plugins/diagram/AbstractDiagram.js
+++ b/source/class/cv/plugins/diagram/AbstractDiagram.js
@@ -366,7 +366,7 @@ qx.Class.define('cv.plugins.diagram.AbstractDiagram', {
         severity: 'urgent',
         message: 'URL: ' + JSON.stringify(key) + '<br/><br/>Response:</br>' + ev._target._transport.responseText
       });
-      console.error('Diagram _onStatusError', ts, key, ev);
+      window.console.error('Diagram _onStatusError', ts, key, ev);
       const tsdata = [];
 
       this.cache[key].data = tsdata;

--- a/source/class/cv/plugins/diagram/AbstractDiagram.js
+++ b/source/class/cv/plugins/diagram/AbstractDiagram.js
@@ -362,9 +362,9 @@ qx.Class.define('cv.plugins.diagram.AbstractDiagram', {
 
     _onStatusError: function(ts, key, ev) {
       cv.core.notifications.Router.dispatchMessage('cv.diagram.error', {
-        title: 'Diagram communication error',
+        title: qx.locale.Manager.tr('Diagram communication error'),
         severity: 'urgent',
-        message: 'URL: ' + JSON.stringify(key) + '<br/><br/>Response:</br>' + ev._target._transport.responseText
+        message: qx.locale.Manager.tr('URL: %1<br/><br/>Response:</br>%2', JSON.stringify(key), ev._target._transport.responseText)
       });
       window.console.error('Diagram _onStatusError', ts, key, ev);
       const tsdata = [];

--- a/source/class/cv/plugins/diagram/AbstractDiagram.js
+++ b/source/class/cv/plugins/diagram/AbstractDiagram.js
@@ -361,7 +361,12 @@ qx.Class.define('cv.plugins.diagram.AbstractDiagram', {
     },
 
     _onStatusError: function(ts, key, ev) {
-      qx.log.Logger.error(this, '_onStatusError', ts, key, ev);
+      cv.core.notifications.Router.dispatchMessage('cv.diagram.error', {
+        title: 'Diagram communication error',
+        severity: 'urgent',
+        message: 'URL: ' + JSON.stringify(key) + '<br/><br/>Response:</br>' + ev._target._transport.responseText
+      });
+      console.error('Diagram _onStatusError', ts, key, ev);
       const tsdata = [];
 
       this.cache[key].data = tsdata;

--- a/source/class/cv/plugins/tr064/CallList.js
+++ b/source/class/cv/plugins/tr064/CallList.js
@@ -270,7 +270,11 @@ qx.Class.define('cv.plugins.tr064.CallList', {
             return response.json(); 
           }
           // else:
-          self.error('Error: reading URL "' + response.url + ' failed with status ' + response.status + ': ' + response.statusText);
+          cv.core.notifications.Router.dispatchMessage('cv.tr064.error', {
+            title: 'TR-064 communication error',
+            severity: 'urgent',
+            message: 'Reading URL "' + response.url + '" failed with status "' + response.status + '": "' + response.statusText + '"'
+          });
           self.__calllistUri = '<fail>';
           return null;
         })
@@ -279,7 +283,11 @@ qx.Class.define('cv.plugins.tr064.CallList', {
             self.__calllistUri = data;
             self.refreshCalllist('getCallListURI');
           } else {
-            self.error('Error: reading URL "' + url + ' failed with content:', data);
+            cv.core.notifications.Router.dispatchMessage('cv.tr064.error', {
+              title: 'TR-064 communication response error',
+              severity: 'urgent',
+              message: 'Reading URL "' + url + '" failed with content: "' + JSON.stringify(data) + '"'
+            });
             self.__calllistUri = '<fail>';
           }
         });
@@ -306,7 +314,11 @@ qx.Class.define('cv.plugins.tr064.CallList', {
             return response.text(); 
           }
           // else:
-          self.error('Error: reading URL "' + response.url + ' failed with status ' + response.status + ': ' + response.statusText);
+          cv.core.notifications.Router.dispatchMessage('cv.tr064.error', {
+            title: 'TR-064 communication error',
+            severity: 'urgent',
+            message: 'Reading URL "' + response.url + '" failed with status "' + response.status + '": "' + response.statusText + '"'
+          });
           return '<xml/>';
         })
         .then(function(str) {
@@ -327,7 +339,12 @@ qx.Class.define('cv.plugins.tr064.CallList', {
           self.__refreshingCalllist = false;
           self.fireEvent('tr064ListRefreshed');
         })
-        .catch(function(error) { 
+        .catch(function(error) {
+          cv.core.notifications.Router.dispatchMessage('cv.tr064.error', {
+            title: 'TR-064 communication error',
+            severity: 'urgent',
+            message: 'refreshCalllist() error: "' + JSON.stringify(error) + '"'
+          });
           self.error('TR-064 refreshCalllist() error:', error);
         });
     },

--- a/source/class/cv/plugins/tr064/CallList.js
+++ b/source/class/cv/plugins/tr064/CallList.js
@@ -271,9 +271,9 @@ qx.Class.define('cv.plugins.tr064.CallList', {
           }
           // else:
           cv.core.notifications.Router.dispatchMessage('cv.tr064.error', {
-            title: 'TR-064 communication error',
+            title: qx.locale.Manager.tr('TR-064 communication error'),
             severity: 'urgent',
-            message: 'Reading URL "' + response.url + '" failed with status "' + response.status + '": "' + response.statusText + '"'
+            message: qx.locale.Manager.tr('Reading URL "%1" failed with status "%2": "%2"',response.url, response.status, response.statusText)
           });
           self.__calllistUri = '<fail>';
           return null;
@@ -284,9 +284,9 @@ qx.Class.define('cv.plugins.tr064.CallList', {
             self.refreshCalllist('getCallListURI');
           } else {
             cv.core.notifications.Router.dispatchMessage('cv.tr064.error', {
-              title: 'TR-064 communication response error',
+              title: qx.locale.Manager.tr('TR-064 communication response error'),
               severity: 'urgent',
-              message: 'Reading URL "' + url + '" failed with content: "' + JSON.stringify(data) + '"'
+              message: qx.locale.Manager.tr('Reading URL "%1" failed with content: "%2"', url, JSON.stringify(data))
             });
             self.__calllistUri = '<fail>';
           }
@@ -315,9 +315,9 @@ qx.Class.define('cv.plugins.tr064.CallList', {
           }
           // else:
           cv.core.notifications.Router.dispatchMessage('cv.tr064.error', {
-            title: 'TR-064 communication error',
+            title: qx.locale.Manager.tr('TR-064 communication error'),
             severity: 'urgent',
-            message: 'Reading URL "' + response.url + '" failed with status "' + response.status + '": "' + response.statusText + '"'
+            message: qx.locale.Manager.tr('Reading URL "%1" failed with status "%2": "%2"',response.url, response.status, response.statusText)
           });
           return '<xml/>';
         })
@@ -341,9 +341,9 @@ qx.Class.define('cv.plugins.tr064.CallList', {
         })
         .catch(function(error) {
           cv.core.notifications.Router.dispatchMessage('cv.tr064.error', {
-            title: 'TR-064 communication error',
+            title: qx.locale.Manager.tr('TR-064 communication error'),
             severity: 'urgent',
-            message: 'refreshCalllist() error: "' + JSON.stringify(error) + '"'
+            message: qx.locale.Manager.tr('refreshCalllist() error: "%1"', JSON.stringify(error))
           });
           self.error('TR-064 refreshCalllist() error:', error);
         });

--- a/source/class/cv/plugins/tr064/CallList.js
+++ b/source/class/cv/plugins/tr064/CallList.js
@@ -273,7 +273,7 @@ qx.Class.define('cv.plugins.tr064.CallList', {
           cv.core.notifications.Router.dispatchMessage('cv.tr064.error', {
             title: qx.locale.Manager.tr('TR-064 communication error'),
             severity: 'urgent',
-            message: qx.locale.Manager.tr('Reading URL "%1" failed with status "%2": "%2"',response.url, response.status, response.statusText)
+            message: qx.locale.Manager.tr('Reading URL "%1" failed with status "%2": "%2"', response.url, response.status, response.statusText)
           });
           self.__calllistUri = '<fail>';
           return null;
@@ -317,7 +317,7 @@ qx.Class.define('cv.plugins.tr064.CallList', {
           cv.core.notifications.Router.dispatchMessage('cv.tr064.error', {
             title: qx.locale.Manager.tr('TR-064 communication error'),
             severity: 'urgent',
-            message: qx.locale.Manager.tr('Reading URL "%1" failed with status "%2": "%2"',response.url, response.status, response.statusText)
+            message: qx.locale.Manager.tr('Reading URL "%1" failed with status "%2": "%2"', response.url, response.status, response.statusText)
           });
           return '<xml/>';
         })

--- a/source/resource/plugins/diagram/influxfetch.php
+++ b/source/resource/plugins/diagram/influxfetch.php
@@ -232,12 +232,16 @@ function getTs( $tsParameter, $field, $start, $end, $ds, $res, $fill, $filter )
     $tz = 'Europe/Berlin';  // best guess for a not good set up system
   $q .= " tz('$tz')";
 
-  if( '' != $_GET['debug'] )
+  if( '' != ($_GET['debug'] ?? '') )
     var_dump($q);
 
   $arrData = array();
 
-  $seriesArr = json_decode( query( $q, $ts[0], $_GET['auth'] ), true );
+  $seriesArr = json_decode( query( $q, $ts[0], ($_GET['auth'] ?? '') ), true );
+
+  if( '' != ($_GET['debug'] ?? '') )
+    var_dump(error_get_last());
+
   $series = $seriesArr['results'][0]['series'][0]['values'];
   foreach( $series as $thisSeries )
   {
@@ -260,7 +264,7 @@ function printRow( $row )
   print ']]';
 }
 
-$arrData = getTs( $_GET['ts'], $_GET['field'], $_GET['start'], $_GET['end'], $_GET['ds'], $_GET['res'], $_GET['fill'], $_GET['filter'] );
+$arrData = getTs( $_GET['ts'] ?? '', $_GET['field'] ?? '', $_GET['start'] ?? '', $_GET['end'] ?? '', $_GET['ds'] ?? '', $_GET['res'] ?? '', $_GET['fill'] ?? '', $_GET['filter'] ?? '');
 
 Header("Content-type: application/json");
 

--- a/source/resource/plugins/tr064/proxy.php
+++ b/source/resource/plugins/tr064/proxy.php
@@ -39,11 +39,11 @@
 
 include '../../config/hidden.php';
 
-$TR064device = $hidden[$_GET['device']];
+$TR064device = $hidden[($_GET['device'] ?? '')] ?? false;
 if( !$TR064device )
 {
   header("HTTP/1.0 404 Not Found");
-  echo 'Device key "' . $_GET['device'] . '" is not known in config file.';
+  echo 'Device key "' . ($_GET['device'] ?? '') . '" is not known in config file.';
   die();
 }
 $TR064_uri = $TR064device['uri'];
@@ -67,7 +67,7 @@ if( array_key_exists( 'selfsigned', $TR064device ) &&
   ) );
 }
 
-$uri = $_GET['uri'];
+$uri = $_GET['uri'] ?? '';
 $uri = preg_replace( '#^(https?://[^/]*/)? */*#', $TR064_uri, $uri );
 
 if( $stream = @fopen($uri, 'r', false, $context) )

--- a/source/translation/de.po
+++ b/source/translation/de.po
@@ -999,3 +999,31 @@ msgstr "Kind-Element '%1' ist nicht erlaubt."
 #: cv/ui/manager/editor/Source.js
 msgid "\"%1\" is not writable. Upgrading not possible."
 msgstr "\"%1\" ist nicht speicherbar. Upgrade kann nicht durchgeführt werden."
+
+#: cv/plugins/diagram/AbstractDiagram.js
+msgid "Diagram communication error"
+msgstr "Diagram Kommunikations-Fehler"
+
+#: cv/plugins/diagram/AbstractDiagram.js
+msgid "URL: %1<br/><br/>Response:</br>%2"
+msgstr "URL: %1<br/><br/>Antwort:</br>%2"
+
+#: cv/plugins/tr064/CallList.js
+msgid "TR-064 communication error"
+msgstr "TR-064 Kommunikations-Fehler"
+
+#: cv/plugins/tr064/CallList.js
+msgid "TR-064 communication response error"
+msgstr "TR-064 Kommunikation-Antwort-Fehler"
+
+#: cv/plugins/tr064/CallList.js
+msgid "Reading URL \"%1\" failed with status \"%2\": \"%2\""
+msgstr "Lesen der URL \"%1\" mit Status \"%2\" fehlgeschlagen: \"%2\""
+
+#: cv/plugins/tr064/CallList.js
+msgid "refreshCalllist() error: \"%1\""
+msgstr "refreshCalllist() Fehler: \"%1\""
+
+#: cv/plugins/tr064/CallList.js
+msgid "Reading URL \"%1\" failed with content: \"%2\""
+msgstr "Lesen der URL  \"%1\" nicht möglich. Inhalt: \"%2\""

--- a/source/translation/en.po
+++ b/source/translation/en.po
@@ -1020,7 +1020,7 @@ msgstr ""
 msgid "Edit text content"
 msgstr ""
 
-#: cv/ui/manager/MenuBar.js
+#: cv/ui/manager/Main.js
 msgid "About"
 msgstr ""
 
@@ -1046,4 +1046,32 @@ msgstr ""
 
 #: cv/ui/manager/editor/Source.js
 msgid "\"%1\" is not writable. Upgrading not possible."
+msgstr ""
+
+#: cv/plugins/diagram/AbstractDiagram.js
+msgid "Diagram communication error"
+msgstr ""
+
+#: cv/plugins/diagram/AbstractDiagram.js
+msgid "URL: %1<br/><br/>Response:</br>%2"
+msgstr ""
+
+#: cv/plugins/tr064/CallList.js
+msgid "TR-064 communication error"
+msgstr ""
+
+#: cv/plugins/tr064/CallList.js
+msgid "TR-064 communication response error"
+msgstr ""
+
+#: cv/plugins/tr064/CallList.js
+msgid "Reading URL \"%1\" failed with status \"%2\": \"%2\""
+msgstr ""
+
+#: cv/plugins/tr064/CallList.js
+msgid "refreshCalllist() error: \"%1\""
+msgstr ""
+
+#: cv/plugins/tr064/CallList.js
+msgid "Reading URL \"%1\" failed with content: \"%2\""
 msgstr ""


### PR DESCRIPTION
Make PHP more robust, show errors in the notification center and give a hint in the documentation about how to detect a missing `selfsigned=true`.

Closes #1133.