### PR TITLE
Fix documentation as the docker "arm" built is now included

### DIFF
--- a/doc/manual/de/install/timberwolf.rst
+++ b/doc/manual/de/install/timberwolf.rst
@@ -97,7 +97,7 @@ Unter *Containers* → *Add Container*
 
 - Name: ``CometVisu``
 - Image configuration: Name: ``cometvisu/cometvisu:latest`` für die "großen" Server
-  (TSW2xxx) oder ``cometvisu/cometvisu:latest-arm`` für die Hutschienen-Server.
+  (TSW2xxx), aber auch für die Hutschienen-Server.
 - Port mapping: host ``18080``, container ``80``
 - Advanced container settings:
 
@@ -268,8 +268,7 @@ kann.
 
 Wie unter :ref:`Docker <docker>` beschrieben hat die neueste
 Entwicklungsversion den Tag ``testing``. Somit ist unter *Anlegen des
-Containers* als ``name`` ``cometvisu/cometvisu:testing`` bzw.
-``cometvisu/cometvisu:testing-arm`` zu verwenden.
+Containers* als ``name`` ``cometvisu/cometvisu:testing`` zu verwenden.
 
 Um für Fehlerberichte u.ä. eine einheitliche Umgebung zu haben, ist die
 Empfehlung die Testing Version mit diesen Parametern zu installieren:
@@ -277,7 +276,7 @@ Empfehlung die Testing Version mit diesen Parametern zu installieren:
 - Container:
 
   - Name: ``CometVisuTest``
-  - Image configuration: Name: ``cometvisu/cometvisu:testing`` bzw. ``cometvisu/cometvisu:testing-arm``
+  - Image configuration: Name: ``cometvisu/cometvisu:testing``
   - Port mapping: host ``28080``, container ``80``
   - Advanced container settings:
 

--- a/doc/manual/en/install/timberwolf.rst
+++ b/doc/manual/en/install/timberwolf.rst
@@ -86,8 +86,7 @@ Under: *Containers* → *Add Container*
 
 - Name: ``CometVisu``
 - Image configuration: Name: ``cometvisu/cometvisu:latest`` for the big servers
-  (TWS2xxx) or ``cometvisu/cometvisu:latest-arm`` for the rail mounted smaller
-  servers
+  (TWS2xxx) and for the rail mounted smaller servers
 - Port mapping: host ``18080``, container ``80``
 - Advanced container settings:
 
@@ -253,10 +252,10 @@ version, a separate volume (for example ``CometVisuTestConfig``)
 should be created, as the format of the config files may change
 incompatibly due to future updates.
 
-As described under :ref:`Docker <docker>` has the newest
-Development version the day ``testing``. Thus, under
+As described under :ref:`Docker <docker>` the newest
+Development version the tag ``testing``. Thus, under
 *Creating the container* as ``name`` ``cometvisu/cometvisu:testing``
-or ``cometvisu/cometvisu:testing-arm`` to use.
+ must be used.
 
 
 In order to have a uniform environment for error reporting, etc.
@@ -265,7 +264,7 @@ the testing version should be installed with these parameters:
 - Container:
 
   - Name: ``CometVisuTest``
-  - Image configuration: Name: ``cometvisu/cometvisu:testing`` or ``cometvisu/cometvisu:testing-arm``
+  - Image configuration: Name: ``cometvisu/cometvisu:testing``
   - Port mapping: host ``28080``, container ``80``
   - Advanced container settings:
 


### PR DESCRIPTION
Fix documentation as the docker "arm" built is now included in the main container

(cherry picked from commit fc58bc0bd6a3d7b203848a0c7480396cd3bebdc9)