### PR TITLE
fix styling and fake data in testmode demo

### DIFF
--- a/source/class/cv/io/Mockup.js
+++ b/source/class/cv/io/Mockup.js
@@ -98,6 +98,28 @@ qx.Class.define('cv.io.Mockup', {
     __applyTestData: function () {
       this.__xhr = cv.Config.initialDemoData.xhr;
 
+      // we need to adjust the timestamps of the chart data
+      const now = Date.now();
+      for (let url in this.__xhr) {
+        if (url.startsWith('rrd')) {
+          this.__xhr[url].forEach(d => {
+            const data = d.body;
+            const offset = now - data[data.length - 1][0];
+            data.forEach(entry => entry[0] += offset);
+          });
+        } else if (url.startsWith('resource/plugin/rsslog.php')) {
+          this.__xhr[url].forEach(d => {
+            const data = d.body.responseData.feed.entries;
+            let date = new Date();
+            date.setDate(date.getDate()-1);
+            data.forEach(entry => {
+              entry.publishedDate = date.toUTCString();
+              date.setTime(date.getTime() + 60*60*1000);
+            });
+          });
+        }
+      }
+
       const that = this;
 
       // override sinons filter handling to be able to manipulate the target URL from the filter
@@ -414,6 +436,9 @@ qx.Class.define('cv.io.Mockup', {
     stop: function () {},
 
     getResourcePath: function (name) {
+      if (name === 'charts') {
+        return null;
+      }
       return name;
     },
 

--- a/source/resource/demo/media/demo_testmode_data.json
+++ b/source/resource/demo/media/demo_testmode_data.json
@@ -56,7 +56,7 @@
     "12/7/92": 250
   },
   "xhr": {
-    "rrd?rrd=13%2F0%2F14.rrd&ds=AVERAGE&start=end-1day&end=now&res=300": [{
+    "rrd?rrd=13%2F0%2F14.rrd&ds=AVERAGE&start=end-1day&end=now&res=300&fill=linear": [{
       "status": 200,
       "headers": {
         "Content-type": "application/json"

--- a/source/resource/demo/media/testmode.css
+++ b/source/resource/demo/media/testmode.css
@@ -8,7 +8,7 @@
     width: 60px;
     height: 60px;
     line-height: 60px;
-    background-color: #222;
+    background-color: #222 !important;
     margin: 0;
 }
 
@@ -49,6 +49,7 @@
 
 .page.type_2d .widget_container .widget {
     margin: 0;
+    background: none;
 }
 
 .page.type_2d .widget_container .widget.custom_bubble > div {
@@ -73,7 +74,7 @@
     line-height: normal;
     font-size: 14px;
     width: 20px;
-    height: 75px;
+    height: 68px;
     background-color: rgba(129, 102, 75, 0.8);
     color: rgb(226, 212, 198);
 }
@@ -174,17 +175,23 @@ html .page .widget.multitrigger.custom_one-line .actor_container {
     margin-right: -1px;
     margin-bottom: -1px;
 }
-
-.page.type_text .clearfix.weather-forecast .clearfix {
+.page.type_text .custom_weather-forecast .clearfix:not(.widget):not(.group) {
     display: block !important;
+    grid-template-columns: unset !important;
+    grid-auto-rows: unset !important;
+    align-items: unset !important;
+    margin-right: unset !important;
+    margin-bottom: unset !important;
+}
+ul.detailed li.night {
+    display: inline-block !important;
 }
 
-.page.type_text .clearfix.weather-forecast .clearfix .widget_container.jowm .weather-forecast {
+.page.type_text .clearfix.custom_weather-forecast .widget_container.jowm .custom_weather-forecast {
     margin: 0 .5rem;
 }
 .page.type_text .widget_container.jowm {
     padding: 0;
-    margin-bottom: 16px;
 }
 .page.type_text .widget_container.jowm .separationLine {
     margin: 16px 0;
@@ -223,4 +230,8 @@ html .page .widget.multitrigger.custom_one-line .actor_container {
 .page.type_text > .clearfix .widget_container .group > .clearfix > h2 {
     grid-column-start: 1;
     grid-column-end: span 12;
+}
+
+.page.type_2d .widget_container, .page.type_2d .widget_container .group:not(.widget) {
+    position: relative;
 }

--- a/source/resource/demo/media/testmode.css
+++ b/source/resource/demo/media/testmode.css
@@ -12,7 +12,7 @@
     margin: 0;
 }
 
-.page.type_2d .widget.custom_bubble.embedded {
+.page.type_2d .widget.custom_bubble.custom_embedded {
     border-width: 0;
     box-shadow: 2px 4px 4px 0px rgba(135, 135, 135, 0.5);
 }
@@ -61,7 +61,7 @@
     color: #888888;
 }
 
-.page.type_2d .widget.custom_embedded, .page.type_2d .widget.embedded {
+.page.type_2d .widget.custom_embedded {
     transform: skew(-10deg, 4deg);
 }
 

--- a/source/resource/demo/visu_config_demo_testmode.xml
+++ b/source/resource/demo/visu_config_demo_testmode.xml
@@ -571,7 +571,6 @@
             <layout colspan="12" rowspan="8"/>
             <axis unit="°C"/>
             <rrd>13/0/14</rrd>
-            <!--address transform="OH:number">Temperature_SF_Bed</address-->
           </diagram>
         </group>
       </page>


### PR DESCRIPTION
The config used as demo for [cometvisu.org](https://www.cometvisu.org/CometVisu/de/0.12/demo/) needed some tweaks in design and data

Can be testet locally by: `CV_TAG_RUNTIME=demo CV_TESTMODE=resource/demo/media/demo_testmode_data.json npx qx compile --watch` and then open the `?config=demo_testmode`