### PR TITLE
fix: use the trimmed tag-array

### DIFF
--- a/source/class/cv/plugins/RssLog.js
+++ b/source/class/cv/plugins/RssLog.js
@@ -507,7 +507,7 @@ qx.Class.define('cv.plugins.RssLog', {
           if (Array.isArray(item.tags)) {
             const tags = item.tags.filter(x => x !== '').map(x => x.trim());
             if (tags.length > 0) {
-              tmp.classList.add.apply(tmp.classList, item.tags);
+              tmp.classList.add.apply(tmp.classList, tags);
             }
           } else {
             tmp.classList.add(item.tags.trim());


### PR DESCRIPTION
fixes error reported here https://knx-user-forum.de/forum/supportforen/cometvisu/1920084-rsslog-invalidcharactererror-the-token-provided-licht-contains-html-space?p=2005483#post2005483