### PR TITLE
fix(build): ship ttf and woff2 fonts so icons work in Safari

### DIFF
--- a/compile.json
+++ b/compile.json
@@ -189,6 +189,13 @@
     {
       "type": "source",
       "outputPath": "compiled/source",
+      "fonts": {
+        "fontTypes": [
+          "woff2",
+          "woff",
+          "ttf"
+        ]
+      },
       "application-types": [
         "browser"
       ],
@@ -207,6 +214,13 @@
         "browser"
       ],
       "outputPath": "compiled/build",
+      "fonts": {
+        "fontTypes": [
+          "woff2",
+          "woff",
+          "ttf"
+        ]
+      },
       "environment": {
         "cv.build": "build",
         "cv.sentry": true,


### PR DESCRIPTION
Icon fonts render as blank boxes in Safari — the config manager and every widget using an icon font
are affected. Chrome and Firefox are fine.

## Cause

The qooxdoo compiler ships only `woff` by default (`fontTypes: ["woff"]`), while
`qx.bom.webfonts.WebFontLoader.getPreferredFormats()` lists Safari solely in the `ttf` branch. No
path matches the filter in `__addFontFace()`, the `src` descriptor is emitted empty and Safari
drops it. The rule that reaches the page carries no source at all:

```css
@font-face { font-family: "Material Icons"; font-style: normal; font-weight: normal; }
```

Measured in Safari 26.6.1: the font itself is fine — served with `200` and `font/woff`, and it
loads and applies through a hand written `@font-face`. Only the generated rule lacks the source.

## Fix

Declare the formats per target so the build carries `woff2`, `woff` and `ttf`. Each browser then
picks the one it accepts: Safari the ttf, everything else the woff2 — which is smaller than the
woff shipped so far.

The build grows by about 600 KB. Per visitor the download does not, since only one file per family
is fetched.

Verified against the built release: the rule now reads
`src: url(".../materialicons-v126.ttf")` and all manager icons appear in Safari. Chrome unchanged.

## Upstream

The root cause sits in qooxdoo, not here: `getPreferredFormats()` omits Safari from the `woff` and
`woff2` branches although Safari has supported WOFF since 5.1 and WOFF2 since 10. I have opened
**qooxdoo/qooxdoo#10886** to add it there.

Both changes are independent and worth having: `compile.json` decides which font files end up in
the build, `getPreferredFormats()` decides which of them a browser accepts. This change also makes
CometVisu correct on the qooxdoo versions already released.

**qooxdoo/qooxdoo#10725** reports the same symptom and was closed as a documentation matter,
pointing at exactly the `fonts.fontTypes` setting used here.
