### PR TITLE
fix(startup): await the config cache restore before the backend clients start

### DIFF
--- a/source/class/cv/Application.js
+++ b/source/class/cv/Application.js
@@ -1072,7 +1072,13 @@ qx.Class.define('cv.Application', {
         if (this._isCached) {
           // load settings
           this.debug('using cache');
-          cv.ConfigCache.restore();
+          try {
+            // must be awaited, the restored configSettings are needed by the backend client initialization
+            await cv.ConfigCache.restore();
+          } catch (e) {
+            this.error('restoring the config cache failed, parsing the config instead:', e);
+            this._isCached = false;
+          }
         }
         // initialize NotificationCenter
         cv.ui.NotificationCenter.getInstance();

--- a/source/class/cv/ConfigCache.js
+++ b/source/class/cv/ConfigCache.js
@@ -98,10 +98,16 @@ qx.Class.define('cv.ConfigCache', {
       });
     },
 
+    /**
+     * Restore the cached config. The caller must wait for the returned promise, everything
+     * that reads cv.Config.configSettings (e.g. the backend client initialization) races
+     * against it otherwise.
+     * @return {Promise}
+     */
     restore() {
       const body = document.querySelector('body');
       const model = cv.data.Model.getInstance();
-      this.getData().then(cache => {
+      return this.getData().then(cache => {
         cv.Config.configSettings = cache.configSettings;
 
         // restore icons


### PR DESCRIPTION
## Problem

Loading a visu from the config cache starts the backend clients before the cached settings are back. `cv.ConfigCache.restore()` resolves asynchronously but dropped its promise, and `cv.Application` called it without waiting, so `initBackendClients()` raced it.

When the initialization won that race, `cv.Config.configSettings` was still the default object. The `backend-*-url` from the config never reached the client, and `cv.io.openhab.Rest` fell back to its default `/rest/` — the visu then talked to the wrong endpoint until the next uncached load.

## Fix

`restore()` returns the promise it already had, and the caller awaits it. A restore that fails no longer surfaces as an unhandled rejection that leaves startup on the cached path with a partially restored state: the error is logged and the config is parsed instead.

## Verification

Reproduced on an installation whose backend URL differs from the default: with a warm cache the first request went to `/rest/`, after the change to the configured URL. A unit test would have to stub `getData()` and the DOM-replacing tail of `restore()`, which also resets the shared `cv.data.Model` singleton, so none was added.
