### PR TITLE
set widget to selectable when the file is writeable to fix source code

### DIFF
--- a/source/class/cv/ui/manager/editor/Source.js
+++ b/source/class/cv/ui/manager/editor/Source.js
@@ -54,6 +54,7 @@ qx.Class.define('cv.ui.manager.editor.Source', {
     this._draw();
     this._initWorker();
     this._currentDecorations = [];
+    this.bind('file.writeable', this, 'selectable');
   },
 
   /*


### PR DESCRIPTION
editing in safari browser. This overrides the default CSS user-select
property from none to text for monaco editor dom element.