### PR TITLE
fix(build): guard the Monaco clipboard workaround in insecure contexts

### DIFF
--- a/utils/compile/bundle-monaco.js
+++ b/utils/compile/bundle-monaco.js
@@ -67,7 +67,48 @@ async function bundle() {
     console.log('  ' + nlsFile);
   }
 
+  patchWebKitClipboardWorkaround(path.join(outDir, 'editor.main.js'));
+
   console.log('Monaco bundles created in source/resource/monaco/');
+}
+
+/**
+ * Monaco calls navigator.clipboard.write() in its WebKit workaround without checking that the
+ * async clipboard API is there. Outside a secure context - plain http on anything but localhost -
+ * it is not, and the handler runs on every click and keydown, so Safari throws on each of them.
+ * Worse, the handler sets webKitPendingClipboardWritePromise before that call, which makes
+ * writeText() take its early exit and skip the execCommand fallback - copying then silently does
+ * nothing. Returning early leaves that promise untouched and keeps copying working.
+ *
+ * Proposed upstream in https://github.com/microsoft/vscode/pull/334878, so this can go once the
+ * fix reaches a monaco-editor release.
+ *
+ * @param {string} file the bundled editor.main.js
+ */
+function patchWebKitClipboardWorkaround(file) {
+  const anchor =
+    'installWebKitWriteTextWorkaround() {\n' +
+    '        const handler = () => {\n' +
+    '          const currentWritePromise = new DeferredPromise();';
+  const guard =
+    'installWebKitWriteTextWorkaround() {\n' +
+    '        const handler = () => {\n' +
+    '          if (!getActiveWindow().navigator.clipboard) {\n' +
+    '            return;\n' +
+    '          }\n' +
+    '          const currentWritePromise = new DeferredPromise();';
+
+  const code = fs.readFileSync(file, 'utf8');
+  const found = code.split(anchor).length - 1;
+  if (found !== 1) {
+    throw new Error(
+      `cannot patch the WebKit clipboard workaround: expected the anchor once, found it ${found} times. ` +
+        'Monaco has changed - check whether the fix has landed upstream and drop this patch, or adjust it.'
+    );
+  }
+
+  fs.writeFileSync(file, code.replace(anchor, guard));
+  console.log('  patched the WebKit clipboard workaround for insecure contexts');
 }
 
 bundle().catch(err => {


### PR DESCRIPTION
## Problem

The manager's Monaco editor is unusable in Safari when CometVisu is served over plain http from anything but localhost — the common case for an installation on the local network.

Monaco's `installWebKitWriteTextWorkaround()` installs a `click` and `keydown` handler that calls `navigator.clipboard.write()` without checking that the async clipboard API exists. Outside a secure context it does not, so every click and keystroke throws. The handler also sets `webKitPendingClipboardWritePromise` before that call, which makes `writeText()` take its early exit and skip the `execCommand` fallback — so copying silently does nothing.

## Fix

`utils/compile/bundle-monaco.js` patches the bundled `editor.main.js` after esbuild has run: the handler returns early when `navigator.clipboard` is missing, leaving `webKitPendingClipboardWritePromise` untouched so the fallback keeps working.

The patch asserts that its anchor appears exactly once and throws a descriptive error otherwise, so a Monaco update cannot silently drop it.

## Notes

Bundled output lives in the gitignored `source/resource/monaco/`, so this changes the build script only. The same fix is proposed upstream in microsoft/vscode#334878 and this patch can be removed once it reaches a monaco-editor release.

## Verification

- `npm run bundle-monaco` reports the patch and the guard is present in the generated bundle
- manager over http on a LAN address in Safari: no console errors while typing, copy and paste work; unchanged in Chrome
