### PR TITLE
Fix icon size and position after the icon font migration

### DIFF
--- a/source/resource/designs/designglobals.css
+++ b/source/resource/designs/designglobals.css
@@ -33,9 +33,25 @@ a, img {
  * Default height for all icons
  */
 .icon {
-  height: 2em;
-  width: 2em;
-  font-size: 1.55em;
+  /* The icons are glyphs of an icon font. width/height do not apply to a non replaced
+     inline element, so the element is made inline-block to keep the 2em x 1.9em box of
+     the surrounding text that the SVG icons had. All lengths here are relative to the
+     font-size of this rule.
+
+     The font-size is chosen so that the glyphs are drawn at the size of the artwork of
+     those SVG icons, which did not fill their box. The icon font normalizes all glyphs
+     to the em box while the SVG artwork did not, so this can only match on average.
+
+     The font has an ascent of ~0.995em and no descent, so the glyph sits at the top of
+     the line box. line-height = height - 0.034em moves the baseline down far enough to
+     center the drawn glyph in the box, like the SVG icons were centered. */
+  display: inline-block;
+  font-size: 1.39em;
+  width: 1.439em;
+  height: 1.367em;
+  line-height: 1.333em;
+  text-align: center;
+  vertical-align: middle;
 }
 .tree-icon {
   height: 20px;

--- a/source/resource/designs/metal/basic.css
+++ b/source/resource/designs/metal/basic.css
@@ -132,7 +132,9 @@ body br
 }
 
 .icon {
-    height: 1.9em;
+    /* 1.9em of the surrounding text, the icon font-size of designglobals.css is 1.39em */
+    height: 1.367em;
+    line-height: 1.333em;
 }
 
 .widget.web
@@ -168,12 +170,19 @@ body br
   box-sizing: border-box;
 }
 .text > div { line-height: 2em; }
-.widget > .label .icon, .text .icon { vertical-align: middle; margin-top: -0.3em; }
+/* The margins below are relative to the font-size of the icon itself, which the .icon
+   rule in designglobals.css sets to 1.39em of the surrounding text. They are divided by
+   that factor so that they keep pulling the icon by the same amount as before, when the
+   icon had no font-size of its own: -0.216em was -0.3em and -0.432em was -0.6em. */
+.widget > .label .icon, .text .icon { vertical-align: middle; margin-top: -0.216em; }
 .widget .pagejump .icon { margin-top: -0; }
 .widget .actor .icon,
-.rsslog_popup .icon { margin-bottom: -0.6em; }
+.rsslog_popup .icon { margin-bottom: -0.432em; }
 .widget .switchPressed .icon, .widget .switchUnpressed .icon {
-    margin-top: -0.4em; margin-bottom: -0.6em;
+    /* The icon is an inline-block with a height of its own now, so the line box would
+       make the button taller than it used to be. The sum of these margins gives the
+       button its height, their distribution centers the icon in it. */
+    margin-top: -0.42em; margin-bottom: -0.3em;
     vertical-align: middle;
 }
 .navbar .widget_container > .pagejump > .label, .navbar .widget_container > .refresh > .label {
@@ -327,10 +336,10 @@ body br
   cursor: pointer;
 }
 
-.switchUnpressed div:has(i), .switchPressed div:has(i)
-{
-    padding: 1px;
-}
+/* The reduced padding of "fix: repair button height with icon" is not needed anymore. It
+   compensated the icon font drawing the glyphs larger than the SVG icons did, which the
+   .icon rule in designglobals.css handles now, so it would only make the buttons
+   narrower than they used to be. */
 
 .pagejump > .switchUnpressed, .pagejump > .switchPressed,
 .navbar .refresh > .switchUnpressed, .navbar .refresh > .switchPressed {
@@ -586,7 +595,10 @@ div#demo_3 {
 .navbar .refresh .label > .icon { 
 	height: 44px !important;
     width: 44px !important;
-    font-size: 36px;
+    /* draws the glyph at the size of the artwork the SVG icons had in this 44px box and
+       centers it there, see the .icon rule in designglobals.css */
+    font-size: 31px;
+    line-height: 42.95px;
 	display: block;
 	margin: 0 auto;
 }


### PR DESCRIPTION
## Fix icon rendering after the 2022 icon font migration

Since the KNX-UF iconset was moved from an SVG sprite to an icon font (commit
`c67a77df9` "replace with iconfont"), the icons in the pure structure render
differently from before. The CSS that used to size the icons was written for
`<svg>` elements and was never adapted to the `<i>` element the font uses, so it
is partly ineffective. Comparison is CometVisu 0.12.6 against current `develop`,
same config, same browser, design "metal".

### Problem 1 – the icon box collapses

`designglobals.css` sizes `.icon` with `width`/`height`. Those apply to a
replaced element like `<svg>`, but not to a plain inline `<i>`, so the box
collapses to the glyph's advance width. Because the glyphs have very different
advance widths (measured 0.148em … 1.0em), narrow icons stand out. Measured on
the thermometer icon in a status row: 0.12.6 (SVG) 37×35px, current (font)
12×29px.

### Problem 2 – the glyphs are drawn too large

The SVG icons never filled their box; the drawing sat inset in a shared viewBox
(measured 58%…74% of the box). The font glyphs are normalized to the em box and
draw ~96% of the font-size, so at the navbar's `font-size: 36px` they render
~34.6px where the SVGs drew 25…32px. The icons look noticeably larger and
heavier.

### Problem 3 – the glyphs sit too high in their box

The font has an ascent of ~0.995em and no descent, so the glyph hangs at the top
of the line box with space below, ~2px too high. The SVG drawing was centered.

### Fix

Restore the box, bring the glyph size back to the former drawing size and center
the glyph. Lengths are relative to the rule's own font-size and converted
accordingly.

`designglobals.css`: `.icon` becomes `inline-block` with an explicit
`font-size`, `width`, `height`, `line-height` and centering.
`designs/metal/basic.css`: matching `height`/`line-height`, per-context margins,
and an explicit navbar size.

Measured against the 0.12.6 instance:

| | 0.12.6 | with fix |
| --- | --- | --- |
| status row, box | 37×35 | 37×35 |
| status row, drawing | 24.9, top 5.3 / bottom 5.2 | 24.9, top 5.27 / bottom 5.27 |
| navbar, box | 44×44 | 44×44 |
| navbar, drawing | 25.4–32.5, centered | 29.8, centered |

### What this cannot fix

The SVGs filled their box by different amounts per icon (58%…74%); the font
normalizes every glyph to the em box, so a single font-size cannot hit every
icon exactly. 31px is the mean; icons at the edges of the range stay a few px
off. That would need the font to be regenerated preserving the original per-icon
size ratios. The SVGs were also multi-color (`currentColor` plus greys/black);
an icon font is single-color, so that shading is lost. Both are inherent to the
font approach and out of scope here.

Affected: everything from `c67a77df9` (Feb 2022), i.e. 0.13.x onward. The
`designglobals.css` rule applies to all pure-structure designs; the navbar rule
here is from design "metal", other designs may need the same treatment.
