### PR TITLE
Handle 404 config-error state better:

### DIFF
--- a/source/class/cv/Config.js
+++ b/source/class/cv/Config.js
@@ -120,6 +120,18 @@ qx.Class.define('cv.Config', {
     pluginsToLoad: [],
 
     /**
+     * Load the manager directly, no config
+     * @type {boolean}
+     */
+    loadManager: false,
+
+    /**
+     * Optional settings for manager loading
+     * @type {Map}
+     */
+    managerOptions: {},
+
+    /**
      * All configuration and settings from the current configuration
      * (Note: all settings that need to be cached must be put in here)
      */
@@ -334,6 +346,12 @@ qx.Class.define('cv.Config', {
     } else if (req.queryKey.log === 'true') {
       cv.Config.enableLogging = true;
     }
+
+    cv.Config.loadManager = cv.Config.request.queryKey.manager || window.location.hash === '#manager';
+    cv.Config.managerOptions = {
+      action: cv.Config.request.queryKey.open ? 'open' : '',
+      data: cv.Config.request.queryKey.open ? cv.Config.request.queryKey.open : undefined
+    };
 
     // "Bug"-Fix for ID: 3204682 "Caching on web server"
     // Config isn't a real fix for the problem as that's part of the web browser,

--- a/source/class/cv/ui/manager/Main.js
+++ b/source/class/cv/ui/manager/Main.js
@@ -224,6 +224,16 @@ qx.Class.define('cv.ui.manager.Main', {
       return actions.includes(actionName);
     },
 
+    _doClose() {
+      if (document.querySelector('#main.loading')) {
+        // there is no config file loaded, load the default one
+        let configLoader = new cv.util.ConfigLoader();
+        let app = qx.core.Init.getApplication();
+        configLoader.load(app.bootstrap, app);
+      }
+      this.setVisible(false);
+    },
+
     handleAction: function (actionName, data) {
       let unsavedFiles;
       switch (actionName) {
@@ -237,6 +247,7 @@ qx.Class.define('cv.ui.manager.Main', {
 
         case 'quit':
           unsavedFiles = this.getOpenFiles().filter(openFile => openFile.getFile().isModified());
+
           if (unsavedFiles.length > 0) {
             const dialog = new qxl.dialog.Confirm({
               message: qx.locale.Manager.tr('You have files opened with unsaved changes, you should save them now.'),
@@ -247,7 +258,7 @@ qx.Class.define('cv.ui.manager.Main', {
                   });
                 }
                 dialog.dispose();
-                this.setVisible(false);
+                this._doClose();
               },
               context: this,
               caption: qx.locale.Manager.tr('Unsaved changes'),
@@ -257,7 +268,7 @@ qx.Class.define('cv.ui.manager.Main', {
             });
             dialog.show();
           } else {
-            this.setVisible(false);
+            this._doClose();
           }
           break;
 

--- a/source/class/cv/util/ConfigLoader.js
+++ b/source/class/cv/util/ConfigLoader.js
@@ -198,6 +198,7 @@ qx.Class.define('cv.util.ConfigLoader', {
       const configSuffix = (cv.Config.configSuffix ? cv.Config.configSuffix : '');
       const title = qx.locale.Manager.tr('Config-File Error!').translate().toString();
       let message = '';
+      let actions;
       switch (textStatus) {
         case 'parsererror':
           message = qx.locale.Manager.tr('Invalid config file!')+'<br/><a href="#" onclick="showConfigErrors(\'' + configSuffix + '\')">'+qx.locale.Manager.tr('Please check!')+'</a>';
@@ -216,6 +217,19 @@ qx.Class.define('cv.util.ConfigLoader', {
         }
         case 'filenotfound':
           message = qx.locale.Manager.tr('404: Config file not found. Neither as normal config (%1) nor as demo config (%2).', additionalErrorInfo[0], additionalErrorInfo[1]).translate().toString();
+          message += '<br/>'  + qx.locale.Manager.tr('You can open the manager to create or upload a config file.').translate().toString();
+          actions = {
+            link: [
+              {
+                title: qx.locale.Manager.tr('Open manager'),
+                type: 'manager',
+                action: () => {
+                  qx.core.Init.getApplication().showManager();
+                },
+                needsConfirmation: false
+              }
+            ]
+          }
           break;
         default:
           message = qx.locale.Manager.tr('Unhandled error of type "%1"', textStatus).translate().toString();
@@ -232,6 +246,9 @@ qx.Class.define('cv.util.ConfigLoader', {
         severity: 'urgent',
         unique: true
       };
+      if (actions) {
+        notification.actions = actions;
+      }
       cv.core.notifications.Router.dispatchMessage(notification.topic, notification);
       this.error(this, message.toString());
       qx.core.Init.getApplication().block(false);

--- a/source/class/cv/util/ConfigLoader.js
+++ b/source/class/cv/util/ConfigLoader.js
@@ -229,7 +229,7 @@ qx.Class.define('cv.util.ConfigLoader', {
                 needsConfirmation: false
               }
             ]
-          }
+          };
           break;
         default:
           message = qx.locale.Manager.tr('Unhandled error of type "%1"', textStatus).translate().toString();

--- a/source/class/cv/util/ConfigLoader.js
+++ b/source/class/cv/util/ConfigLoader.js
@@ -230,8 +230,7 @@ qx.Class.define('cv.util.ConfigLoader', {
         title: title,
         message: message,
         severity: 'urgent',
-        unique: true,
-        deletable: false
+        unique: true
       };
       cv.core.notifications.Router.dispatchMessage(notification.topic, notification);
       this.error(this, message.toString());

--- a/source/resource/designs/designglobals.css
+++ b/source/resource/designs/designglobals.css
@@ -749,6 +749,10 @@ pre.inline { display: inline-block; }
   text-align: center;
 }
 
+#manager {
+  color: rgb(192, 192, 192);
+}
+
 #manager div.touch-tree-open-icon {
   line-height: 32px !important;
   text-align: right !important;

--- a/source/translation/de.po
+++ b/source/translation/de.po
@@ -1063,3 +1063,15 @@ msgstr "Der Manager steht nicht zu Verfügung"
 #: cv/Application.js
 msgid "Your system does not provide the required PHP version for the manager. Installed: %1, required: %2"
 msgstr "Die auf Ihrem System installierte PHP Version wird vom Manager nicht unterstützt. Installiert: %1, erforderlich: %2"
+
+#: cv/Application.js
+msgid "Manager"
+msgstr "Manager"
+
+#: cv/util/ConfigLoader.js
+msgid "You can open the manager to create or upload a config file."
+msgstr "Sie können den Manager öffnen, um eine neue Konfigurations-Datei zu erstellen oder eine bestehende hochzuladen."
+
+#: cv/util/ConfigLoader.js
+msgid "Open manager"
+msgstr "Manager öffnen"

--- a/source/translation/en.po
+++ b/source/translation/en.po
@@ -1020,7 +1020,7 @@ msgstr ""
 msgid "Edit text content"
 msgstr ""
 
-#: cv/ui/manager/Main.js
+#: cv/ui/manager/MenuBar.js
 msgid "About"
 msgstr ""
 
@@ -1134,4 +1134,16 @@ msgstr ""
 
 #: cv/Application.js
 msgid "Your system does not provide the required PHP version for the manager. Installed: %1, required: %2"
+msgstr ""
+
+#: cv/Application.js
+msgid "Manager"
+msgstr ""
+
+#: cv/util/ConfigLoader.js
+msgid "You can open the manager to create or upload a config file."
+msgstr ""
+
+#: cv/util/ConfigLoader.js
+msgid "Open manager"
 msgstr ""


### PR DESCRIPTION
* Always be able to load the manager
* If manager is loaded directly, do not load the config
* If directly loaded manager is closes, open the config
* allow config error to be closed, because you can do something in the manager then
* fix history when manager is closed