### PR TITLE
Inset the popup close button in the designs as well

### DIFF
--- a/source/resource/designs/alaska/basic.css
+++ b/source/resource/designs/alaska/basic.css
@@ -318,8 +318,6 @@ div#loading
 
 .popup_close {
   position: absolute;
-  right: 1em;
-  top: -0.8em;
   width: 1.2em;
   text-align: center;
   -moz-border-radius: .5em; -webkit-border-radius: .5em; border-radius: .5em;

--- a/source/resource/designs/alaska_slim/basic.css
+++ b/source/resource/designs/alaska_slim/basic.css
@@ -298,8 +298,6 @@ div#loading
 
 .popup_close {
   position: absolute;
-  right: 1em;
-  top: -0.8em;
   width: 1.2em;
   text-align: center;
   -moz-border-radius: .5em; -webkit-border-radius: .5em; border-radius: .5em;

--- a/source/resource/designs/discreet/basic.css
+++ b/source/resource/designs/discreet/basic.css
@@ -347,8 +347,6 @@ div#loading {
 
 .popup_close {
   position: absolute;
-  right: 1em;
-  top: -0.8em;
   width: 1.2em;
   text-align: center;
   -moz-border-radius: 4px; -webkit-border-radius: 4px; border-radius: 4px;

--- a/source/resource/designs/discreet_sand/basic.css
+++ b/source/resource/designs/discreet_sand/basic.css
@@ -330,8 +330,6 @@ div#loading {
 
 .popup_close {
   position: absolute;
-  right: 1em;
-  top: -0.8em;
   width: 1.2em;
   text-align: center;
   -moz-border-radius: 4px; -webkit-border-radius: 4px; border-radius: 4px;

--- a/source/resource/designs/discreet_slim/basic.css
+++ b/source/resource/designs/discreet_slim/basic.css
@@ -350,8 +350,6 @@ div#loading {
 
 .popup_close {
   position: absolute;
-  right: 1em;
-  top: -0.8em;
   width: 1.2em;
   text-align: center;
   -moz-border-radius: 4px; -webkit-border-radius: 4px; border-radius: 4px;

--- a/source/resource/designs/planet/basic.css
+++ b/source/resource/designs/planet/basic.css
@@ -740,8 +740,6 @@ position: relative;
 
 .popup_close {
   position: absolute;
-  right: 2rem;
-  top: -0.5rem;
   width: 2.0rem;
   height: 1.5rem;
   text-align: center;

--- a/source/resource/designs/pure/basic.css
+++ b/source/resource/designs/pure/basic.css
@@ -447,8 +447,6 @@ div#loading {
 
 .popup_close {
   position: absolute;
-  right: 1em;
-  top: -0.8em;
   width: 1.2em;
   text-align: center;
   -moz-border-radius: 4px; -webkit-border-radius: 4px; border-radius: 4px;


### PR DESCRIPTION
Follow-up to #1478, which moved the close button inside the popup but only in
`designglobals.css`.

## Problem

The close button of a popup is cut in half: only the lower part of the `X` is visible, which reads
as a caret. Reproducible with any popup, e.g. the "Manager is not available" dialog behind
*Config-Manager*.

## Cause

Since #1478 `.popup` is a scroll container (`overflow-y: auto`) and clips whatever reaches beyond
its edges, so `designglobals.css` places the button inside it:

```css
.popup_close {
  /* has to stay inside the popup: since "make popup scrollable on small screens" .popup
     is a scroll container (overflow-y: auto) and clips everything reaching beyond its
     edges. Before that the X was placed on the upper border with top: -0.8em. */
  top: 0.3em;
  right: 0.3em;
```

The design stylesheets are loaded after that file and set the same two properties with the old
values, so they win. Measured in a running instance, distance between the button's edge and the
popup's edge:

| | top | right |
| --- | --- | --- |
| current | **-10.1 px** (outside, clipped) | 23.9 px |
| without the design's `top` | 10.7 px | **23.9 px** (uneven) |
| without `top` and `right` | **10.7 px** | **10.7 px** |

## Fix

Remove the `top` and `right` declarations from the seven designs that carry them, so the position
comes from `designglobals.css` alone and cannot drift apart again. Width, borders, colors and the
larger box of the `planet` design are untouched - two lines per file.

Affected: `pure`, `alaska`, `alaska_slim`, `discreet`, `discreet_sand`, `discreet_slim`, `planet`.

## Verification

Checked in a running instance: with both declarations gone the whole `X` is visible and the inset is
the same on both sides (10.7 px). No design stylesheet sets `top` or `right` for `.popup_close`
anymore, and a release build was made to confirm the compiled CSS.
