### PR TITLE
enable mapping and infoaction for wgplugin_info

### DIFF
--- a/source/resource/visu_config.xsd
+++ b/source/resource/visu_config.xsd
@@ -1903,6 +1903,7 @@
     <xsd:attribute ref="align" use="optional" />
     <xsd:attribute ref="flavour" use="optional" />
     <xsd:attribute ref="class" use="optional" />
+    <xsd:attribute ref="mapping" use="optional" />
   </xsd:complexType>
 
   <xsd:complexType name="image">
@@ -3231,6 +3232,7 @@
     <xsd:choice>
       <xsd:element name="text" type="text" />
       <xsd:element name="info" type="info" />
+      <xsd:element name="wgplugin_info" type="wgplugin_info" />
     </xsd:choice>
   </xsd:group>
   


### PR DESCRIPTION
I may be the one of the last fellows using wgplugin_info, but it still works.
With this xsd adjustment, configs using wgplugin_info with mappings or inside an infoaction element will be valid. (They were already working fine before - but the config validation failed)