### PR TITLE
fixes icon cache error

### DIFF
--- a/source/class/cv/IconHandler.js
+++ b/source/class/cv/IconHandler.js
@@ -81,8 +81,10 @@ qx.Class.define('cv.IconHandler', {
      * @param {string?} source
      */
     insert: function (name, uri, type= '*', flavour='*', color='*', styling=undefined, dynamic='', source = undefined) {
+      let added = false;
       if (!this.__db[name]) {
         this.__db[name] = {};
+        added = true;
       }
       if (source) {
         this.__db[name].source = source;
@@ -104,6 +106,8 @@ qx.Class.define('cv.IconHandler', {
           styling: styling
         };
       }
+
+      return added;
     },
 
     /**

--- a/source/class/cv/parser/MetaParser.js
+++ b/source/class/cv/parser/MetaParser.js
@@ -85,8 +85,9 @@ qx.Class.define('cv.parser.MetaParser', {
 
     parseIcons: function(elem) {
       let icon = this.__parseIconDefinition(elem);
-      cv.Config.configSettings.iconsFromConfig.push(icon);
-      cv.IconHandler.getInstance().insert(icon.name, icon.uri, icon.type, icon.flavour, icon.color, icon.styling, icon.dynamic, icon.source);
+      if (cv.IconHandler.getInstance().insert(icon.name, icon.uri, icon.type, icon.flavour, icon.color, icon.styling, icon.dynamic, icon.source)) {
+        cv.Config.configSettings.iconsFromConfig.push(icon);
+      }
     },
 
     parseMappings: function(elem) {

--- a/source/class/cv/util/IconTools.js
+++ b/source/class/cv/util/IconTools.js
@@ -289,12 +289,14 @@ qx.Class.define('cv.util.IconTools', {
       const parameters = (icon.className.split ? icon.className.split(' ') : icon.className.baseVal.split(' '))[0].substring(4).split('_');
       if (parameters.length === 2) {
         const cacheEntry = cv.util.IconTools.iconCache[cv.util.IconTools.iconCacheMap[parameters[0]]];
-        const coloredIcon = cacheEntry.colors['#' + parameters[1]];
+        if (cacheEntry) {
+          const coloredIcon = cacheEntry.colors['#' + parameters[1]];
 
-        if (undefined === coloredIcon) {
-          cv.util.IconTools.iconDelayed(icon, cacheEntry.colors, '#' + parameters[1]);
-        } else {
-          cv.util.IconTools.fillCanvas(icon, coloredIcon);
+          if (undefined === coloredIcon) {
+            cv.util.IconTools.iconDelayed(icon, cacheEntry.colors, '#' + parameters[1]);
+          } else {
+            cv.util.IconTools.fillCanvas(icon, coloredIcon);
+          }
         }
       }
     },


### PR DESCRIPTION
see https://knx-user-forum.de/forum/supportforen/cometvisu/1796829-fehler-nach-upgrade-auf-0-12-0-typeerror-n-is-undefined

also makes sure that cv.Config.configSettings.iconsFromConfig is not filled from cache and from config which makes it growing with duplicated everytime the cometvisu is loaded.

Use this config to reproduce::

```xml
<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
<pages xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backend="openhab" design="metal" lib_version="9" xsi:noNamespaceSchemaLocation="../visu_config.xsd" screensave_time="60" screensave_page="Übersicht">
  <meta>
    <icons>
      <icon-definition name="energy_meter" uri="./resource/config/media/energy_meter.png" dynamic="recolorNonTransparent"/>
      <icon-definition name="bmw_logo" uri="./resource/config/media/bmw-logo.png"/>
      <icon-definition name="tesla_logo" uri="./resource/config/media/tesla-logo.png"/>
      <icon-definition name="ev_station" uri="./resource/config/media/ev_station.png"/>
    </icons>
  </meta>
  <page name="Übersicht" showtopnavigation="false" showfooter="true" shownavbar-left="true">
        <info mapping="Empty">
          <layout colspan="2"/>
          <label>
            <icon name="energy_meter"/>
          </label>
          <address transform="OH:number" variant="" mode="read">StromBezug</address>
        </info>
  </page>
</pages>
```

Make sure that cache is enabled in source-build with url parameter `enableCache=true`.

Without this fix the error occurs on second loading, also `cv.Config.configSettings.iconsFromConfig` is growing with duplicated for evenry reload. With this fix both problems should be gone.
