### PR TITLE
Fix multi backend for pure

### DIFF
--- a/source/class/cv/data/Model.js
+++ b/source/class/cv/data/Model.js
@@ -162,7 +162,7 @@ qx.Class.define('cv.data.Model', {
           }
         }, this);
       } else {
-        this.warn('no addresses registered for backend "' + backendName + '", skipping update');
+        this.debug('no addresses registered for backend "' + backendName + '", skipping update');
       }
     },
 

--- a/source/class/cv/ui/structure/pure/Controller.js
+++ b/source/class/cv/ui/structure/pure/Controller.js
@@ -90,7 +90,7 @@ qx.Class.define('cv.ui.structure.pure.Controller', {
       let defaultBackendName = '';
       if (pagesElement.getAttribute('backend') !== null) {
         settings.backend = pagesElement.getAttribute('backend');
-        defaultBackendName = settings.backend;
+        defaultBackendName = settings.backend.split(',')[0];
       } else {
         defaultBackendName = (
           cv.Config.URL.backend ||

--- a/source/resource/visu_config.xsd
+++ b/source/resource/visu_config.xsd
@@ -407,7 +407,7 @@
         New values, should be used now:
           knxd, openhab, mqtt
          -->
-        <xsd:pattern value="^(knxd|openhab|mqtt|cgi-bin|oh|oh2|openhab2|default)(,(knxd|openhab|mqtt|cgi-bin|oh|oh2|openhab2|default))*$"/>
+        <xsd:pattern value="(knxd|openhab|mqtt|cgi-bin|oh|oh2|openhab2|default)(,(knxd|openhab|mqtt|cgi-bin|oh|oh2|openhab2|default))*"/>
       </xsd:restriction>
     </xsd:simpleType>
   </xsd:attribute>

--- a/source/resource/visu_config.xsd
+++ b/source/resource/visu_config.xsd
@@ -401,16 +401,13 @@
     </xsd:annotation>
     <xsd:simpleType>
       <xsd:restriction base="xsd:string">
-        <!-- Old values, kept for backwards compability -->
-        <xsd:enumeration value="cgi-bin" />
-        <xsd:enumeration value="oh" />
-        <xsd:enumeration value="oh2" />
-        <xsd:enumeration value="openhab2" />
-        <xsd:enumeration value="default" />
-        <!-- New values, should be used now -->
-        <xsd:enumeration value="knxd" />
-        <xsd:enumeration value="openhab" />
-        <xsd:enumeration value="mqtt" />
+        <!--
+        Old values, kept for backwards compatibility:
+          cgi-bin, oh, oh2, openhab2, default
+        New values, should be used now:
+          knxd, openhab, mqtt
+         -->
+        <xsd:pattern value="^(knxd|openhab|mqtt|cgi-bin|oh|oh2|openhab2|default)(,(knxd|openhab|mqtt|cgi-bin|oh|oh2|openhab2|default))*$"/>
       </xsd:restriction>
     </xsd:simpleType>
   </xsd:attribute>


### PR DESCRIPTION
- Correctly handle when multiple backends are configured in the config file `backend` property
- Fix XSD to have the rule that checks for the proper multi backend config here
- show message about unused backend only for debug to prevent false alarms (-> https://knx-user-forum.de/forum/supportforen/cometvisu/1999022-messwerte-oder-stati-in-cometvisu-anzeigen?p=2000369#post2000369)
- simplify `sendToBackend` (change should be neutral)

Note: this PR is based on the changes of #1420 - so that PR should be merged first.