### PR TITLE
Fix the diagram popup being clipped, too small and not evenly spaced

### DIFF
--- a/source/class/cv/plugins/diagram/AbstractDiagram.js
+++ b/source/class/cv/plugins/diagram/AbstractDiagram.js
@@ -593,7 +593,9 @@ qx.Class.define('cv.plugins.diagram.AbstractDiagram', {
       const popupDiagram = qx.dom.Element.create('div', {
         class: 'diagram',
         id: this.getPath() + '_big',
-        style: 'height: 90%'
+        // fills the content area of the popup, the spacing comes from its padding.
+        // margin has to be set because .popup div in designglobals.css defines 4px
+        style: 'height: 100%; width: 100%; margin: 0'
       });
 
       this._init = true;
@@ -616,7 +618,18 @@ qx.Class.define('cv.plugins.diagram.AbstractDiagram', {
       });
 
       const parent = popupDiagram.parentNode;
-      Object.entries({ height: '100%', width: '95%', margin: 'auto' }).forEach(function (key_value) {
+      // Equal spacing on all sides: a percentage padding refers to the width on the top
+      // and bottom as well, so it is the same value everywhere. "margin: auto" only
+      // centered horizontally, at the top and bottom it computes to 0. display: flex
+      // makes the diagram sit exactly at the content box.
+      Object.entries({
+        height: '100%',
+        width: '100%',
+        margin: '0',
+        padding: '2.5%',
+        boxSizing: 'border-box',
+        display: 'flex'
+      }).forEach(function (key_value) {
         parent.style[key_value[0]] = key_value[1];
       });
 

--- a/source/resource/designs/designglobals.css
+++ b/source/resource/designs/designglobals.css
@@ -639,11 +639,11 @@ button.ui-slider-handle {
 .popup_close {
   position: absolute;
   z-index: 100002;
-  right: 1em;
   /* has to stay inside the popup: since "make popup scrollable on small screens" .popup
      is a scroll container (overflow-y: auto) and clips everything reaching beyond its
      edges. Before that the X was placed on the upper border with top: -0.8em. */
-  top: 0;
+  top: 0.3em;
+  right: 0.3em;
   width: 1.2em;
   text-align: center;
   -moz-border-radius: 4px; -webkit-border-radius: 4px; border-radius: 4px;
@@ -660,13 +660,6 @@ button.ui-slider-handle {
   border: 1px solid #fff;
 }
 
-.popup div {
-  margin: 4px;
-  /* no max-height: since "make popup scrollable on small screens" .popup itself is
-     bounded by max-height: 100vh and scrolls when needed. An additional limit here only
-     made the content (e.g. diagrams) smaller than the popup containing it. */
-}
-
 .popup div.head {
   border-bottom: 1px solid;
   color: white;
@@ -674,6 +667,9 @@ button.ui-slider-handle {
 
 .popup .main {
   overflow-y: auto;
+  /* bound only the scrolling content area, so a scrollbar appears just when the
+     content is too tall, not for every popup */
+  max-height: 80vh;
 }
 
 .popup iframe {

--- a/source/resource/designs/designglobals.css
+++ b/source/resource/designs/designglobals.css
@@ -640,7 +640,10 @@ button.ui-slider-handle {
   position: absolute;
   z-index: 100002;
   right: 1em;
-  top: -0.8em;
+  /* has to stay inside the popup: since "make popup scrollable on small screens" .popup
+     is a scroll container (overflow-y: auto) and clips everything reaching beyond its
+     edges. Before that the X was placed on the upper border with top: -0.8em. */
+  top: 0;
   width: 1.2em;
   text-align: center;
   -moz-border-radius: 4px; -webkit-border-radius: 4px; border-radius: 4px;
@@ -659,7 +662,9 @@ button.ui-slider-handle {
 
 .popup div {
   margin: 4px;
-  max-height: 60vh;
+  /* no max-height: since "make popup scrollable on small screens" .popup itself is
+     bounded by max-height: 100vh and scrolls when needed. An additional limit here only
+     made the content (e.g. diagrams) smaller than the popup containing it. */
 }
 
 .popup div.head {


### PR DESCRIPTION
Three issues of the diagram popup, the first two introduced by f4c2808af
"make popup scrollable on small screens".

### 1. The close button is cut off

That commit made `.popup` a scroll container:

```css
.popup {
  max-height: 100vh;
  max-width: 100vw;
  overflow-y: auto;   /* new */
}
```

The close button has always been placed outside of it, sitting on the upper border
on purpose:

```css
.popup_close { position: absolute; right: 1em; top: -0.8em; }
```

`.popup` and `.popup_background` are the same element, so that placement was
intentional. As soon as `overflow` is no longer `visible` everything outside the
padding box is clipped, and the button reaches 9.9px above the top edge. It is now
placed inside the popup with `top: 0`.

Worth noting that the computed `overflow-x` becomes `auto` as well, even though only
`overflow-y` was declared - per spec `visible` computes to `auto` once the other axis
clips.

### 2. The content is capped below the height of the popup

The same commit also lowered the limit of `.popup div` from `80vh` to `60vh`. That
rule applies to *every* div inside the popup, so the content area is capped below the
height of the popup containing it. Measured at a 1440x647 viewport:

```
.popup   584px high (metal: height: 90%)
.main    388px high (max-height: 60vh)   -> 196px of the popup stay empty
```

The limit is removed. `.popup` itself is bounded by `max-height: 100vh` and scrolls
when needed, which is what the limit was there for. `.main` already has its own
`overflow-y: auto` as well.

| | `.main` | diagram | popup filled |
| --- | --- | --- | --- |
| before | 388 | 349 | 66 % |
| after | 582 | 524 | 100 % |
| 0.12.6 (80vh) | 518 | 466 | 89 % |

### 3. The diagram is only centered horizontally

`AbstractDiagram._action()` sets:

```js
style: 'height: 90%'                                  // leaves 10 % unused below
{ height: '100%', width: '95%', margin: 'auto' }      // centers horizontally only
```

`margin: auto` distributes the remaining space along the inline axis only, at the top
and bottom it computes to `0`. Together with the `height: 90%` the diagram ended up
with 2.5 % on the left and right, nothing at the top and a large gap at the bottom.

The spacing now comes from a percentage padding of the content area. A percentage
padding refers to the *width* on all four sides, so it yields the same pixel value
everywhere regardless of the popup's aspect ratio. `display: flex` is needed because
`.popup div { margin: 4px }` otherwise offsets the diagram by 4px vertically.

Resulting gaps around the diagram, same viewport:

```
before   left 37   top  5   right 37   bottom 230
after    left 33   top 33   right 33   bottom  33
```

### Screenshots

<img width="1440" height="647" alt="popup-before" src="https://github.com/user-attachments/assets/dd73b4c8-1767-43df-9012-2a29f1e6d911" />
<img width="1440" height="647" alt="popup-after" src="https://github.com/user-attachments/assets/78dd0914-63c9-40ca-9e32-a443d34cdaa0" />

### Testing

Verified in Chrome against a running instance, and compared with a 0.12.6 installation
for the intended geometry. `qx compile` passes, `qx lint` reports only the pre-existing
`QxConnector` error in `tile/Controller.js`.
