### PR TITLE
fix: fix missing pure-structure states when in cached mode

### DIFF
--- a/source/class/cv/ConfigCache.js
+++ b/source/class/cv/ConfigCache.js
@@ -92,7 +92,8 @@ qx.Class.define('cv.ConfigCache', {
         addresses: model.getAddressList(),
         configSettings: JSON.stringify(cv.Config.configSettings),
         config: cv.Config.configSuffix === null ? 'NULL' : cv.Config.configSuffix,
-        body: document.querySelector('body').innerHTML
+        body: document.querySelector('body').innerHTML,
+        defaultBackendName: cv.data.Model.getInstance().getDefaultBackendName()
       });
     },
 
@@ -182,6 +183,7 @@ qx.Class.define('cv.ConfigCache', {
           }, this);
         }
         model.setWidgetDataModel(cache.data);
+        model.setDefaultBackendName(cache.defaultBackendName);
         model.setAddressList(cache.addresses);
         const widgetsToInitialize = Object.keys(cache.data).filter(function (widgetId) {
           return cache.data[widgetId].$$initOnCacheLoad === true;


### PR DESCRIPTION
defaultBackendName needs to be cached too.

Refs: https://knx-user-forum.de/forum/supportforen/cometvisu/2026519-0-13-0-dev-caching-problem-mit-design-metal-lib_version-9