### PR TITLE
Fix image updates

### DIFF
--- a/source/class/cv/ui/common/Refresh.js
+++ b/source/class/cv/ui/common/Refresh.js
@@ -266,9 +266,7 @@ qx.Mixin.define('cv.ui.common.Refresh', {
       iframe.addEventListener('load', loadCallback, false);
       iframe.addEventListener('error', loadCallback, false);
       doc = iframe.contentWindow.document;
-      doc.open();
-      doc.write('<html><head><title></title></head><body><img src="' + src + '"></body></html>');
-      doc.close();
+      doc.body.innerHTML='<img src="' + src + '"></body></html>';
       if (twostage) {
         return function(proceed) {
           if (!twostage) {

--- a/source/class/cv/ui/common/Refresh.js
+++ b/source/class/cv/ui/common/Refresh.js
@@ -226,17 +226,21 @@ qx.Mixin.define('cv.ui.common.Refresh', {
           canvas.width = elem.width;
           canvas.height = elem.height;
           canvas.style = 'position:fixed';
-          canvas.getContext('2d').drawImage(elem, 0, 0);
+          try {
+            canvas.getContext('2d').drawImage(elem, 0, 0);
+          } catch(e) {
+            console.log('Refresh image: failed to show old image on temporary canvas', e);
+          }
           canvases.push(canvas);
           elem.parentNode.insertBefore(canvas, elem);
           elem.removeAttribute('src');
+          elem.width = canvas.width;
+          elem.height = canvas.height;
         });
       };
       const imgReloadRestore = function () {
         elements.forEach(function (elem) {
           elem.setAttribute('src', src);
-          elem.removeAttribute('width');
-          elem.removeAttribute('height');
         });
         canvases.forEach(function (elem) {
           elem.parentNode.removeChild(elem);

--- a/source/class/cv/ui/common/Refresh.js
+++ b/source/class/cv/ui/common/Refresh.js
@@ -228,8 +228,8 @@ qx.Mixin.define('cv.ui.common.Refresh', {
           canvas.style = 'position:fixed';
           try {
             canvas.getContext('2d').drawImage(elem, 0, 0);
-          } catch(e) {
-            console.log('Refresh image: failed to show old image on temporary canvas', e);
+          } catch (e) {
+            window.console.log('Refresh image: failed to show old image on temporary canvas', e);
           }
           canvases.push(canvas);
           elem.parentNode.insertBefore(canvas, elem);


### PR DESCRIPTION
Remove depreciation warning.
Remove layout break flicker during update.
Also try to fix very sporadic issue about 'broken' state during drawImage.