### PR TITLE
Fix clock plugin.

### DIFF
--- a/source/class/cv/TemplateEngine.js
+++ b/source/class/cv/TemplateEngine.js
@@ -571,6 +571,7 @@ qx.Class.define('cv.TemplateEngine', {
         }
         cv.ui.layout.Manager.adjustColumns();
         cv.ui.layout.Manager.applyColumnWidths('#'+cv.Config.initialPage, true);
+        cv.ui.layout.ResizeHandler.invalidateScreensize();
 
         this.main_scroll = new cv.ui.PageHandler();
         if (this.scrollSpeed !== undefined) {

--- a/source/class/cv/ui/layout/ResizeHandler.js
+++ b/source/class/cv/ui/layout/ResizeHandler.js
@@ -100,17 +100,17 @@ qx.Class.define('cv.ui.layout.ResizeHandler', {
 
     makeAllSizesValid : function() {
       if (this.states.isPageSizeInvalid()) {
- this.makePagesizeValid(); 
-} // must be first due to dependencies
+        this.makePagesizeValid();
+      } // must be first due to dependencies
       if (this.states.isNavbarInvalid()) {
- this.makeNavbarValid(); 
-}
+        this.makeNavbarValid();
+      }
       if (this.states.isRowspanInvalid()) {
- this.makeRowspanValid(); 
-}
+        this.makeRowspanValid();
+      }
       if (this.states.isBackdropInvalid()) {
- this.makeBackdropValid(); 
-}
+        this.makeBackdropValid();
+      }
     },
 
     makeBackdropValid: function () {
@@ -170,8 +170,8 @@ qx.Class.define('cv.ui.layout.ResizeHandler', {
               left: backdropLeft + 'px',
               top: backdropTop + 'px'
             }).forEach(function(key_value) {
- backdrop.style[key_value[0]]=key_value[1]; 
-});
+              backdrop.style[key_value[0]]=key_value[1];
+            });
           }
 
           page.getDomElement().querySelectorAll('.widget_container').forEach(function (widgetContainer) {
@@ -254,8 +254,8 @@ qx.Class.define('cv.ui.layout.ResizeHandler', {
 
     __makePagesizeValid: function() {
       if (!cv.Config.currentPageId) {
- return; 
-}
+        return;
+      }
       qx.log.Logger.debug(this, 'makePagesizeValid');
       const page = cv.ui.structure.WidgetFactory.getInstanceById(cv.Config.currentPageId);
       if (page && !page.isInitialized()) {
@@ -298,9 +298,9 @@ qx.Class.define('cv.ui.layout.ResizeHandler', {
       if (height === 0) {
         // not ready try again
         const self = this;
-        qx.bom.AnimationFrame.request(function() {
- self.__updateRowHeight(elem); 
-}, this);
+        window.requestAnimationFrame(() => {
+          self.__updateRowHeight(elem);
+        });
         return;
       }
       let styles = '';


### PR DESCRIPTION
Closes #1193 and #1213 as well as handles the situation where bus data might arrive quicker than the SVG to display.

Note: There was a startup issue that didn't set `#rowspanStyle` right after start, only after a screen resize. This PR might thus fix some subtle other layout issues.