### PR TITLE
fix custom start date conversion, enables

### DIFF
--- a/source/class/cv/io/openhab/Rest.js
+++ b/source/class/cv/io/openhab/Rest.js
@@ -113,8 +113,7 @@ qx.Class.define('cv.io.openhab.Rest', {
             }
             startTime.setTime(endTime.getTime() - (amount * interval));
           } else if (/^[\d]+$/.test(map.start)) {
-            const d = new Date();
-            d.setTime(parseInt(map.start) * 1000);
+            startTime.setTime(parseInt(map.start) * 1000);
           }
 
           params.push('starttime=' + startTime.toISOString());


### PR DESCRIPTION
scrolling in diagrams with openhab backend again

fix for https://knx-user-forum.de/forum/supportforen/cometvisu/1738508-rc5-diagrammdaten-werden-nicht-nachgeladen