### PR TITLE
replace some special characters in attribute values

### DIFF
--- a/source/class/cv/ui/manager/model/XmlElement.js
+++ b/source/class/cv/ui/manager/model/XmlElement.js
@@ -64,6 +64,20 @@ qx.Class.define('cv.ui.manager.model.XmlElement', {
 
   /*
   ***********************************************
+    STATICS
+  ***********************************************
+  */
+  statics: {
+    entityMap: {
+      '&': '&amp;',
+      '"': '&quot;',
+      '\'': '&#39;',
+      '`': '&#x60;'
+    }
+  },
+
+  /*
+  ***********************************************
     PROPERTIES
   ***********************************************
   */
@@ -845,6 +859,9 @@ qx.Class.define('cv.ui.manager.model.XmlElement', {
           } else {
             value = '' + value;
           }
+          value = value.replace(/[&"'`]/g, function (s) {
+            return cv.ui.manager.model.XmlElement.entityMap[s];
+          });
           newValue = value;
           if (attribute.isValueValid(value)) {
             if (oldValue !== value) {


### PR DESCRIPTION
that are not allowed there (&!'`)

closes problem reported here:
https://knx-user-forum.de/forum/supportforen/cometvisu/1756069-cv-0-12-0-rc9-fehler-in-konfiguration-bei-web-und-image-widget