### PR TITLE
Show already received values while other addresses are still missing

### DIFF
--- a/source/class/cv/ui/common/BasicUpdate.js
+++ b/source/class/cv/ui/common/BasicUpdate.js
@@ -82,7 +82,17 @@ qx.Mixin.define('cv.ui.common.BasicUpdate', {
      * against the parser of the installed sprintf-js, so such a change fails the tests. When that
      * happens, align this expression with the "placeholder" regex of the new version.
      */
-    PLACEHOLDER_REGEX: /%%|%(?:([1-9]\d*)\$|\(([^)]+)\))?(\+)?(0|'[^$])?(-)?(\d+)?(?:\.(\d+))?([b-gijosuxX])/g,
+    PLACEHOLDER_REGEX: /%%|%(?:([1-9]\d*)\$|\(([^)]+)\))?(\+)?(0|'[^$])?(-)?(\d+)?(?:\.(\d+))?([b-gijosuxX])/,
+
+    /**
+     * A fresh global regex for the placeholder syntax. A global regex keeps its own lastIndex, so a
+     * shared instance would make callers depend on each other's search progress.
+     *
+     * @return {RegExp} a copy of {@link cv.ui.common.BasicUpdate#PLACEHOLDER_REGEX} with the g flag
+     */
+    placeholderRegex() {
+      return new RegExp(cv.ui.common.BasicUpdate.PLACEHOLDER_REGEX.source, 'g');
+    },
 
     /**
      * Replace those placeholders of a format string whose value is still missing by a literal
@@ -98,8 +108,7 @@ qx.Mixin.define('cv.ui.common.BasicUpdate', {
      */
     replaceMissingFormatValues(format, values, placeholder) {
       const missing = [];
-      const regex = cv.ui.common.BasicUpdate.PLACEHOLDER_REGEX;
-      regex.lastIndex = 0;
+      const regex = cv.ui.common.BasicUpdate.placeholderRegex();
       let match = regex.exec(format);
       while (match !== null) {
         if (match[1] !== undefined && values[parseInt(match[1], 10)] === undefined) {
@@ -114,7 +123,7 @@ qx.Mixin.define('cv.ui.common.BasicUpdate', {
       const cache = cv.ui.common.BasicUpdate.__formatWithPlaceholders;
       const key = JSON.stringify([format, placeholder, missing]);
       if (cache[key] === undefined) {
-        cache[key] = format.replace(cv.ui.common.BasicUpdate.PLACEHOLDER_REGEX, (found, position) =>
+        cache[key] = format.replace(cv.ui.common.BasicUpdate.placeholderRegex(), (found, position) =>
           position !== undefined && missing.includes(position) ? placeholder : found
         );
       }

--- a/source/class/cv/ui/common/BasicUpdate.js
+++ b/source/class/cv/ui/common/BasicUpdate.js
@@ -63,6 +63,64 @@ qx.Mixin.define('cv.ui.common.BasicUpdate', {
   ******************************************************
   */
   statics: {
+    /** cache for {@link replaceMissingFormatValues}, keyed by format string and missing positions */
+    __formatWithPlaceholders: {},
+
+    /**
+     * Shown instead of a value that has not been received yet. It is the same marker
+     * {@link cv.util.String#sprintf} already returns when formatting fails.
+     */
+    MISSING_VALUE_PLACEHOLDER: '-',
+
+    /**
+     * The placeholder syntax of sprintf-js, taken from its own source (1.0.3) so that every case it
+     * accepts is recognized here as well. The leading alternative keeps a literal "%%" from being
+     * treated as a placeholder.
+     *
+     * This is a copy and can therefore drift apart when sprintf-js changes - 1.1.x for example added
+     * the conversion characters "t", "T" and "v". The spec of this mixin compares the expression
+     * against the parser of the installed sprintf-js, so such a change fails the tests. When that
+     * happens, align this expression with the "placeholder" regex of the new version.
+     */
+    PLACEHOLDER_REGEX: /%%|%(?:([1-9]\d*)\$|\(([^)]+)\))?(\+)?(0|'[^$])?(-)?(\d+)?(?:\.(\d+))?([b-gijosuxX])/g,
+
+    /**
+     * Replace those placeholders of a format string whose value is still missing by a literal
+     * placeholder text. The values of a widget's addresses arrive one by one, so a format that
+     * refers to several of them would otherwise make sprintf throw until the last value was
+     * received - substituting the value itself is no option, because the numeric conversions of
+     * sprintf only accept real numbers.
+     *
+     * @param {string} format - the format string
+     * @param {Array} values - the values by argument position, index 0 holds the format
+     * @param {string} placeholder - text to show instead of a missing value
+     * @return {string} the format string to hand to sprintf
+     */
+    replaceMissingFormatValues(format, values, placeholder) {
+      const missing = [];
+      const regex = cv.ui.common.BasicUpdate.PLACEHOLDER_REGEX;
+      regex.lastIndex = 0;
+      let match = regex.exec(format);
+      while (match !== null) {
+        if (match[1] !== undefined && values[parseInt(match[1], 10)] === undefined) {
+          missing.push(match[1]);
+        }
+        match = regex.exec(format);
+      }
+      if (missing.length === 0) {
+        return format;
+      }
+
+      const cache = cv.ui.common.BasicUpdate.__formatWithPlaceholders;
+      const key = JSON.stringify([format, placeholder, missing]);
+      if (cache[key] === undefined) {
+        cache[key] = format.replace(cv.ui.common.BasicUpdate.PLACEHOLDER_REGEX, (found, position) =>
+          position !== undefined && missing.includes(position) ? placeholder : found
+        );
+      }
+      return cache[key];
+    },
+
     /**
      * Apply the given mapping to the value
      *
@@ -175,16 +233,27 @@ qx.Mixin.define('cv.ui.common.BasicUpdate', {
      * @return {var} the formatted value
      */
     applyFormat(address, value) {
-      if (this.getFormat()) {
+      const format = this.getFormat();
+      if (format) {
         if (!this.formatValueCache) {
-          this.formatValueCache = [this.getFormat()];
+          this.formatValueCache = [format];
         }
 
         const argListPos = this.getAddress() && this.getAddress()[address] ? this.getAddress()[address].formatPos : 1;
 
         this.formatValueCache[argListPos] = value;
 
-        return cv.util.String.sprintf.apply(this, this.formatValueCache);
+        // Show the values that are already known and a placeholder for the ones still missing. The
+        // rewritten format must not replace the cached one, otherwise the next update would run the
+        // replacement on an already substituted format.
+        const args = this.formatValueCache.slice();
+        args[0] = cv.ui.common.BasicUpdate.replaceMissingFormatValues(
+          format,
+          this.formatValueCache,
+          cv.ui.common.BasicUpdate.MISSING_VALUE_PLACEHOLDER
+        );
+
+        return cv.util.String.sprintf.apply(this, args);
       }
       return value;
     },

--- a/source/test/karma/ui/structure/common/BasicUpdate-spec.js
+++ b/source/test/karma/ui/structure/common/BasicUpdate-spec.js
@@ -96,5 +96,147 @@ describe('testing the basic update mixin', function() {
     });
 
     expect(trigger.applyMapping(10, 'test')).toBe(20);
+  });  it('should show a placeholder for values that have not been received yet', function () {
+    var info = new cv.ui.structure.pure.Info({
+      path: 'id_0',
+      $$type: 'info',
+      format: '%1$.1f °C => %2$.1f °C',
+      address: {
+        'first': { formatPos: 1 },
+        'second': { formatPos: 2 }
+      }
+    });
+
+    // the values arrive one address at a time, the known one is shown right away
+    expect(info.applyFormat('first', 19)).toBe('19.0 °C => - °C');
+    expect(info.applyFormat('second', 21)).toBe('19.0 °C => 21.0 °C');
+    // an update of a single address keeps both values
+    expect(info.applyFormat('first', 20)).toBe('20.0 °C => 21.0 °C');
+  });
+
+  it('should show a placeholder for a missing string value', function () {
+    var info = new cv.ui.structure.pure.Info({
+      path: 'id_0',
+      $$type: 'info',
+      format: '%1$s / %2$s',
+      address: {
+        'first': { formatPos: 1 },
+        'second': { formatPos: 2 }
+      }
+    });
+
+    expect(info.applyFormat('first', 'on')).toBe('on / -');
+  });
+
+  it('should keep a literal percent sign', function () {
+    var info = new cv.ui.structure.pure.Info({
+      path: 'id_0',
+      $$type: 'info',
+      format: '%1$d %% of %2$d',
+      address: {
+        'first': { formatPos: 1 },
+        'second': { formatPos: 2 }
+      }
+    });
+
+    expect(info.applyFormat('first', 40)).toBe('40 % of -');
+    expect(info.applyFormat('second', 100)).toBe('40 % of 100');
+  });
+
+  it('should format a single value without positions as before', function () {
+    var info = new cv.ui.structure.pure.Info({
+      path: 'id_0',
+      $$type: 'info',
+      format: '%.1f °C',
+      address: { 'only': { formatPos: 1 } }
+    });
+
+    expect(info.applyFormat('only', 19)).toBe('19.0 °C');
+  });
+
+  it('should only replace the placeholders of missing positions', function () {
+    var replace = cv.ui.common.BasicUpdate.replaceMissingFormatValues;
+    var format = '%1$.1f °C => %2$.1f °C';
+    // index 0 holds the format itself, so the values start at index 1
+    expect(replace(format, [format, 19, 21], '-')).toBe(format);
+    expect(replace(format, [format, 19], '-')).toBe('%1$.1f °C => - °C');
+    expect(replace(format, [format], '-')).toBe('- °C => - °C');
+    expect(replace('%.1f °C', [format], '-')).toBe('%.1f °C');
+  });
+  it('should recognize exactly the placeholders that sprintf-js recognizes', function () {
+    // Our regex is a copy of the placeholder syntax of sprintf-js. This test compares it against
+    // that library's own parser, so an update that changes the syntax fails here instead of making
+    // replaceMissingFormatValues() silently miss or mangle placeholders.
+    expect(typeof sprintf.parse).toBe('function');
+
+    // ask the installed version which conversion characters it accepts, so the corpus grows
+    // automatically when a newer version adds some (1.1.x added 't', 'T' and 'v')
+    var supported = 'bcdiefgjostTuvxX'.split('').filter(function (type) {
+      try {
+        sprintf.parse('%1$' + type);
+        return true;
+      } catch (e) {
+        return false;
+      }
+    });
+    expect(supported.length).toBeGreaterThan(0);
+
+    var formats = supported.map(function (type) {
+      return '%1$' + type;
+    });
+    formats = formats.concat([
+      '%s',
+      '%1$s',
+      '%2$s %1$s',
+      '%1$.1f °C => %2$.1f °C',
+      '%1$+d',
+      '%1$05d',
+      "%1$'x8d",
+      '%1$-8s|',
+      '%1$8.3f',
+      '%(name)s',
+      '%(a.b)s %(c)d',
+      'no placeholder at all',
+      '%% literal',
+      '%1$d %% of %2$d'
+    ]);
+
+    // what sprintf-js itself considers a placeholder - the node shape differs between versions
+    // (1.0.x hands out the raw match array, 1.1.x an object), the syntax is what matters here
+    var placeholdersOfSprintfJs = function (format) {
+      return sprintf.parse(format)
+        .filter(function (node) {
+          return typeof node !== 'string';
+        })
+        .map(function (node) {
+          return Array.isArray(node)
+            ? { text: node[0], position: node[1] }
+            : { text: node.placeholder, position: node.param_no };
+        });
+    };
+
+    // what our own regex finds, "%%" is a literal on both sides
+    var placeholdersOfRegex = function (format) {
+      var found = [];
+      var regex = cv.ui.common.BasicUpdate.PLACEHOLDER_REGEX;
+      regex.lastIndex = 0;
+      var match = regex.exec(format);
+      while (match !== null) {
+        if (match[0] !== '%%') {
+          found.push({ text: match[0], position: match[1] });
+        }
+        match = regex.exec(format);
+      }
+      return found;
+    };
+
+    var total = 0;
+    formats.forEach(function (format) {
+      var expected = placeholdersOfSprintfJs(format);
+      total += expected.length;
+      expect(placeholdersOfRegex(format)).toEqual(expected, 'differing placeholders for ' + format);
+    });
+    // guard against a test that silently compares nothing
+    expect(total).toBeGreaterThan(formats.length);
   });
 });

--- a/source/test/karma/ui/structure/common/BasicUpdate-spec.js
+++ b/source/test/karma/ui/structure/common/BasicUpdate-spec.js
@@ -163,6 +163,22 @@ describe('testing the basic update mixin', function() {
     expect(replace(format, [format], '-')).toBe('- °C => - °C');
     expect(replace('%.1f °C', [format], '-')).toBe('%.1f °C');
   });
+  it('should hand out a fresh placeholder regex for every scan', function () {
+    // A global regex keeps its own lastIndex. Sharing one instance would make a scan that was left
+    // half way move the starting point of the next one.
+    var first = cv.ui.common.BasicUpdate.placeholderRegex();
+    var second = cv.ui.common.BasicUpdate.placeholderRegex();
+
+    expect(first).not.toBe(second);
+    expect(first.global).toBe(true);
+    expect(cv.ui.common.BasicUpdate.PLACEHOLDER_REGEX.global).toBe(false);
+
+    first.exec('%1$s %2$s');
+
+    expect(first.lastIndex).toBeGreaterThan(0);
+    expect(cv.ui.common.BasicUpdate.placeholderRegex().lastIndex).toBe(0);
+  });
+
   it('should recognize exactly the placeholders that sprintf-js recognizes', function () {
     // Our regex is a copy of the placeholder syntax of sprintf-js. This test compares it against
     // that library's own parser, so an update that changes the syntax fails here instead of making
@@ -218,8 +234,7 @@ describe('testing the basic update mixin', function() {
     // what our own regex finds, "%%" is a literal on both sides
     var placeholdersOfRegex = function (format) {
       var found = [];
-      var regex = cv.ui.common.BasicUpdate.PLACEHOLDER_REGEX;
-      regex.lastIndex = 0;
+      var regex = cv.ui.common.BasicUpdate.placeholderRegex();
       var match = regex.exec(format);
       while (match !== null) {
         if (match[0] !== '%%') {


### PR DESCRIPTION
## Problem

A widget whose `format` refers to several addresses only showed `-` until the last address had
been received, and logged a warning on **every** update until then:

```
cv.ui.structure.pure.Info[908-0]: TypeError: [sprintf] expecting number but found undefined,
["%1$.1f °C   ==>   %2$.1f °C",19]
```

Example configuration:

```xml
<info format="%1$.1f °C   ==&gt;   %2$.1f °C">
  <address format-pos="1">Outside</address>
  <address format-pos="2">Exhaust</address>
</info>
```

## Cause

`applyFormat()` fills `formatValueCache` per address and calls sprintf immediately. Since the
values of the addresses arrive one by one, the arguments of the other positions are still
`undefined`, which sprintf rejects for its numeric conversions. `cv.util.String.sprintf` catches
that, logs the warning and returns `-` for the whole widget.

## Fix

Instead of the value, the **placeholder** of a missing position is replaced by `-` before the
format is handed to sprintf. The values that already arrived are therefore visible right away:

| state | before | after |
| --- | --- | --- |
| only position 1 received | `-` | `19.0 °C   ==>   - °C` |
| both received | `19.0 °C   ==>   21.0 °C` | unchanged |

Substituting the value itself is no option: the numeric conversions of sprintf only accept real
numbers, `'-'` and `null` throw, `NaN` renders as `NaN` and `0` would look like a real reading.

Formats without explicit positions (`%.1f`) are untouched - their argument is consumed
sequentially and cannot be attributed to an address.

## sprintf-js compatibility

The expression that finds the placeholders is a copy of the one inside sprintf-js and could drift
apart when that library changes. A spec therefore compares it against `sprintf.parse()` of the
installed version, builds its corpus from the conversion characters that version actually accepts
and reads the parse tree in both shapes (1.0.x hands out the raw match array, 1.1.x an object).
A syntax change - 1.1.x added `t`, `T` and `v` - fails the tests instead of silently mis-parsing.

## Tests

`grunt karma:ci`: 1741 passing. The new specs cover a partially received format, a fully received
one, a later update of a single address, string placeholders, a literal `%%`, single value
formats and the equivalence with sprintf-js. Removing a character from the expression makes the
equivalence spec fail, so it actually guards the copy.
