### PR TITLE
fix several errors in the reporting:

### DIFF
--- a/source/class/cv/Application.js
+++ b/source/class/cv/Application.js
@@ -73,6 +73,22 @@ qx.Class.define('cv.Application',
     HTML_STRUCT: '<div id="top" class="loading"><div class="nav_path">-</div></div><div id="navbarTop" class="loading"></div><div id="centerContainer"><div id="navbarLeft" class="loading page"></div><div id="main" style="position:relative; overflow: hidden;" class="loading"><div id="pages" style="position:relative;clear:both;"><!-- all pages will be inserted here --></div></div><div id="navbarRight" class="loading page"></div></div><div id="navbarBottom" class="loading"></div><div id="bottom" class="loading"><hr /><div class="footer"></div></div>',
     consoleCommands: [],
     __commandManager: null,
+    _relResourcePath: null,
+    _fullResourcePath: null,
+
+    getRelativeResourcePath(fullPath) {
+      if (!this._relResourcePath) {
+        const baseUrl = window.location.origin + window.location.pathname.split('/').slice(0, -1).join('/');
+        this._relResourcePath = qx.util.Uri.getAbsolute(qx.util.LibraryManager.getInstance().get('cv', 'resourceUri')).substring(baseUrl.length+1) + '/';
+      }
+      if (fullPath === true) {
+        if (!this._fullResourcePath) {
+          this._fullResourcePath = window.location.pathname.split('/').slice(0, -1).join('/') + '/' + this._relResourcePath;
+        }
+        return this._fullResourcePath;
+      }
+      return this._relResourcePath;
+    },
 
     /**
      * Client factory method -> create a client
@@ -732,7 +748,7 @@ qx.Class.define('cv.Application',
         }, this);
         const parts = qx.Part.getInstance().getParts();
         const partPlugins = [];
-        const path = qx.util.LibraryManager.getInstance().get('cv', 'resourceUri');
+        const path = cv.Application.getRelativeResourcePath();
         plugins.forEach(function(plugin) {
           if (Object.prototype.hasOwnProperty.call(parts, plugin)) {
             partPlugins.push(plugin);

--- a/source/class/cv/report/Record.js
+++ b/source/class/cv/report/Record.js
@@ -157,12 +157,12 @@ qx.Class.define('cv.report.Record', {
 
     normalizeUrl: function(url) {
       try {
-        const parsed = qx.util.Uri.parseUri(url);
+        const parsed = qx.util.Uri.parseUri(qx.util.Uri.getAbsolute(url));
         url = parsed.path;
         const filteredParams = Object.keys(parsed.queryKey).filter(name => name !== 'nocache' && name !== 'ts');
         if (filteredParams.length > 0) {
           url += '?';
-          filteredParams.forEach(param => url += `${param}=${parsed.queryKey[param]}`);
+          url += filteredParams.map(param => `${param}=${parsed.queryKey[param]}`).join('&');
         }
       } catch (e) {
         if (url.indexOf('nocache=') >= 0) {

--- a/source/class/cv/report/Replay.js
+++ b/source/class/cv/report/Replay.js
@@ -104,7 +104,7 @@ qx.Class.define('cv.report.Replay', {
         cv.ConfigCache._parseCacheData = log.data.cache;
         // parse stringified data
         cv.ConfigCache._parseCacheData.data = typeof log.data.cache.data === 'string' ? JSON.parse(log.data.cache.data) : log.data.cache.data;
-        cv.ConfigCache._parseCacheData.configSettings = typeof log.data.cache.configSettings === 'string' ? JSON.parse(log.data.cache.configSettings) : log.data.cache.configSettings
+        cv.ConfigCache._parseCacheData.configSettings = typeof log.data.cache.configSettings === 'string' ? JSON.parse(log.data.cache.configSettings) : log.data.cache.configSettings;
       }
       if (log.data.storage) {
         const store = qx.bom.Storage.getLocal();

--- a/source/class/cv/report/Replay.js
+++ b/source/class/cv/report/Replay.js
@@ -103,12 +103,13 @@ qx.Class.define('cv.report.Replay', {
       if (log.data.cache) {
         cv.ConfigCache._parseCacheData = log.data.cache;
         // parse stringified data
-        cv.ConfigCache._parseCacheData.data = JSON.parse(log.data.cache.data);
-        cv.ConfigCache._parseCacheData.configSettings = JSON.parse(log.data.cache.configSettings);
+        cv.ConfigCache._parseCacheData.data = typeof log.data.cache.data === 'string' ? JSON.parse(log.data.cache.data) : log.data.cache.data;
+        cv.ConfigCache._parseCacheData.configSettings = typeof log.data.cache.configSettings === 'string' ? JSON.parse(log.data.cache.configSettings) : log.data.cache.configSettings
       }
       if (log.data.storage) {
+        const store = qx.bom.Storage.getLocal();
         Object.keys(log.data.storage).forEach(name => {
-          window.localStorage[name] = log.data.storage[name];
+          store.setItem(name, log.data.storage[name]);
         });
       }
       cv.report.utils.FakeServer.init(log.xhr, this.__data.runtime.build);

--- a/source/class/cv/report/utils/FakeServer.js
+++ b/source/class/cv/report/utils/FakeServer.js
@@ -32,15 +32,7 @@ qx.Class.define('cv.report.utils.FakeServer', {
     _index : 0,
 
     init: function (log, build) {
-      //let prependResourcePath = null;
       qx.log.Logger.info(this, build+' log replaying in '+qx.core.Environment.get('cv.build'));
-      /*if (build !== qx.core.Environment.get('cv.build')) {
-        // the log has not been recorded in the same build as is is replayed, some paths must be adjusted
-        if (build === 'build') {
-          // map from build to source
-          prependResourcePath = '../source/';
-        }
-      }*/
 
       const urlMapping = {
         '/resource/': cv.Application.getRelativeResourcePath(true),
@@ -54,19 +46,10 @@ qx.Class.define('cv.report.utils.FakeServer', {
           const index = url.indexOf(pattern);
           if (index >= 0) {
             url = urlMapping[pattern] + url.substr(index + pattern.length);
-            console.log(url);
             return true;
           }
           return false;
         });
-        /*let index = url.indexOf('/resource/');
-        if (prependResourcePath && index >= 0) {
-          url = prependResourcePath+url.substr(index+1);
-          console.log(url);
-        } else if (url.includes('/rest/manager/index.php')) {
-          url = cv.io.rest.Client.getBaseUrl() + url.substr(url.indexOf('/rest/manager/index.php') + '/rest/manager/index.php'.length);
-          console.log(url);
-        }*/
         if (!this._xhr[url]) {
           this._xhr[url] = [];
         }

--- a/source/class/cv/report/utils/MXhrHook.js
+++ b/source/class/cv/report/utils/MXhrHook.js
@@ -60,18 +60,22 @@ qx.Mixin.define('cv.report.utils.MXhrHook', {
     _onPhaseChange: function(ev) {
       const hash = this.getRequestHash();
       let delay;
+      const url = cv.report.Record.normalizeUrl(this._getConfiguredUrl());
 
       if (ev.getData() === 'opened') {
         this.__sendTime = Date.now();
         // calculate Hash value for request
         cv.report.Record.record(cv.report.Record.XHR, 'request', {
-          url: cv.report.Record.normalizeUrl(this._getConfiguredUrl()),
+          url: url,
+          method: this.getMethod(),
+          headers: this._getAllRequestHeaders(),
+          requestData: this.getRequestData(),
           hash: hash
         });
         if (!cv.report.utils.MXhrHook.PENDING[hash]) {
           cv.report.utils.MXhrHook.PENDING[hash] = [];
         }
-        cv.report.utils.MXhrHook.PENDING[hash].push(cv.report.Record.normalizeUrl(this._getConfiguredUrl()));
+        cv.report.utils.MXhrHook.PENDING[hash].push(url);
       } else if (ev.getData() === 'load') {
         if (!this.__sendTime) {
           this.error('response received without sendTime set. Not possible to calculate correct delay');
@@ -90,11 +94,10 @@ qx.Mixin.define('cv.report.utils.MXhrHook', {
         // end the logged ones break the replay for some reason
         if (this.getStatus() !== 404) {
           cv.report.Record.record(cv.report.Record.XHR, 'response', {
-            url: cv.report.Record.normalizeUrl(this._getConfiguredUrl()),
+            url: url,
             method: this.getMethod(),
             status: this.getStatus(),
             delay: delay,
-            requestData: this.getRequestData(),
             headers: headers,
             body: this.getTransport().responseText,
             hash: hash,
@@ -113,7 +116,7 @@ qx.Mixin.define('cv.report.utils.MXhrHook', {
 
         // request aborted, maybe by watchdog
         cv.report.Record.record(cv.report.Record.XHR, 'response', {
-          url: cv.report.Record.normalizeUrl(this._getConfiguredUrl()),
+          url: url,
           delay: delay,
           hash: hash,
           phase: 'abort'

--- a/source/class/cv/ui/manager/editor/Source.js
+++ b/source/class/cv/ui/manager/editor/Source.js
@@ -32,7 +32,6 @@ qx.Class.define('cv.ui.manager.editor.Source', {
   construct: function () {
     this.base(arguments);
     this._handledActions = ['save', 'cut', 'copy', 'paste', 'undo', 'redo'];
-    this._basePath = window.location.origin + window.location.pathname + qx.util.LibraryManager.getInstance().get('cv', 'resourceUri') + '/config/';
     this.getContentElement().setAttribute('contentEditable', 'true');
     this.set({
       droppable: false,
@@ -139,7 +138,6 @@ qx.Class.define('cv.ui.manager.editor.Source', {
   members: {
     __schema: null,
     _editor: null,
-    _basePath: null,
     _workerWrapper: null,
     _currentDecorations: null,
     _configClient: null,

--- a/source/class/cv/util/IconTools.js
+++ b/source/class/cv/util/IconTools.js
@@ -251,7 +251,9 @@ qx.Class.define('cv.util.IconTools', {
         if (color in cv.util.IconTools.colorMapping) {
           color = cv.util.IconTools.colorMapping[color];
         }
-        const iconPath = qx.util.ResourceManager.getInstance().toUri('icons/knx-uf-iconset.svg');
+        // use relative path here, otherwise it won't work in replay mode
+        const iconPath = cv.Application.getRelativeResourcePath() + 'icons/knx-uf-iconset.svg';
+
         let style = styling || '';
         if (color) {
           style += 'color:' + color + ';';

--- a/source/replay.html
+++ b/source/replay.html
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
         "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml"> <!--manifest="cometvisu.appcache"-->
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
   <title>CometVisu-Client</title>
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-  <link rel="manifest" href="manifest.json">
-  <link rel="icon" href="icons/comet_16x16_000000.png" type="image/png" />
-  <link rel="apple-touch-icon" sizes="76x76" href="icons/comet_webapp_icon_76.png" />
-  <link rel="apple-touch-icon" sizes="120x120" href="icons/comet_webapp_icon_120.png" />
-  <link rel="apple-touch-icon" sizes="152x152" href="icons/comet_webapp_icon_152.png" />
-  <link rel="apple-touch-icon" sizes="167x167" href="icons/comet_webapp_icon_167.png" />
-  <link rel="apple-touch-icon" sizes="180x180" href="icons/comet_webapp_icon_180.png" />
+  <link rel="manifest" href="cv/manifest.json">
+  <link rel="icon" href="resource/icons/comet_16x16_000000.png" type="image/png" />
+  <link rel="apple-touch-icon" sizes="76x76" href="resource/icons/comet_webapp_icon_76.png" />
+  <link rel="apple-touch-icon" sizes="120x120" href="resource/icons/comet_webapp_icon_120.png" />
+  <link rel="apple-touch-icon" sizes="152x152" href="resource/icons/comet_webapp_icon_152.png" />
+  <link rel="apple-touch-icon" sizes="167x167" href="resource/icons/comet_webapp_icon_167.png" />
+  <link rel="apple-touch-icon" sizes="180x180" href="resource/icons/comet_webapp_icon_180.png" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" />
   <meta name="apple-mobile-web-app-capable" content="yes" />
   <meta name="apple-mobile-web-app-status-bar-style" content="black" />


### PR DESCRIPTION
1. Fix paths in replay.html
2. Stop replay.py when the browser gets closed
3. open devtools in firefox when requested
4. Normalize all paths to fix problems when the recorded session was run in a cometvisu installation in a subfolder (e.g. /proxy/visu/)
5. Use relative paths for KNX-UF sprite, because they are
cached + recorded and absolute paths won't work in the replay