### PR TITLE
set navbars to inactive before bailing out

### DIFF
--- a/source/class/cv/ui/PagePartsHandler.js
+++ b/source/class/cv/ui/PagePartsHandler.js
@@ -308,6 +308,7 @@ qx.Class.define('cv.ui.PagePartsHandler', {
             const data = cv.data.Model.getInstance().getWidgetData(id + pos + '_navbar');
             if (data.scope >= 0 && tree.length-level > data.scope) {
               // navbar that is not visible at the moment -> ignore it
+              nav.classList.remove('navbarActive');
               return;
             }
             if (data.dynamic !== null) {


### PR DESCRIPTION
closes problem reported here https://knx-user-forum.de/forum/supportforen/cometvisu/1768292-cv0-12-rc11-navbar-wir-f%C3%A4lschlicherweise-vererbt-nach-reload-ok