### PR TITLE
fix: guard against missing #centerContainer DOM element

### DIFF
--- a/source/class/cv/ui/structure/pure/NavBar.js
+++ b/source/class/cv/ui/structure/pure/NavBar.js
@@ -111,6 +111,9 @@ qx.Class.define('cv.ui.structure.pure.NavBar', {
       //   When during a valid swipe the direction is reversed the fading
       //   action is also reverted.
       const content = document.body.querySelector('#centerContainer');
+      if (!content) {
+        return;
+      }
       content.addEventListener(
         'touchstart',
         function (evt) {


### PR DESCRIPTION
fix: guard against missing #centerContainer DOM element in NavBar.initializeNavbars

The touch event listeners on #centerContainer were registered without a null check, causing a 'Cannot read properties of null (reading addEventListener)' TypeError in the CI test suite (Chrome Beta) where the test DOM does not include a #centerContainer element.

Add an early return if the element is not found.