### PR TITLE
preprare openhab backend authentification

### DIFF
--- a/client/source/class/cv/io/Client.js
+++ b/client/source/class/cv/io/Client.js
@@ -689,6 +689,10 @@ qx.Class.define('cv.io.Client', {
     // this client does not implement an authorization
     authorize(req) {},
 
+    canAuthorize() {
+      return false;
+    },
+
     /**
      * Restart the connection
      * @param full

--- a/client/source/class/cv/io/IClient.js
+++ b/client/source/class/cv/io/IClient.js
@@ -131,6 +131,12 @@ qx.Interface.define('cv.io.IClient', {
     authorize(req) {},
 
     /**
+     * Client is able to authorize a request, by knowing the credentials
+     * @return {Boolean}
+     */
+    canAuthorize() {},
+
+    /**
      * return the relative path to a resource on the currently used backend
      *
      * @param name {String} Name of the resource (e.g. login, read, write, chart)

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,11 @@
       "version": "0.13.0-dev",
       "license": "GPL-3.0",
       "dependencies": {
-        "@qooxdoo/framework": "^7.7.1",
+        "@qooxdoo/framework": "^7.7.2",
         "@sentry/browser": "^8.12.0",
         "crc-32": "^1.2.2",
-        "monaco-editor": "^0.45.0"
+        "monaco-editor": "^0.50.0",
+        "oauth-pkce": "^0.0.7"
       },
       "devDependencies": {
         "@babel/eslint-parser": "^7.23.3",
@@ -24,11 +25,11 @@
         "babel-preset-es2015": "^6.24.1",
         "chmodr": "^1.2.0",
         "easyimage": "^3.1.1",
-        "eslint": "^8.56.0",
+        "eslint": "^9.6.0",
         "eslint-plugin-babel": "^5.3.1",
         "eslint-plugin-custom-elements": "^0.0.8",
         "eslint-plugin-jasmine": "^4.1.3",
-        "eslint-plugin-jsdoc": "^46.9.1",
+        "eslint-plugin-jsdoc": "^48.5.0",
         "eslint-plugin-protractor": "^2.1.1",
         "fast-glob": "^3.3.2",
         "fs-extra": "^11.2.0",
@@ -1855,13 +1856,13 @@
       }
     },
     "node_modules/@es-joy/jsdoccomment": {
-      "version": "0.41.0",
-      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.41.0.tgz",
-      "integrity": "sha512-aKUhyn1QI5Ksbqcr3fFJj16p99QdjUxXAEuFst1Z47DRyoiMwivIH9MV/ARcJOCXVjPfjITciej8ZD2O/6qUmw==",
+      "version": "0.46.0",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.46.0.tgz",
+      "integrity": "sha512-C3Axuq1xd/9VqFZpW4YAzOx5O9q/LP46uIQy/iNDpHG3fmPa6TBtvfglMCs3RBiBxAIi0Go97r8+jvTt55XMyQ==",
       "dev": true,
       "dependencies": {
         "comment-parser": "1.4.1",
-        "esquery": "^1.5.0",
+        "esquery": "^1.6.0",
         "jsdoc-type-pratt-parser": "~4.0.0"
       },
       "engines": {
@@ -1894,22 +1895,35 @@
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.10.0.tgz",
-      "integrity": "sha512-Cu96Sd2By9mCNTx2iyKOmq10v22jUVQv0lQnlGNy16oE9589yE+QADPbrMGCkA51cKZSg3Pu/aTJVTGfL/qjUA==",
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.11.0.tgz",
+      "integrity": "sha512-G/M/tIiMrTAxEWRfLfQJMmGNX28IxBg4PBz8XqQhqUHLFI6TL2htpIB1iQCj144V5ee/JaKyT9/WZ0MGZWfA7A==",
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
     },
+    "node_modules/@eslint/config-array": {
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.17.1.tgz",
+      "integrity": "sha512-BlYOpej8AQ8Ev9xVqroV7a02JK3SkBAaN9GfMMH9W6Ch8FlQlkjGw4Ir7+FgYwfirivAf4t+GtzuAxqfukmISA==",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.4",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
     "node_modules/@eslint/eslintrc": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
-      "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.1.0.tgz",
+      "integrity": "sha512-4Bfj15dVJdoy3RfZmmo86RK1Fwzn6SstsvK9JS+BaVKqC6QQQQyXekNaC+g+LKNgkQ+2VhGAzm6hO40AhMR3zQ==",
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
-        "espree": "^9.6.0",
-        "globals": "^13.19.0",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
         "js-yaml": "^4.1.0",
@@ -1917,7 +1931,7 @@
         "strip-json-comments": "^3.1.1"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -1939,14 +1953,11 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/globals": {
-      "version": "13.24.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
-      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
-      "dependencies": {
-        "type-fest": "^0.20.2"
-      },
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
       "engines": {
-        "node": ">=8"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -1957,29 +1968,27 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
-    "node_modules/@eslint/eslintrc/node_modules/type-fest": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+    "node_modules/@eslint/js": {
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.7.0.tgz",
+      "integrity": "sha512-ChuWDQenef8OSFnvuxv0TCVxEwmu3+hPNKvM9B34qpM0rDRbjL8t5QkQeHHeAfsKQjuH9wS82WeCi1J/owatng==",
       "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
-    "node_modules/@eslint/js": {
-      "version": "8.57.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.0.tgz",
-      "integrity": "sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==",
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.4.tgz",
+      "integrity": "sha512-BsWiH1yFGjXXS2yvrf5LyuoSIIbPrGUWob917o+BTKuZ7qJdxX8aJLRxs1fS9n6r7vESrq1OUqb68dANcFXuQQ==",
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.14",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
       "integrity": "sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==",
+      "deprecated": "Use @eslint/config-array instead",
       "dependencies": {
         "@humanwhocodes/object-schema": "^2.0.2",
         "debug": "^4.3.1",
@@ -2012,7 +2021,20 @@
     "node_modules/@humanwhocodes/object-schema": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
-      "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA=="
+      "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
+      "deprecated": "Use @eslint/object-schema instead"
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.3.0.tgz",
+      "integrity": "sha512-d2CGZR2o7fS6sWB7DG/3a95bGKQyHMACZ5aW8qGkkqQpUoZV6C0X7Pc7l4ZNMZkfNBf4VWNe9E1jRsf0G146Ew==",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
@@ -2711,6 +2733,18 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@pkgr/core": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.1.1.tgz",
+      "integrity": "sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unts"
       }
     },
     "node_modules/@pnpm/config.env-replace": {
@@ -3795,9 +3829,9 @@
       }
     },
     "node_modules/@qooxdoo/framework": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/@qooxdoo/framework/-/framework-7.7.1.tgz",
-      "integrity": "sha512-dRaBvw/ljrZd/+hyDZHvJeVPATaOn9uQU1MuafIXP+7+KXYrjtyK1hLoolENcYrF47HBvxHji2g6m4RpiW48rw==",
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/@qooxdoo/framework/-/framework-7.7.2.tgz",
+      "integrity": "sha512-sKKU+uMJWnYQaUrCAkt/1axrfQOCYOkRyPcJ8sU4YJM8zUUt4JOHlAiHHpJeutV96G7XORo283W3Lxvy77Ij5Q==",
       "hasInstallScript": true,
       "dependencies": {
         "@babel/core": "^7.23.2",
@@ -3885,6 +3919,51 @@
         "node": ">=16"
       }
     },
+    "node_modules/@qooxdoo/framework/node_modules/@eslint/eslintrc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+      "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
+      "dependencies": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^9.6.0",
+        "globals": "^13.19.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.1.2",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@qooxdoo/framework/node_modules/@eslint/eslintrc/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@qooxdoo/framework/node_modules/@eslint/js": {
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.0.tgz",
+      "integrity": "sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
     "node_modules/@qooxdoo/framework/node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -3949,6 +4028,60 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@qooxdoo/framework/node_modules/eslint": {
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
+      "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/regexpp": "^4.6.1",
+        "@eslint/eslintrc": "^2.1.4",
+        "@eslint/js": "8.57.0",
+        "@humanwhocodes/config-array": "^0.11.14",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@nodelib/fs.walk": "^1.2.8",
+        "@ungap/structured-clone": "^1.2.0",
+        "ajv": "^6.12.4",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.3.2",
+        "doctrine": "^3.0.0",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^7.2.2",
+        "eslint-visitor-keys": "^3.4.3",
+        "espree": "^9.6.1",
+        "esquery": "^1.4.2",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^6.0.1",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "globals": "^13.19.0",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "is-path-inside": "^3.0.3",
+        "js-yaml": "^4.1.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3",
+        "strip-ansi": "^6.0.1",
+        "text-table": "^0.2.0"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/@qooxdoo/framework/node_modules/eslint-plugin-jsdoc": {
       "version": "46.8.2",
       "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-46.8.2.tgz",
@@ -3971,6 +4104,87 @@
         "eslint": "^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/@qooxdoo/framework/node_modules/eslint-scope": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+      "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@qooxdoo/framework/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@qooxdoo/framework/node_modules/eslint/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@qooxdoo/framework/node_modules/espree": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+      "dependencies": {
+        "acorn": "^8.9.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@qooxdoo/framework/node_modules/file-entry-cache": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+      "dependencies": {
+        "flat-cache": "^3.0.4"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/@qooxdoo/framework/node_modules/flat-cache": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
+      "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.3",
+        "rimraf": "^3.0.2"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
     "node_modules/@qooxdoo/framework/node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -3989,6 +4203,31 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@qooxdoo/framework/node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/@qooxdoo/framework/node_modules/globals": {
+      "version": "13.24.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@qooxdoo/framework/node_modules/has-flag": {
@@ -4029,6 +4268,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/@qooxdoo/framework/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "node_modules/@qooxdoo/framework/node_modules/node-fetch": {
       "version": "3.3.2",
@@ -4120,6 +4364,17 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@qooxdoo/framework/node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/@sentry-internal/browser-utils": {
       "version": "8.12.0",
@@ -4339,9 +4594,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.11.3",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
-      "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
+      "version": "8.12.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
+      "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7417,9 +7672,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
+      "integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -8122,6 +8377,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.5.4.tgz",
+      "integrity": "sha512-MVNK56NiMrOwitFB7cqDwq0CQutbw+0BvLshJSse0MUNU+y1FC3bUS/AQg7oUng+/wKrrki7JfmwtVHkVfPLlw==",
+      "dev": true
+    },
     "node_modules/es6-promise": {
       "version": "4.2.8",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
@@ -8207,40 +8468,36 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.57.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
-      "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.7.0.tgz",
+      "integrity": "sha512-FzJ9D/0nGiCGBf8UXO/IGLTgLVzIxze1zpfA8Ton2mjLovXdAPlYDv+MQDcqj3TmrhAGYfOpz9RfR+ent0AgAw==",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
-        "@eslint-community/regexpp": "^4.6.1",
-        "@eslint/eslintrc": "^2.1.4",
-        "@eslint/js": "8.57.0",
-        "@humanwhocodes/config-array": "^0.11.14",
+        "@eslint-community/regexpp": "^4.11.0",
+        "@eslint/config-array": "^0.17.0",
+        "@eslint/eslintrc": "^3.1.0",
+        "@eslint/js": "9.7.0",
         "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.3.0",
         "@nodelib/fs.walk": "^1.2.8",
-        "@ungap/structured-clone": "^1.2.0",
         "ajv": "^6.12.4",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
         "debug": "^4.3.2",
-        "doctrine": "^3.0.0",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^7.2.2",
-        "eslint-visitor-keys": "^3.4.3",
-        "espree": "^9.6.1",
-        "esquery": "^1.4.2",
+        "eslint-scope": "^8.0.2",
+        "eslint-visitor-keys": "^4.0.0",
+        "espree": "^10.1.0",
+        "esquery": "^1.5.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
-        "file-entry-cache": "^6.0.1",
+        "file-entry-cache": "^8.0.0",
         "find-up": "^5.0.0",
         "glob-parent": "^6.0.2",
-        "globals": "^13.19.0",
-        "graphemer": "^1.4.0",
         "ignore": "^5.2.0",
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
         "is-path-inside": "^3.0.3",
-        "js-yaml": "^4.1.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
         "lodash.merge": "^4.6.2",
@@ -8254,10 +8511,10 @@
         "eslint": "bin/eslint.js"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
-        "url": "https://opencollective.com/eslint"
+        "url": "https://eslint.org/donate"
       }
     },
     "node_modules/eslint-formatter-codeframe": {
@@ -8379,23 +8636,24 @@
       }
     },
     "node_modules/eslint-plugin-jsdoc": {
-      "version": "46.10.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-46.10.1.tgz",
-      "integrity": "sha512-x8wxIpv00Y50NyweDUpa+58ffgSAI5sqe+zcZh33xphD0AVh+1kqr1ombaTRb7Fhpove1zfUuujlX9DWWBP5ag==",
+      "version": "48.8.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-48.8.3.tgz",
+      "integrity": "sha512-AtIvwwW9D17MRkM0Z0y3/xZYaa9mdAvJrkY6fU/HNUwGbmMtHVvK4qRM9CDixGVtfNrQitb8c6zQtdh6cTOvLg==",
       "dev": true,
       "dependencies": {
-        "@es-joy/jsdoccomment": "~0.41.0",
+        "@es-joy/jsdoccomment": "~0.46.0",
         "are-docs-informative": "^0.0.2",
         "comment-parser": "1.4.1",
-        "debug": "^4.3.4",
+        "debug": "^4.3.5",
         "escape-string-regexp": "^4.0.0",
-        "esquery": "^1.5.0",
-        "is-builtin-module": "^3.2.1",
-        "semver": "^7.5.4",
-        "spdx-expression-parse": "^4.0.0"
+        "esquery": "^1.6.0",
+        "parse-imports": "^2.1.1",
+        "semver": "^7.6.3",
+        "spdx-expression-parse": "^4.0.0",
+        "synckit": "^0.9.1"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       },
       "peerDependencies": {
         "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0"
@@ -8414,9 +8672,9 @@
       }
     },
     "node_modules/eslint-plugin-jsdoc/node_modules/semver": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -8569,26 +8827,26 @@
       }
     },
     "node_modules/eslint/node_modules/eslint-scope": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
-      "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.0.2.tgz",
+      "integrity": "sha512-6E4xmrTw5wtxnLA5wYL3WDfhZ/1bUBGOXV0zQvVRDOtrR8D0p6W7fs3JweNYhwRYeGvd/1CKX2se0/2s7Q/nJA==",
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/eslint/node_modules/eslint-visitor-keys": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.0.0.tgz",
+      "integrity": "sha512-OtIRv/2GyiF6o/d8K7MYKKbXrOUBIK6SfkIRM4Z0dY3w+LiQ0vy3F57m0Z71bjbyeiWFiHJ8brqnmE6H6/jEuw==",
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -8603,20 +8861,6 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/eslint/node_modules/globals": {
-      "version": "13.24.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
-      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
-      "dependencies": {
-        "type-fest": "^0.20.2"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/eslint/node_modules/has-flag": {
@@ -8643,39 +8887,28 @@
         "node": ">=8"
       }
     },
-    "node_modules/eslint/node_modules/type-fest": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/espree": {
-      "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
-      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.1.0.tgz",
+      "integrity": "sha512-M1M6CpiE6ffoigIOWYO9UDP8TMUw9kqb21tf+08IgDYjCsOvCuDt4jQcZmoYxx+w7zlKw9/N0KXfto+I8/FrXA==",
       "dependencies": {
-        "acorn": "^8.9.0",
+        "acorn": "^8.12.0",
         "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^3.4.1"
+        "eslint-visitor-keys": "^4.0.0"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/espree/node_modules/eslint-visitor-keys": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.0.0.tgz",
+      "integrity": "sha512-OtIRv/2GyiF6o/d8K7MYKKbXrOUBIK6SfkIRM4Z0dY3w+LiQ0vy3F57m0Z71bjbyeiWFiHJ8brqnmE6H6/jEuw==",
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -8694,9 +8927,9 @@
       }
     },
     "node_modules/esquery": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
-      "integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
+      "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
       "dependencies": {
         "estraverse": "^5.1.0"
       },
@@ -9142,14 +9375,14 @@
       }
     },
     "node_modules/file-entry-cache": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
-      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
       "dependencies": {
-        "flat-cache": "^3.0.4"
+        "flat-cache": "^4.0.0"
       },
       "engines": {
-        "node": "^10.12.0 || >=12.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/file-type": {
@@ -9278,16 +9511,15 @@
       }
     },
     "node_modules/flat-cache": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
-      "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
       "dependencies": {
         "flatted": "^3.2.9",
-        "keyv": "^4.5.3",
-        "rimraf": "^3.0.2"
+        "keyv": "^4.5.4"
       },
       "engines": {
-        "node": "^10.12.0 || >=12.0.0"
+        "node": ">=16"
       }
     },
     "node_modules/flatted": {
@@ -14029,9 +14261,9 @@
       }
     },
     "node_modules/monaco-editor": {
-      "version": "0.45.0",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.45.0.tgz",
-      "integrity": "sha512-mjv1G1ZzfEE3k9HZN0dQ2olMdwIfaeAAjFiwNprLfYNRSz7ctv9XuCT7gPtBGrMUeV1/iZzYKj17Khu1hxoHOA=="
+      "version": "0.50.0",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.50.0.tgz",
+      "integrity": "sha512-8CclLCmrRRh+sul7C08BmPBP3P8wVWfBHomsTcndxg5NRCEPfu/mc2AGU8k37ajjDVXcXFc12ORAMUkmk+lkFA=="
     },
     "node_modules/morgan": {
       "version": "1.10.0",
@@ -14335,6 +14567,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/oauth-pkce": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/oauth-pkce/-/oauth-pkce-0.0.7.tgz",
+      "integrity": "sha512-HMMakoec7G3Fyhq/VfYfQXmsJhZGQLncPCj/ir0xQQqX/kRDE9w1WFOaMJXlxfNlDDq3XDSy4mXGFPqU6oMAGg=="
     },
     "node_modules/oauth-sign": {
       "version": "0.9.0",
@@ -14905,6 +15142,19 @@
       },
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/parse-imports": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/parse-imports/-/parse-imports-2.1.1.tgz",
+      "integrity": "sha512-TDT4HqzUiTMO1wJRwg/t/hYk8Wdp3iF/ToMIlAoVQfL1Xs/sTxq1dKWSMjMbQmIarfWKymOyly40+zmPHXMqCA==",
+      "dev": true,
+      "dependencies": {
+        "es-module-lexer": "^1.5.3",
+        "slashes": "^3.0.12"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/parse-passwd": {
@@ -16950,6 +17200,12 @@
         }
       ]
     },
+    "node_modules/slashes": {
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/slashes/-/slashes-3.0.12.tgz",
+      "integrity": "sha512-Q9VME8WyGkc7pJf6QEkj3wE+2CnvZMI+XJhwdTPR8Z/kWQRXi7boAWLDibRPyHRTUTPx5FaU7MsyrjI3yLB4HA==",
+      "dev": true
+    },
     "node_modules/slice-ansi": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
@@ -17461,6 +17717,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/synckit": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.9.1.tgz",
+      "integrity": "sha512-7gr8p9TQP6RAHusBOSLs46F4564ZrjV8xFmw5zCmgmhGUcw2hxsShhJ6CEiHQMgPDwAQ1fWHPM0ypc4RMAig4A==",
+      "dev": true,
+      "dependencies": {
+        "@pkgr/core": "^0.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unts"
       }
     },
     "node_modules/syntax-error": {

--- a/package.json
+++ b/package.json
@@ -47,11 +47,11 @@
     "babel-preset-es2015": "^6.24.1",
     "chmodr": "^1.2.0",
     "easyimage": "^3.1.1",
-    "eslint": "^8.56.0",
+    "eslint": "^9.6.0",
     "eslint-plugin-babel": "^5.3.1",
     "eslint-plugin-custom-elements": "^0.0.8",
     "eslint-plugin-jasmine": "^4.1.3",
-    "eslint-plugin-jsdoc": "^46.9.1",
+    "eslint-plugin-jsdoc": "^48.5.0",
     "eslint-plugin-protractor": "^2.1.1",
     "fast-glob": "^3.3.2",
     "fs-extra": "^11.2.0",
@@ -86,10 +86,11 @@
     "xml-js": "^1.6.11"
   },
   "dependencies": {
-    "@qooxdoo/framework": "^7.7.1",
+    "@qooxdoo/framework": "^7.7.2",
     "@sentry/browser": "^8.12.0",
     "crc-32": "^1.2.2",
-    "monaco-editor": "^0.45.0"
+    "monaco-editor": "^0.50.0",
+    "oauth-pkce": "^0.0.7"
   },
   "eslintConfig": {
     "root": true,
@@ -227,6 +228,7 @@
       "Favico": "readonly",
       "jQuery": "readonly",
       "localStorage": "readonly",
+      "sessionStorage": "readonly",
       "monaco": "readonly",
       "Paho": "readonly",
       "replayLog": "readonly",

--- a/source/class/cv/Application.js
+++ b/source/class/cv/Application.js
@@ -1119,9 +1119,6 @@ qx.Class.define('cv.Application', {
             if (Object.prototype.hasOwnProperty.call(env, 'requiresAuth')) {
               cv.io.rest.Client.AUTH_REQUIRED = env.requiresAuth === true;
             }
-            // DO NOT COMMIT THIS!!!!
-            cv.io.rest.Client.AUTH_REQUIRED = true;
-            this.setServedByOpenhab(true);
 
             const serverVersionId = env.PHP_VERSION_ID;
             const orParts = env.required_php_version

--- a/source/class/cv/Application.js
+++ b/source/class/cv/Application.js
@@ -67,8 +67,14 @@ qx.Class.define('cv.Application', {
 
     const check = e => {
       const req = e.getTarget();
-      const header = req.getResponseHeader('Server');
-      const isOpenHAB = header ? header.startsWith('Jetty') : false;
+      let header = req.getResponseHeader('Server');
+      let isOpenHAB = false;
+      if (header) {
+        isOpenHAB = header.startsWith('Jetty');
+      } else {
+        header = req.getResponseHeader('X-CometVisu-Backend-Name');
+        isOpenHAB = header === 'openhab';
+      }
       this.setServedByOpenhab(isOpenHAB);
       this.setServerChecked(true);
     };
@@ -1110,6 +1116,9 @@ qx.Class.define('cv.Application', {
 
             this.setServerPhpVersion(env.phpversion);
             this.setServer(env.SERVER_SOFTWARE);
+            if (Object.prototype.hasOwnProperty.call(env, 'requiresAuth')) {
+              cv.io.rest.Client.AUTH_REQUIRED = env.requiresAuth === true;
+            }
 
             const serverVersionId = env.PHP_VERSION_ID;
             const orParts = env.required_php_version

--- a/source/class/cv/io/Mockup.js
+++ b/source/class/cv/io/Mockup.js
@@ -222,6 +222,10 @@ qx.Class.define('cv.io.Mockup', {
 
     authorize(req) {},
 
+    canAuthorize() {
+      return false;
+    },
+
     terminate() {},
 
     update(json) {},

--- a/source/class/cv/io/System.js
+++ b/source/class/cv/io/System.js
@@ -199,6 +199,9 @@ qx.Class.define('cv.io.System', {
     },
 
     authorize(req) {},
+    canAuthorize() {
+      return false;
+    },
 
     terminate() {},
 

--- a/source/class/cv/io/mqtt/Client.js
+++ b/source/class/cv/io/mqtt/Client.js
@@ -237,6 +237,9 @@ qx.Class.define('cv.io.mqtt.Client', {
      * @param req {qx.io.request.Xhr}
      */
     authorize(req) {},
+    canAuthorize() {
+      return false;
+    },
 
     /**
      * return the relative path to a resource on the currently used backend

--- a/source/class/cv/io/openhab/Rest.js
+++ b/source/class/cv/io/openhab/Rest.js
@@ -20,6 +20,7 @@
 /**
  * openHAB Rest client, that uses the native openHAB REST-API directly and does not
  * need the openHAB-cometvisu binding to be installed
+ * @ignore(getPkce)
  */
 qx.Class.define('cv.io.openhab.Rest', {
   extend: cv.io.AbstractClient,
@@ -170,6 +171,10 @@ qx.Class.define('cv.io.openhab.Rest', {
       if (this.__token) {
         req.setRequestHeader('Authorization', this.__token);
       }
+    },
+
+    canAuthorize() {
+      return !!this.__token;
     },
 
     /**
@@ -389,7 +394,7 @@ qx.Class.define('cv.io.openhab.Rest', {
     login(loginOnly, credentials, callback, context) {
       if (credentials && credentials.username) {
         // just saving the credentials for later use as we are using basic authentication
-        this.__token = 'Basic ' + btoa(credentials.username + ':' + (credentials.password || ''));
+        this.__token = 'Bearer ' + credentials.username;
       }
       this.setDataReceived(false);
       // no login needed we just do a request to the if the backend is reachable

--- a/source/class/cv/io/rest/Client.js
+++ b/source/class/cv/io/rest/Client.js
@@ -54,7 +54,7 @@ qx.Class.define('cv.io.rest.Client', {
     checkAuth(req) {
       if (this.AUTH_REQUIRED) {
         if (qx.core.Init.getApplication().isServedByOpenhab()) {
-          const backend = cv.io.BackendConnections.getClientByType("openhab");
+          const backend = cv.io.BackendConnections.getClientByType('openhab');
           if (backend) {
             backend.authorize(req);
           } else {

--- a/source/class/cv/io/rest/Client.js
+++ b/source/class/cv/io/rest/Client.js
@@ -34,6 +34,7 @@ qx.Class.define('cv.io.rest.Client', {
     __dirClient: null,
     __dpClient: null,
     __callbacks: {},
+    AUTH_REQUIRED: false,
 
     getBaseUrl() {
       if (!this.BASE_URL) {
@@ -48,6 +49,21 @@ qx.Class.define('cv.io.rest.Client', {
         this.BASE_URL = path;
       }
       return this.BASE_URL;
+    },
+
+    checkAuth(req) {
+      if (this.AUTH_REQUIRED) {
+        if (qx.core.Init.getApplication().isServedByOpenhab()) {
+          const backend = cv.io.BackendConnections.getClientByType("openhab");
+          if (backend) {
+            backend.authorize(req);
+          } else {
+            qx.log.Logger.warn('no openHAB backend configured, cannot authorize');
+          }
+        } else {
+          qx.log.Logger.warn('authentication is currently only implemented for the openHAB API backend');
+        }
+      }
     },
 
     getConfigClient() {
@@ -89,6 +105,7 @@ qx.Class.define('cv.io.rest.Client', {
             req.setRequestHeader('Content-Type', 'application/json');
           }
           req.setAccept('application/json');
+          cv.io.rest.Client.checkAuth(req);
         });
 
         this._enableSync(this.__configFile, config);
@@ -153,6 +170,7 @@ qx.Class.define('cv.io.rest.Client', {
             }
             req.setAccept('application/json');
           }
+          cv.io.rest.Client.checkAuth(req);
         });
 
         this._enableSync(this.__dirClient, config);
@@ -207,6 +225,7 @@ qx.Class.define('cv.io.rest.Client', {
         if (cv.Config.transactionId) {
           this.__dpClient.configureRequest(function (req, action, params) {
             req.setRequestHeader('X-Transaction-ID', cv.Config.transactionId);
+            cv.io.rest.Client.checkAuth(req);
           });
         }
 

--- a/source/class/cv/ui/Popup.js
+++ b/source/class/cv/ui/Popup.js
@@ -196,6 +196,16 @@ qx.Class.define('cv.ui.Popup', {
         } else {
           this.destroyElement('progress');
         }
+      } else if (attributes.iframe) {
+        if (!this.__elementMap.iframe) {
+          this.__elementMap.iframe = qx.dom.Element.create('iframe', {
+            width: '100%',
+            height: '100%'
+          });
+          ret_val.appendChild(this.__elementMap.iframe);
+        }
+        this.__elementMap.iframe.setAttribute('src', attributes.iframe);
+
       }
 
       if (attributes.actions && Object.getOwnPropertyNames(attributes.actions).length > 0) {
@@ -348,6 +358,13 @@ qx.Class.define('cv.ui.Popup', {
         this.__elementMap[name].parentNode.removeChild(this.__elementMap[name]);
         delete this.__elementMap[name];
       }
+    },
+
+    getElement(name) {
+      if (this.__elementMap[name]) {
+        return this.__elementMap[name];
+      }
+      return null;
     },
 
     /**

--- a/source/class/cv/ui/Popup.js
+++ b/source/class/cv/ui/Popup.js
@@ -205,7 +205,6 @@ qx.Class.define('cv.ui.Popup', {
           ret_val.appendChild(this.__elementMap.iframe);
         }
         this.__elementMap.iframe.setAttribute('src', attributes.iframe);
-
       }
 
       if (attributes.actions && Object.getOwnPropertyNames(attributes.actions).length > 0) {

--- a/source/class/cv/ui/manager/Main.js
+++ b/source/class/cv/ui/manager/Main.js
@@ -23,6 +23,7 @@
  * @since 0.12.0
  *
  * @asset(manager/*)
+ * @ignore(sessionStorage)
  */
 qx.Class.define('cv.ui.manager.Main', {
   extend: qx.core.Object,
@@ -45,9 +46,11 @@ qx.Class.define('cv.ui.manager.Main', {
     this.__actionDispatcher.setMain(this);
 
     this.__initCommands();
-    this._draw();
 
+    this._draw();
     qx.event.message.Bus.subscribe('cv.manager.*', this._onManagerEvent, this);
+
+    this._initAuth();
 
     // Initialize tooltip manager
     qx.ui.tooltip.Manager.getInstance();
@@ -401,6 +404,45 @@ qx.Class.define('cv.ui.manager.Main', {
       this._tree.refresh();
     },
 
+    _initAuth() {
+      if (cv.io.rest.Client.AUTH_REQUIRED && qx.core.Init.getApplication().isServedByOpenhab()) {
+        const storedToken = sessionStorage.getItem('openhab.cv:token');
+        if (storedToken) {
+          let backend = cv.io.BackendConnections.getClientByType('openhab');
+          if (!backend) {
+            backend = cv.io.BackendConnections.addBackendClient('openhab', 'openhab', undefined, 'manager');
+          }
+          backend.login(true, { username: storedToken });
+        } else {
+          this._handleUnauthorized();
+        }
+      }
+    },
+
+    _handleUnauthorized() {
+      if (cv.io.rest.Client.AUTH_REQUIRED && qx.core.Init.getApplication().isServedByOpenhab()) {
+        const storedToken = sessionStorage.getItem('openhab.cv:token');
+        if (storedToken) {
+          // remove old token, because it does not work anymore
+          sessionStorage.removeItem('openhab.cv:token')
+        }
+        let loginWidget = qxl.dialog.Dialog.prompt(qx.locale.Manager.tr('Please provide an openHAB API token. It can be generated in openHABs main UI.')).set({
+          caption: qx.locale.Manager.tr('Provide API token')
+        });
+        loginWidget.promise().then((token) => {
+          if (token) {
+            sessionStorage.setItem('openhab.cv:token', token);
+            let backend = cv.io.BackendConnections.getClientByType('openhab');
+            if (!backend) {
+              backend = cv.io.BackendConnections.addBackendClient('openhab', 'openhab', undefined, 'manager');
+            }
+            backend.login(true, { username: token });
+          }
+        });
+        loginWidget.show();
+      }
+    },
+
     __findConfigFile(name) {
       let file = null;
       let demoFolder = null;
@@ -534,6 +576,9 @@ qx.Class.define('cv.ui.manager.Main', {
         }
         if (!editorConfig.instance) {
           editorConfig.instance = new editorConfig.Clazz();
+          if (editorConfig.instance instanceof cv.ui.manager.editor.AbstractEditor) {
+            editorConfig.instance.addListener('unauthorized', this._handleUnauthorized, this);
+          }
         }
         editorConfig.instance.setFile(file);
         if (this._stack.indexOf(editorConfig.instance) < 0) {

--- a/source/class/cv/ui/manager/Main.js
+++ b/source/class/cv/ui/manager/Main.js
@@ -409,7 +409,7 @@ qx.Class.define('cv.ui.manager.Main', {
         let backend = cv.io.BackendConnections.getClientByType('openhab');
         if (backend && backend.canAuthorize()) {
           // already logged in
-          return
+          return;
         }
         const storedToken = sessionStorage.getItem('openhab.cv:token');
         if (storedToken) {
@@ -428,12 +428,12 @@ qx.Class.define('cv.ui.manager.Main', {
         const storedToken = sessionStorage.getItem('openhab.cv:token');
         if (storedToken) {
           // remove old token, because it does not work anymore
-          sessionStorage.removeItem('openhab.cv:token')
+          sessionStorage.removeItem('openhab.cv:token');
         }
         let loginWidget = qxl.dialog.Dialog.prompt(qx.locale.Manager.tr('Please provide an openHAB API token. It can be generated in openHABs main UI.')).set({
           caption: qx.locale.Manager.tr('Provide API token')
         });
-        loginWidget.promise().then((token) => {
+        loginWidget.promise().then(token => {
           if (token) {
             sessionStorage.setItem('openhab.cv:token', token);
             let backend = cv.io.BackendConnections.getClientByType('openhab');

--- a/source/class/cv/ui/manager/editor/AbstractEditor.js
+++ b/source/class/cv/ui/manager/editor/AbstractEditor.js
@@ -34,7 +34,23 @@ qx.Class.define('cv.ui.manager.editor.AbstractEditor', {
   construct() {
     super();
     this._initClient();
+    if (this._client) {
+      this._client.addListener('error', function(ev) {
+        if (ev.getRequest().getStatus() === 401) {
+          this.fireEvent('unauthorized');
+        }
+      }, this);
+    }
     this._nativePasteSupported = document.queryCommandSupported('paste');
+  },
+
+  /*
+  ***********************************************
+   EVENTS
+  ***********************************************
+  */
+  events: {
+   'unauthorized': 'qx.event.type.Event'
   },
 
   /*

--- a/source/class/cv/ui/manager/editor/Config.js
+++ b/source/class/cv/ui/manager/editor/Config.js
@@ -71,6 +71,20 @@ qx.Class.define('cv.ui.manager.editor.Config', {
       this._client = cv.io.rest.Client.getConfigClient();
       this._client.addListener('getSuccess', this._onModelValueChange, this);
       this._client.addListener('updateSuccess', this._onSaved, this);
+      this._client.addListener('error', function(ev) {
+        let data = ev.getData();
+        if (typeof data === 'string') {
+          if (data.startsWith('{') && data.endsWith('}')) {
+            try {
+              data = JSON.parse(data);
+            } catch (e) {}
+          }
+        }
+        if (data.error) {
+          data = data.error;
+        }
+        cv.ui.manager.snackbar.Controller.error(data.message);
+      }, this);
     },
 
     _loadFile(file) {

--- a/source/resource/designs/designglobals.css
+++ b/source/resource/designs/designglobals.css
@@ -620,7 +620,6 @@ button.ui-slider-handle {
 
 .popup.notification,
 .popup_background.notification {
-  position: absolute;
   padding: 30px;
   width: auto;
   height: auto;
@@ -628,6 +627,7 @@ button.ui-slider-handle {
 }
 
 .popup {
+  position: absolute;
   z-index: 100001;
   background: transparent;
   font-family: Arial, sans-serif;
@@ -642,6 +642,7 @@ button.ui-slider-handle {
   text-align: center;
   -moz-border-radius: 4px; -webkit-border-radius: 4px; border-radius: 4px;
   background: #000;
+  color: white;
   border: 1px solid #fff;
   cursor: pointer;
 }
@@ -660,10 +661,15 @@ button.ui-slider-handle {
 
 .popup div.head {
   border-bottom: 1px solid;
+  color: white;
 }
 
 .popup .main {
   overflow-y: auto;
+}
+
+.popup iframe {
+  border: none;
 }
 
 .popup .main > div > .icon:not(.spinner) {

--- a/source/resource/libs/CvClientBaseClass.js
+++ b/source/resource/libs/CvClientBaseClass.js
@@ -179,6 +179,10 @@
     authorize(req) {
     }
 
+    canAuthorize() {
+      return false;
+    }
+
     /**
      * return the relative path to a resource on the currently used backend
      *

--- a/utils/compile/cv/CompileHandler.js
+++ b/utils/compile/cv/CompileHandler.js
@@ -26,6 +26,7 @@ const filesToCopy = [
   '../package.json',
   'version',
   '../node_modules/monaco-editor',
+  '../node_modules/oauth-pkce/dist/oauth-pkce.min.js',
   'rest/manager',
   'rest/openapi.yaml',
   'test',

--- a/utils/protractor.conf.js
+++ b/utils/protractor.conf.js
@@ -16,6 +16,7 @@ exports.config = {
   capabilities: {
     browserName: 'chrome',
     'chromeOptions': {
+      binary: process.env.CHROME_BIN || process.env.BROWSER_PATH,
       args: [
         // '--no-sandbox',
         '--headless',


### PR DESCRIPTION
next openhab version requires authentication for some of the managers REST-API endpoints (basically all non-reading + hidden config endpoints). This is only relevant when users serve the cometvisu with openHABs builtin webserver, the the native JAVA implementation for cometvisus REST API is used and for security reasons some of them require an authenticated user now.

There are some basic features included in this changeset that prepare using oauth to authorize. Unfortunately openHAB blocks all "external" clients from using this, as I found out at the end of implementing this. I do not want to throw away the outh related changes although they are not used at the moment. We might need them in future and then we have something to start with.